### PR TITLE
Add `$plugin` to the list of global variables that shouldn't be overridden

### DIFF
--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -708,6 +708,7 @@ abstract class Sniff implements PHPCS_Sniff {
 		'PHP_SELF'                         => true,
 		'phpmailer'                        => true,
 		'plugin_page'                      => true,
+		'plugin'                           => true,
 		'plugins'                          => true,
 		'post'                             => true,
 		'post_default_category'            => true,


### PR DESCRIPTION
If a plugin overrides the `$plugin` global, things can break. See https://github.com/Rarst/laps/issues/35.

This variable is missing from the list of global WP variables.