### PR TITLE
Fixes #1696, errors on invalid post type

### DIFF
--- a/WordPress-Extra/ruleset.xml
+++ b/WordPress-Extra/ruleset.xml
@@ -130,6 +130,9 @@
 	<!-- Verify that everything in the global namespace is prefixed. -->
 	<rule ref="WordPress.NamingConventions.PrefixAllGlobals"/>
 
+	<!-- Validates post type slugs for valid characters, length and reserved keywords. -->
+	<rule ref="WordPress.NamingConventions.ValidPostTypeSlug"/>
+
 	<!-- Check that object instantiations always have braces & are not assigned by reference.
 		 https://github.com/WordPress/WordPress-Coding-Standards/issues/919
 		 Note: there is a similar upstream sniff `PSR12.Classes.ClassInstantiation`, however

--- a/WordPress/Docs/NamingConventions/ValidPostTypeSlugStandard.xml
+++ b/WordPress/Docs/NamingConventions/ValidPostTypeSlugStandard.xml
@@ -1,0 +1,117 @@
+<documentation title="Validate post type slugs">
+    <standard>
+    <![CDATA[
+    The post type slug used in register_post_type() must be between 1 and 20 characters.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: short post type slug.">
+        <![CDATA[
+register_post_type( 
+    <em>'my_short_slug'</em>, 
+    array() 
+);
+        ]]>
+        </code>
+        <code title="Invalid: too long post type slug.">
+        <![CDATA[
+register_post_type( 
+    <em>'my_own_post_type_too_long'</em>, 
+    array() 
+);
+        ]]>
+        </code>
+    </code_comparison>
+    <standard>
+    <![CDATA[
+    The post type slug used in register_post_type() can only contain lowercase alphanumeric characters, dashes and underscores.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: no special characters in post type slug.">
+        <![CDATA[
+register_post_type( 
+    <em>'my_post_type_slug'</em>, 
+    array() 
+);
+        ]]>
+        </code>
+        <code title="Invalid: invalid characters in post type slug.">
+        <![CDATA[
+register_post_type( 
+    <em>'my/post/type/slug'</em>, 
+    array() 
+);
+        ]]>
+        </code>
+    </code_comparison>
+    <standard>
+    <![CDATA[
+    One should be careful with passing dynamic slug names to "register_post_type()", as the slug may become too long and could contain invalid characters.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: static post type slug.">
+        <![CDATA[
+register_post_type( 
+    <em>'my_post_active'</em>, 
+    array() 
+);
+        ]]>
+        </code>
+        <code title="Invalid: dynamic post type slug.">
+        <![CDATA[
+register_post_type( 
+    <em>"my_post_{$status}"</em>, 
+    array() 
+);
+        ]]>
+        </code>
+    </code_comparison>
+    <standard>
+    <![CDATA[
+    The post type slug used in register_post_type() can not use reserved keywords, such as the ones used by WordPress itself.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: prefixed post slug.">
+        <![CDATA[
+register_post_type( 
+    <em>'prefixed_author'</em>, 
+    array() 
+);
+        ]]>
+        </code>
+        <code title="Invalid: using a reserved keyword as slug.">
+        <![CDATA[
+register_post_type( 
+    <em>'author'</em>, 
+    array() 
+);
+        ]]>
+        </code>
+    </code_comparison>
+    <standard>
+    <![CDATA[
+    The post type slug used in register_post_type() can not use reserved prefixes, such as 'wp_', which is used by WordPress itself.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: custom prefix post slug.">
+        <![CDATA[
+register_post_type( 
+    <em>'prefixed_author'</em>, 
+    array() 
+);
+        ]]>
+        </code>
+        <code title="Invalid: using a reserved prefix.">
+        <![CDATA[
+register_post_type( 
+    <em>'wp_author'</em>, 
+    array() 
+);
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/WordPress/Sniffs/NamingConventions/ValidPostTypeSlugSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidPostTypeSlugSniff.php
@@ -1,0 +1,208 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPressCS\WordPress\Sniffs\NamingConventions;
+
+use WordPressCS\WordPress\AbstractFunctionParameterSniff;
+use PHP_CodeSniffer\Util\Tokens;
+
+/**
+ * Validates post type names.
+ *
+ * Checks the post type slug for invalid characters, long function names
+ * and reserved names.
+ *
+ * @link https://developer.wordpress.org/reference/functions/register_post_type/
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since 2.2.0
+ */
+class ValidPostTypeSlugSniff extends AbstractFunctionParameterSniff {
+
+	/**
+	 * Max length of a post type name is limited by the SQL field.
+	 *
+	 * @since 2.2.0
+	 *
+	 * @var int
+	 */
+	const POST_TYPE_MAX_LENGTH = 20;
+
+	/**
+	 * Regex that whitelists characters that can be used as the post type slug.
+	 *
+	 * @link https://developer.wordpress.org/reference/functions/register_post_type/
+	 * @since 2.2.0
+	 *
+	 * @var string
+	 */
+	const POST_TYPE_CHARACTER_WHITELIST = '/^[a-z0-9_-]+$/';
+
+	/**
+	 * Array of functions that must be checked.
+	 *
+	 * @since 2.2.0
+	 *
+	 * @var array List of function names as keys. Value irrelevant.
+	 */
+	protected $target_functions = array(
+		'register_post_type' => true,
+	);
+
+	/**
+	 * Array of reserved post type names which can not be used by themes and plugins.
+	 *
+	 * @since 2.2.0
+	 *
+	 * @var array
+	 */
+	protected $reserved_names = array(
+		'post'                => true,
+		'page'                => true,
+		'attachment'          => true,
+		'revision'            => true,
+		'nav_menu_item'       => true,
+		'custom_css'          => true,
+		'customize_changeset' => true,
+		'oembed_cache'        => true,
+		'user_request'        => true,
+		'wp_block'            => true,
+		'action'              => true,
+		'author'              => true,
+		'order'               => true,
+		'theme'               => true,
+	);
+
+	/**
+	 * All valid tokens for in the first parameter of register_post_type().
+	 *
+	 * Set in `register()`.
+	 *
+	 * @since 2.2.0
+	 *
+	 * @var string
+	 */
+	private $valid_tokens = array();
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @since 2.2.0
+	 *
+	 * @return array
+	 */
+	public function register() {
+		$this->valid_tokens = Tokens::$textStringTokens + Tokens::$heredocTokens + Tokens::$emptyTokens;
+		return parent::register();
+	}
+
+	/**
+	 * Process the parameter of a matched function.
+	 *
+	 * Errors on invalid post type names when reserved keywords are used,
+	 * the post type is too long, or contains invalid characters.
+	 *
+	 * @since 2.2.0
+	 *
+	 * @param int    $stackPtr        The position of the current token in the stack.
+	 * @param array  $group_name      The name of the group which was matched.
+	 * @param string $matched_content The token content (function name) which was matched.
+	 * @param array  $parameters      Array with information about the parameters.
+	 *
+	 * @return void
+	 */
+	public function process_parameters( $stackPtr, $group_name, $matched_content, $parameters ) {
+
+		$string_pos         = $this->phpcsFile->findNext( Tokens::$textStringTokens, $parameters[1]['start'], ( $parameters[1]['end'] + 1 ) );
+		$has_invalid_tokens = $this->phpcsFile->findNext( $this->valid_tokens, $parameters[1]['start'], ( $parameters[1]['end'] + 1 ), true );
+		if ( false !== $has_invalid_tokens || false === $string_pos ) {
+			// Check for non string based slug parameter (we cannot determine if this is valid).
+			$this->phpcsFile->addWarning(
+				'The post type slug is not a string literal. It is not possible to automatically determine the validity of this slug. Found: %s.',
+				$stackPtr,
+				'NotStringLiteral',
+				array(
+					$parameters[1]['raw'],
+				),
+				3
+			);
+			return;
+		}
+
+		$post_type = $this->strip_quotes( $this->tokens[ $string_pos ]['content'] );
+
+		if ( strlen( $post_type ) === 0 ) {
+			// Error for using empty slug.
+			$this->phpcsFile->addError(
+				'register_post_type() called without a post type slug. The slug must be a non-empty string.',
+				$parameters[1]['start'],
+				'Empty'
+			);
+			return;
+		}
+
+		$data = array(
+			$this->tokens[ $string_pos ]['content'],
+		);
+
+		// Warn for dynamic parts in the slug parameter.
+		if ( 'T_DOUBLE_QUOTED_STRING' === $this->tokens[ $string_pos ]['type'] || ( 'T_HEREDOC' === $this->tokens[ $string_pos ]['type'] && strpos( $this->tokens[ $string_pos ]['content'], '$' ) !== false ) ) {
+			$this->phpcsFile->addWarning(
+				'The post type slug may, or may not, get too long with dynamic contents and could contain invalid characters. Found: %s.',
+				$string_pos,
+				'PartiallyDynamic',
+				$data
+			);
+			$post_type = $this->strip_interpolated_variables( $post_type );
+		}
+
+		if ( preg_match( self::POST_TYPE_CHARACTER_WHITELIST, $post_type ) === 0 ) {
+			// Error for invalid characters.
+			$this->phpcsFile->addError(
+				'register_post_type() called with invalid post type %s. Post type contains invalid characters. Only lowercase alphanumeric characters, dashes, and underscores are allowed.',
+				$string_pos,
+				'InvalidCharacters',
+				$data
+			);
+		}
+
+		if ( isset( $this->reserved_names[ $post_type ] ) ) {
+			// Error for using reserved slug names.
+			$this->phpcsFile->addError(
+				'register_post_type() called with reserved post type %s. Reserved post types should not be used as they interfere with the functioning of WordPress itself.',
+				$string_pos,
+				'Reserved',
+				$data
+			);
+		} elseif ( stripos( $post_type, 'wp_' ) === 0 ) {
+			// Error for using reserved slug prefix.
+			$this->phpcsFile->addError(
+				'The post type passed to register_post_type() uses a prefix reserved for WordPress itself. Found: %s.',
+				$string_pos,
+				'ReservedPrefix',
+				$data
+			);
+		}
+
+		// Error for slugs that are too long.
+		if ( strlen( $post_type ) > self::POST_TYPE_MAX_LENGTH ) {
+			$this->phpcsFile->addError(
+				'A post type slug must not exceed %d characters. Found: %s (%d characters).',
+				$string_pos,
+				'TooLong',
+				array(
+					self::POST_TYPE_MAX_LENGTH,
+					$this->tokens[ $string_pos ]['content'],
+					strlen( $post_type ),
+				)
+			);
+		}
+	}
+}

--- a/WordPress/Tests/NamingConventions/ValidPostTypeSlugUnitTest.inc
+++ b/WordPress/Tests/NamingConventions/ValidPostTypeSlugUnitTest.inc
@@ -1,0 +1,52 @@
+<?php
+
+register_post_type( 'my-own-post-type', array() ); // OK.
+register_post_type( 'my_own_post_type', array() ); // OK.
+register_post_type( 'my-own-post-type-too-long', array() ); // Bad.
+register_post_type( 'author', array() ); // Bad. Reserved slug name.
+register_post_type( 'My-Own-Post-Type', array() ); // Bad. Invalid chars: uppercase.
+register_post_type( 'my/own/post/type', array() ); // Bad. Invalid chars: "/".
+
+register_post_type( <<<EOD
+my_own_post_type
+EOD
+); // OK.
+register_post_type( <<<'EOD'
+my_own_post_type
+EOD
+); // OK.
+
+register_post_type( <<<'EOD'
+my/own/post/type
+EOD
+); // Bad. Invalid chars: "/".
+
+register_post_type( "my_post_type_{$i}" ); // Warning, post type may or may not get too long with dynamic contents in the id.
+
+// Non string literals.
+register_post_type( sprintf( 'my_post_type_%d', $i ) ); // Non string literal. Warning with severity: 3
+register_post_type( post ); // = lowercase global constant. Non string literal. Warning with severity: 3
+register_post_type( self::ID ); // Non string literal. Warning with severity: 3
+register_post_type( $post_type_name ); // Non string literal. Warning with severity: 3
+register_post_type( $this->get_post_type_id() ); // Non string literal. Warning with severity: 3
+
+register_post_type( null, array() ); // Non string literal. Warning with severity: 3
+register_post_type( 1000, array() ); // Non string literal. Warning with severity: 3
+
+register_post_type( 'wp_', array() ); // Bad. Reserved prefix.
+register_post_type( 'wp_post_type', array() ); // Bad. Reserved prefix.
+
+register_post_type( '', array() ); // Bad. Empty post type slug.
+register_post_type( /*comment*/, array() ); // Bad. No post type slug.
+
+register_post_type( 'post_type_1', array() ); // OK.
+
+register_post_type( <<<EOD
+my_here_doc_{$i}
+EOD
+); // Warning, post type may or may not get too long with dynamic contents in the id.
+
+register_post_type( "my-own-post-type-too-long-{$i}" ); // 1x Error, Too long. 1x Warning, post type may or may not get too long with dynamic contents in the id.
+register_post_type( 'my/own/post/type/too/long', array() ); // Bad. Invalid chars: "/" and too long.
+
+register_post_type( 'wp_block', array() ); // Bad. Must only error on reserved keyword, not invalid prefix.

--- a/WordPress/Tests/NamingConventions/ValidPostTypeSlugUnitTest.php
+++ b/WordPress/Tests/NamingConventions/ValidPostTypeSlugUnitTest.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Unit test class for WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPressCS\WordPress\Tests\NamingConventions;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+/**
+ * Unit test class for the PostType sniff.
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   X.X.X
+ */
+class ValidPostTypeSlugUnitTest extends AbstractSniffUnitTest {
+
+	/**
+	 * Set warnings level to 3 to trigger suggestions as warnings.
+	 *
+	 * @param string                  $filename The name of the file being tested.
+	 * @param \PHP_CodeSniffer\Config $config   The config data for the run.
+	 *
+	 * @return void
+	 */
+	public function setCliValues( $filename, $config ) {
+		$config->warningSeverity = 3;
+	}
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * @return array <int line number> => <int number of errors>
+	 */
+	public function getErrorList() {
+		return array(
+			5  => 1,
+			6  => 1,
+			7  => 1,
+			8  => 1,
+			20 => 1,
+			36 => 1,
+			37 => 1,
+			39 => 1,
+			49 => 1,
+			50 => 2,
+			52 => 1,
+		);
+	}
+
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * @return array <int line number> => <int number of warnings>
+	 */
+	public function getWarningList() {
+		return array(
+			24 => 1,
+			27 => 1,
+			28 => 1,
+			29 => 1,
+			30 => 1,
+			31 => 1,
+			33 => 1,
+			34 => 1,
+			40 => 1,
+			45 => 1,
+			49 => 1,
+		);
+	}
+}

--- a/WordPress/Tests/NamingConventions/ValidPostTypeSlugUnitTest.php
+++ b/WordPress/Tests/NamingConventions/ValidPostTypeSlugUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @package WPCS\WordPressCodingStandards
  *
- * @since   X.X.X
+ * @since   2.2.0
  */
 class ValidPostTypeSlugUnitTest extends AbstractSniffUnitTest {
 


### PR DESCRIPTION
Adds a new sniff. Checks if the first parameters given to a `register_post_type()` call is actually a valid value.

Fixes #1696 