### PR TITLE
Composer: Update repo URL references

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
 	"authors": [
 		{
 			"name": "Contributors",
-			"homepage": "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/graphs/contributors"
+			"homepage": "https://github.com/WordPress/WordPress-Coding-Standards/graphs/contributors"
 		}
 	],
 	"require": {
@@ -42,8 +42,8 @@
 		]
 	},
 	"support": {
-		"issues": "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues",
-		"wiki": "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki",
-		"source": "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards"
+		"issues": "https://github.com/WordPress/WordPress-Coding-Standards/issues",
+		"wiki": "https://github.com/WordPress/WordPress-Coding-Standards/wiki",
+		"source": "https://github.com/WordPress/WordPress-Coding-Standards"
 	}
 }


### PR DESCRIPTION
The repo has moved organization within GitHub.

Replaces #1749