### PR TITLE
WordPress ruleset: efficiency fix

### DIFF
--- a/WordPress/ruleset.xml
+++ b/WordPress/ruleset.xml
@@ -3,7 +3,10 @@
 
 	<description>WordPress Coding Standards</description>
 
+	<!--
+	Included via WordPress-Extra.
 	<rule ref="WordPress-Core"/>
+	-->
 	<rule ref="WordPress-Docs"/>
 	<rule ref="WordPress-Extra"/>
 


### PR DESCRIPTION
Rulesets are processed top-to-bottom, one rule at the time.

For the `WordPress` ruleset, this means that PHPCS would first load the `WordPress-Core` ruleset and process all rules in that file, then read the `WordPress-Docs` ruleset and lastly, the `WordPress-Extra` ruleset.

As the `WordPress-Extra` ruleset includes `WordPress-Core`, it would re-process the `WordPress-Core` ruleset a second time and then process the additional rules in the `Extra` ruleset.

This means that in effect, the `WordPress-Core` ruleset is processed twice when using the `WordPress` ruleset which is inefficient.

By commenting that rule out, we still document that the `WordPress` ruleset includes `WordPress-Core` without double processing the ruleset.