### PR TITLE
CastStructureSpacing: allow for spread operator

### DIFF
--- a/WordPress/Docs/WhiteSpace/CastStructureSpacingStandard.xml
+++ b/WordPress/Docs/WhiteSpace/CastStructureSpacingStandard.xml
@@ -2,12 +2,16 @@
     <standard>
     <![CDATA[
     A type cast should be preceded by whitespace.
+    There is only one exception to this rule: when the cast is preceded by the spread operator there should be no space between the spread operator and the cast.
     ]]>
     </standard>
     <code_comparison>
         <code title="Valid: space before typecast.">
         <![CDATA[
 $a =<em> </em>(int) '420';
+
+// No space between spread operator and cast.
+$a = function_call( <em>...(array)</em> $mixed );
         ]]>
         </code>
         <code title="Invalid: no space before typecast.">

--- a/WordPress/Sniffs/WhiteSpace/CastStructureSpacingSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/CastStructureSpacingSniff.php
@@ -24,6 +24,7 @@ use PHP_CodeSniffer\Util\Tokens;
  * @since   0.11.0 The error level for all errors thrown by this sniff has been raised from warning to error.
  * @since   0.12.0 This class now extends the WordPressCS native `Sniff` class.
  * @since   0.13.0 Class name changed: this class is now namespaced.
+ * @since   2.2.0  Added exception for whitespace between spread operator and cast.
  */
 class CastStructureSpacingSniff extends Sniff {
 
@@ -45,7 +46,9 @@ class CastStructureSpacingSniff extends Sniff {
 	 */
 	public function process_token( $stackPtr ) {
 
-		if ( \T_WHITESPACE !== $this->tokens[ ( $stackPtr - 1 ) ]['code'] ) {
+		if ( \T_WHITESPACE !== $this->tokens[ ( $stackPtr - 1 ) ]['code']
+			&& \T_ELLIPSIS !== $this->tokens[ ( $stackPtr - 1 ) ]['code']
+		) {
 			$error = 'No space before opening casting parenthesis is prohibited';
 			$fix   = $this->phpcsFile->addFixableError( $error, $stackPtr, 'NoSpaceBeforeOpenParenthesis' );
 			if ( true === $fix ) {

--- a/WordPress/Tests/WhiteSpace/CastStructureSpacingUnitTest.inc
+++ b/WordPress/Tests/WhiteSpace/CastStructureSpacingUnitTest.inc
@@ -20,3 +20,5 @@ $unset2 = (unset) $unset; // Ok.
 
 $float1 =(float )$float; // Bad; n.b. spacing within the cast is dealt with by an upstream sniff.
 $float2 = (float) $float; // Ok.
+
+function_call( ...(array) $mixed ); // OK.

--- a/WordPress/Tests/WhiteSpace/CastStructureSpacingUnitTest.inc.fixed
+++ b/WordPress/Tests/WhiteSpace/CastStructureSpacingUnitTest.inc.fixed
@@ -20,3 +20,5 @@ $unset2 = (unset) $unset; // Ok.
 
 $float1 = (float )$float; // Bad; n.b. spacing within the cast is dealt with by an upstream sniff.
 $float2 = (float) $float; // Ok.
+
+function_call( ...(array) $mixed ); // OK.


### PR DESCRIPTION
Allow for no whitespace before a cast when used in combination with a spread operator.

This pre-emptively prevents a fixer conflict between this sniff and the upstream sniff we intend to add to address #1762.

Includes updated docs.

Related #1762
Related #1524