### PR TITLE
Travis: add "quicktest" stage for non-PR/merge builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,14 +27,23 @@ env:
   # Lowest supported release in the 3.x series with which WPCS is compatible.
   - PHPCS_BRANCH="3.3.1"
 
+# Define the stages used.
+# For non-PRs, only the sniff, ruleset and quicktest stages are run.
+# For pull requests and merges, the full script is run (skipping quicktest).
+# Note: for pull requests, "develop" should be the base branch name.
+# See: https://docs.travis-ci.com/user/conditions-v1
 stages:
-  - sniff
-  - rulesets
-  - test
+  - name: sniff
+  - name: rulesets
+  - name: quicktest
+    if: type = push AND branch NOT IN (master, develop)
+  - name: test
+    if: branch IN (master, develop)
 
 jobs:
   fast_finish: true
   include:
+    #### SNIFF STAGE ####
     - stage: sniff
       php: 7.3
       env: PHPCS_BRANCH="dev-master"
@@ -61,6 +70,7 @@ jobs:
         - diff -B --tabsize=4 ./WordPress-Extra/ruleset.xml <(xmllint --format "./WordPress-Extra/ruleset.xml")
         - diff -B --tabsize=4 ./phpcs.xml.dist.sample <(xmllint --format "./phpcs.xml.dist.sample")
 
+    #### RULESET STAGE ####
     # Make sure the rulesets don't throw unexpected errors or warnings.
     # This check needs to be run against a high PHP version to prevent triggering the syntax error check.
     # It also needs to be run against all PHPCS versions WPCS is tested against.
@@ -88,6 +98,19 @@ jobs:
         - $(pwd)/vendor/bin/phpcs -ps ./bin/class-ruleset-test.php --standard=WordPress-Docs
         - $(pwd)/vendor/bin/phpcs -ps ./bin/class-ruleset-test.php --standard=WordPress-Extra
         - $(pwd)/vendor/bin/phpcs -ps ./bin/class-ruleset-test.php --standard=WordPress
+
+    #### QUICK TEST STAGE ####
+    # This is a much quicker test which only runs the unit tests and linting against the low/high
+    # supported PHP/PHPCS combinations.
+    - stage: quicktest
+      php: 7.3
+      env: PHPCS_BRANCH="dev-master" LINT=1
+    - php: 7.3
+      env: PHPCS_BRANCH="3.3.1"
+    - php: 5.4
+      env: PHPCS_BRANCH="dev-master" LINT=1
+    - php: 5.4
+      env: PHPCS_BRANCH="3.3.1"
 
   allow_failures:
     # Allow failures for unstable builds.


### PR DESCRIPTION
The "quicktest" stage will only run a CS check, ruleset check, linting and the unit tests against low/high PHP/PHPCS combinations. This should catch most issues.

The more comprehensive complete build against a larger combination of PHP/PHPCS combination will now only be run on PRs and merges to `develop`/`master`.

To see the difference, compare the output of the `push` and `pr` Travis runs for this PR.