### PR TITLE
Merge non validated and non sanitized errors

### DIFF
--- a/WordPress/Sniffs/VIP/ValidatedSanitizedInputSniff.php
+++ b/WordPress/Sniffs/VIP/ValidatedSanitizedInputSniff.php
@@ -82,6 +82,8 @@ class WordPress_Sniffs_VIP_ValidatedSanitizedInputSniff extends WordPress_Sniff 
 	 */
 	public function process_token( $stackPtr ) {
 
+		$notValidated = $notSanitized = false;
+
 		$superglobals = $this->input_superglobals;
 
 		// Handling string interpolation.
@@ -122,8 +124,7 @@ class WordPress_Sniffs_VIP_ValidatedSanitizedInputSniff extends WordPress_Sniff 
 
 		// Check for validation first.
 		if ( ! $this->is_validated( $stackPtr, $array_key, $this->check_validation_in_scope_only ) ) {
-			$this->phpcsFile->addError( 'Detected usage of a non-validated input variable: %s', $stackPtr, 'InputNotValidated', $error_data );
-			// return; // Should we just return and not look for sanitizing functions ?
+			$notValidated = true;
 		}
 
 		if ( $this->has_whitelist_comment( 'sanitization', $stackPtr ) ) {
@@ -139,6 +140,14 @@ class WordPress_Sniffs_VIP_ValidatedSanitizedInputSniff extends WordPress_Sniff 
 
 		// Now look for sanitizing functions.
 		if ( ! $this->is_sanitized( $stackPtr, true ) ) {
+			$notSanitized = true;
+		}
+
+		if ( true === $notValidated && true === $notSanitized  ) {
+			$this->phpcsFile->addError( 'Detected usage of a non-validated nor non-sanitized input variable: %s', $stackPtr, 'InputNotValidatedNotSanitized', $error_data );
+		} else if ( true === $notValidated ) {
+			$this->phpcsFile->addError( 'Detected usage of a non-validated input variable: %s', $stackPtr, 'InputNotValidated', $error_data );
+		} else if ( true === $notSanitized ) {
 			$this->phpcsFile->addError( 'Detected usage of a non-sanitized input variable: %s', $stackPtr, 'InputNotSanitized', $error_data );
 		}
 

--- a/WordPress/Sniffs/VIP/ValidatedSanitizedInputSniff.php
+++ b/WordPress/Sniffs/VIP/ValidatedSanitizedInputSniff.php
@@ -82,7 +82,8 @@ class WordPress_Sniffs_VIP_ValidatedSanitizedInputSniff extends WordPress_Sniff 
 	 */
 	public function process_token( $stackPtr ) {
 
-		$notValidated = $notSanitized = false;
+		$notValidated = false;
+		$notSanitized = false;
 
 		$superglobals = $this->input_superglobals;
 
@@ -143,7 +144,7 @@ class WordPress_Sniffs_VIP_ValidatedSanitizedInputSniff extends WordPress_Sniff 
 			$notSanitized = true;
 		}
 
-		if ( true === $notValidated && true === $notSanitized  ) {
+		if ( true === $notValidated && true === $notSanitized ) {
 			$this->phpcsFile->addError( 'Detected usage of a non-validated nor non-sanitized input variable: %s', $stackPtr, 'InputNotValidatedNotSanitized', $error_data );
 		} else if ( true === $notValidated ) {
 			$this->phpcsFile->addError( 'Detected usage of a non-validated input variable: %s', $stackPtr, 'InputNotValidated', $error_data );

--- a/WordPress/Tests/VIP/ValidatedSanitizedInputUnitTest.inc
+++ b/WordPress/Tests/VIP/ValidatedSanitizedInputUnitTest.inc
@@ -149,3 +149,11 @@ function test_this() {
 
 	$abc = sanitize_twitter_handle( $_POST['abc_field'] ); // Bad x2, sanitize + unslash.
 }
+
+function foo() {
+	// Following line should produce validation error.
+	$foo = $_POST['bar']; // sanitization OK.
+	if ( 'a' == $_POST['foo'] ) { // Bad. Only validation error. No sanitisation as it's a comparison.
+		;
+	}
+}

--- a/WordPress/Tests/VIP/ValidatedSanitizedInputUnitTest.php
+++ b/WordPress/Tests/VIP/ValidatedSanitizedInputUnitTest.php
@@ -46,6 +46,8 @@ class WordPress_Tests_VIP_ValidatedSanitizedInputUnitTest extends AbstractSniffU
 			137 => 1,
 			138 => 1,
 			150 => 2,
+			155 => 1,
+			156 => 1,
 		);
 
 	}

--- a/WordPress/Tests/VIP/ValidatedSanitizedInputUnitTest.php
+++ b/WordPress/Tests/VIP/ValidatedSanitizedInputUnitTest.php
@@ -22,11 +22,11 @@ class WordPress_Tests_VIP_ValidatedSanitizedInputUnitTest extends AbstractSniffU
 	 */
 	public function getErrorList() {
 		return array(
-			5 => 3,
+			5 => 2,
 			7 => 1,
 			10 => 1,
 			20 => 1,
-			33 => 3,
+			33 => 2,
 			65 => 1,
 			79 => 1,
 			80 => 1,


### PR DESCRIPTION
The ValidatedSanitizedInput Sniff is currently reporting two different errors for the same code, in case the global variable is not sanitized nor validated. This commit is merging the two errors into one, in caes both conditions are met. It's preserving the individual errors for cases when only one of them is true.

We have been using this improvement on the WordPress.com VIP for a while already (introduced in https://github.com/Automattic/VIP-Coding-Standards/pull/12 )

cc. @grappler 