### PR TITLE
OperatorSpacing: add insteadof keyword

### DIFF
--- a/WordPress/Sniffs/WhiteSpace/OperatorSpacingSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/OperatorSpacingSniff.php
@@ -55,6 +55,7 @@ class OperatorSpacingSniff extends PHPCS_Squiz_OperatorSpacingSniff {
 		$tokens                   = parent::register();
 		$tokens[ \T_BOOLEAN_NOT ] = \T_BOOLEAN_NOT;
 		$tokens[ \T_INSTANCEOF ]  = \T_INSTANCEOF;
+		$tokens[ \T_INSTEADOF ]   = \T_INSTEADOF;
 		$logical_operators        = Tokens::$booleanOperators;
 
 		// Using array union to auto-dedup.

--- a/WordPress/Tests/WhiteSpace/OperatorSpacingUnitTest.inc
+++ b/WordPress/Tests/WhiteSpace/OperatorSpacingUnitTest.inc
@@ -68,3 +68,14 @@ if ( $a === $b or
 // Instanceof
 if ( MyClass    instanceof    SomeOtherClass ) {}
 if ( MyClass instanceof SomeOtherClass ) {}
+
+// Insteadof
+class Foo {
+    use A, B {
+        A::Talk insteadof B; // OK.
+        B::smallTalk     insteadof       A;
+        A::bigTalk
+			insteadof
+			B; // OK.
+    }
+}

--- a/WordPress/Tests/WhiteSpace/OperatorSpacingUnitTest.inc.fixed
+++ b/WordPress/Tests/WhiteSpace/OperatorSpacingUnitTest.inc.fixed
@@ -68,3 +68,14 @@ if ( $a === $b or
 // Instanceof
 if ( MyClass instanceof SomeOtherClass ) {}
 if ( MyClass instanceof SomeOtherClass ) {}
+
+// Insteadof
+class Foo {
+    use A, B {
+        A::Talk insteadof B; // OK.
+        B::smallTalk insteadof A;
+        A::bigTalk
+			insteadof
+			B; // OK.
+    }
+}

--- a/WordPress/Tests/WhiteSpace/OperatorSpacingUnitTest.php
+++ b/WordPress/Tests/WhiteSpace/OperatorSpacingUnitTest.php
@@ -43,6 +43,7 @@ class OperatorSpacingUnitTest extends AbstractSniffUnitTest {
 			50 => 2,
 			51 => 2,
 			69 => 2,
+			76 => 2,
 		);
 	}
 


### PR DESCRIPTION
The PHP `insteadof` ~~operator~~ keyword is used to resolve conflicts when importing multiple traits (PHP 5.4+).

This adds this ~~operator~~ keyword to the list of operators checked by the `WordPress.WhiteSpace.OperatorSpacing` sniff.

Includes unit test.

Also see: https://www.php.net/manual/en/language.oop5.traits.php

Related #764