### PR TITLE
New DisallowShortTernary sniff

### DIFF
--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -367,6 +367,8 @@
 		 An exception would be using ! empty(), as testing for false here is generally more intuitive.
 		 https://github.com/WordPress/WordPress-Coding-Standards/issues/643 -->
 
+	<!-- Rule: The short ternary operator must not be used. -->
+	<rule ref="WordPress.PHP.DisallowShortTernary"/>
 
 	<!--
 	#############################################################################

--- a/WordPress/Docs/PHP/DisallowShortTernaryStandard.xml
+++ b/WordPress/Docs/PHP/DisallowShortTernaryStandard.xml
@@ -1,0 +1,19 @@
+<documentation title="Disallow Short Ternaries">
+    <standard>
+    <![CDATA[
+    The short ternary operator must not be used.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: long ternary.">
+        <![CDATA[
+$height = ! empty( $data['height'] ) <em>?</em> $data['height'] <em>:</em> 0;
+        ]]>
+        </code>
+        <code title="Invalid: short ternary.">
+        <![CDATA[
+$height = $data['height'] <em>? :</em> 0;
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/WordPress/Sniffs/PHP/DisallowShortTernarySniff.php
+++ b/WordPress/Sniffs/PHP/DisallowShortTernarySniff.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPressCS\WordPress\Sniffs\PHP;
+
+use WordPressCS\WordPress\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
+
+/**
+ * Disallow the use of short ternaries.
+ *
+ * @link    https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#ternary-operator
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   2.2.0
+ */
+class DisallowShortTernarySniff extends Sniff {
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @since 2.2.0
+	 *
+	 * @return array
+	 */
+	public function register() {
+		return array( \T_INLINE_THEN );
+	}
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @since 2.2.0
+	 *
+	 * @param int $stackPtr The position of the current token in the stack.
+	 *
+	 * @return void
+	 */
+	public function process_token( $stackPtr ) {
+
+		$nextNonEmpty = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true );
+		if ( false === $nextNonEmpty ) {
+			// Live coding or parse error.
+			return;
+		}
+
+		if ( \T_INLINE_ELSE !== $this->tokens[ $nextNonEmpty ]['code'] ) {
+			return;
+		}
+
+		$this->phpcsFile->addError(
+			'Using short ternaries is not allowed',
+			$stackPtr,
+			'Found'
+		);
+	}
+
+}

--- a/WordPress/Tests/PHP/DisallowShortTernaryUnitTest.inc
+++ b/WordPress/Tests/PHP/DisallowShortTernaryUnitTest.inc
@@ -1,0 +1,12 @@
+<?php
+
+$long = $compare ? 'a' : 'b';
+
+$short = $compare ? : 0; // Bad.
+$short = $compare ?: 0; // Bad.
+$short = $compare ?
+	: 0; // Bad.
+$short = $compare ? /* intentionally left empty */ : 0; // Bad.
+
+/* Intentional parse error. This should be the last test in the file. */
+$unfinished = $compare ? /* comment */

--- a/WordPress/Tests/PHP/DisallowShortTernaryUnitTest.php
+++ b/WordPress/Tests/PHP/DisallowShortTernaryUnitTest.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Unit test class for WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPressCS\WordPress\Tests\PHP;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+/**
+ * Unit test class for the DisallowShortTernary sniff.
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   2.2.0
+ */
+class DisallowShortTernaryUnitTest extends AbstractSniffUnitTest {
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * @return array <int line number> => <int number of errors>
+	 */
+	public function getErrorList() {
+		return array(
+			5 => 1,
+			6 => 1,
+			7 => 1,
+			9 => 1,
+		);
+	}
+
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * @return array <int line number> => <int number of warnings>
+	 */
+	public function getWarningList() {
+		return array();
+	}
+
+}


### PR DESCRIPTION
This new sniff addresses the new "_The short ternary operator must not be used._" rule which was recently added to the handbook.

The sniff has been added to the `WordPress-Core` ruleset.

Refs:
* https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#ternary-operator
* https://make.wordpress.org/core/2019/07/12/php-coding-standards-changes/

Includes unit tests.
Includes documentation.

Loosely related to #764