### PR TITLE
Core: Add upstream Generic.Arrays.DisallowShortArraySyntax sniff

### DIFF
--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -101,6 +101,16 @@
 
 	<!--
 	#############################################################################
+	Handbook: PHP - Declaring Arrays.
+	Ref: https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#declaring-arrays
+	#############################################################################
+	-->
+	<!-- Covers rule: Arrays must be declared using long array syntax. -->
+	<rule ref="Generic.Arrays.DisallowShortArraySyntax"/>
+
+
+	<!--
+	#############################################################################
 	Handbook: PHP - Use elseif, not else if.
 	Ref: https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#use-elseif-not-else-if
 	#############################################################################


### PR DESCRIPTION
Recently a new section has been added to the handbook which forbids the use of short arrays.

> Using long array syntax ( array( 1, 2, 3 ) ) for declaring arrays is generally more readable than short array syntax ( [ 1, 2, 3 ] ), particularly for those with vision difficulties. Additionally, it’s much more descriptive for beginners.
>
> Arrays must be declared using long array syntax.

https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#declaring-arrays

This PR add an existing upstream sniff which addresses this.
Includes auto-fixer.

Also see: https://make.wordpress.org/core/2019/07/12/php-coding-standards-changes/

Loosely related to #764