### PR TITLE
RestrictedPHPFunctions: add error for use of date()

### DIFF
--- a/WordPress/Sniffs/PHP/RestrictedPHPFunctionsSniff.php
+++ b/WordPress/Sniffs/PHP/RestrictedPHPFunctionsSniff.php
@@ -17,6 +17,7 @@ use WordPressCS\WordPress\AbstractFunctionRestrictionsSniff;
  * @package WPCS\WordPressCodingStandards
  *
  * @since   0.14.0
+ * @since   2.2.0  New group `date` added.
  */
 class RestrictedPHPFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 
@@ -40,6 +41,13 @@ class RestrictedPHPFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 				'message'   => '%s() is deprecated as of PHP 7.2, please use full fledged functions or anonymous functions instead.',
 				'functions' => array(
 					'create_function',
+				),
+			),
+			'date' => array(
+				'type'      => 'error',
+				'message'   => '%s() is affected by runtime timezone changes which can cause date/time to be incorrectly displayed. Use gmdate() instead.',
+				'functions' => array(
+					'date',
 				),
 			),
 		);

--- a/WordPress/Tests/PHP/RestrictedPHPFunctionsUnitTest.inc
+++ b/WordPress/Tests/PHP/RestrictedPHPFunctionsUnitTest.inc
@@ -3,3 +3,6 @@
 add_action( 'widgets_init', create_function( '', // Error.
 	'return register_widget( "time_more_on_time_widget" );'
 ) );
+
+$post_data['post_title'] = sprintf( __( 'Draft created on %1$s at %2$s' ), date( __( 'F j, Y' ), $now ), date( __( 'g:i a' ), $now ) ); // Error.
+$post_data['post_title'] = sprintf( __( 'Draft created on %1$s at %2$s' ), gmdate( __( 'F j, Y' ), $now ), gmdate( __( 'g:i a' ), $now ) ); // OK.

--- a/WordPress/Tests/PHP/RestrictedPHPFunctionsUnitTest.php
+++ b/WordPress/Tests/PHP/RestrictedPHPFunctionsUnitTest.php
@@ -28,6 +28,7 @@ class RestrictedPHPFunctionsUnitTest extends AbstractSniffUnitTest {
 	public function getErrorList() {
 		return array(
 			3 => 1,
+			7 => 2,
 		);
 	}
 


### PR DESCRIPTION
As this sniff is already included in the WP Core ruleset and the enhancement request is about PHP native functions, this seemed liked a logical sniff to add this to.

I've elected to make this an `error` instead of a `warning` as the code within WP Core has been cleaned up for this issue now and it would be good to prevent new instances of `date()` creeping in.

Fixes #1713