### PR TITLE
New unneeded ternary sniff

### DIFF
--- a/WordPress/Docs/PHP/NoUnneededTernaryStandard.xml
+++ b/WordPress/Docs/PHP/NoUnneededTernaryStandard.xml
@@ -1,0 +1,19 @@
+<documentation title="Discourage the usage of the unneeded ternary operator">
+    <standard>
+    <![CDATA[
+    When storing a boolean value to a variable, a ternary check is not needed.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: simple test in the assignment.">
+        <![CDATA[
+$true_variable = $var === 42;
+        ]]>
+        </code>
+        <code title="Invalid: ternary usage with boolean in the assignment.">
+        <![CDATA[
+$true_variable = $var === 42 ? <em>true</em> : <em>false</em>;
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/WordPress/Sniffs/PHP/NoUnneededTernarySniff.php
+++ b/WordPress/Sniffs/PHP/NoUnneededTernarySniff.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPressCS\WordPress\Sniffs\PHP;
+
+use WordPressCS\WordPress\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
+
+/**
+ * Discourage the usage of the unneeded ternary operator.
+ *
+ * This sniff is influenced by the same rule set in the ESLint rules.
+ * When we want to store a boolean value in a variable, using a ternary operator
+ * is not needed, because a test will return a boolean value.
+ *
+ * @link https://eslint.org/docs/rules/no-unneeded-ternary
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   2.2.0
+ */
+class NoUnneededTernarySniff extends Sniff {
+
+	/**
+	 * Boolean tokens array.
+	 *
+	 * @since   2.2.0
+	 *
+	 * @var array
+	 */
+	private $boolean_tokens = array(
+		'T_TRUE'  => true,
+		'T_FALSE' => true,
+	);
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @since 2.2.0
+	 *
+	 * @return array
+	 */
+	public function register() {
+		return array( \T_INLINE_THEN );
+	}
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @since 2.2.0
+	 *
+	 * @param int $stackPtr The position of the current token in the stack.
+	 */
+	public function process_token( $stackPtr ) {
+		$first_token      = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true );
+		$end_of_statement = $this->phpcsFile->findNext( array( \T_SEMICOLON, \T_CLOSE_TAG ), $stackPtr );
+		$last_token       = $this->phpcsFile->findPrevious( Tokens::$emptyTokens, ( $end_of_statement - 1 ), null, true );
+
+		$first_token_type = $this->tokens[ $first_token ]['type'];
+		$last_token_type  = $this->tokens[ $last_token ]['type'];
+
+		if ( isset( $this->boolean_tokens[ $first_token_type ] ) && isset( $this->boolean_tokens[ $last_token_type ] ) ) {
+			$this->phpcsFile->addError(
+				'Don\'t use ternary epression to store a boolean value in a variable.',
+				$stackPtr,
+				'Detected'
+			);
+		}
+	}
+
+}

--- a/WordPress/Tests/PHP/NoUnneededTernaryUnitTest.inc
+++ b/WordPress/Tests/PHP/NoUnneededTernaryUnitTest.inc
@@ -1,0 +1,30 @@
+<?php
+
+$var = 'a';
+$trueVariable = $var === 'a' ? true : false;  // Bad.
+// Can be written as.
+$trueVariable = $var === 'a'; // Ok.
+
+$test_var = $boolean ? true : false;  // Bad.
+
+$test = $var === 'a' ? // Bad.
+			true :
+			false;
+
+$test = $var === 'a'
+			? true // Bad.
+			: false;
+
+$isTrue = $var === 4 ? false : true;  // Bad.
+
+$isTrue = $var === 4 ? 'Yes' : 'No';  // Ok.
+
+$isTrue = $var === 4 ? true : 'No';  // Ok.
+
+$isTrue = $var === 4 ? 'True' : false;  // Ok.
+
+$isTrue = $var === 4 ? false : 'True';  // Ok.
+
+$isTrue = $var === 4 ? 'False' : true;  // Ok.
+
+$notFalse = $var !== false; // Ok.

--- a/WordPress/Tests/PHP/NoUnneededTernaryUnitTest.php
+++ b/WordPress/Tests/PHP/NoUnneededTernaryUnitTest.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Unit test class for WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPressCS\WordPress\Tests\PHP;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+/**
+ * Unit test class for the PHP_NoUnneededTernary sniff.
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   2.2.0
+ */
+class NoUnneededTernaryUnitTest extends AbstractSniffUnitTest {
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * @return array <int line number> => <int number of errors>
+	 */
+	public function getErrorList() {
+		return array(
+			4  => 1,
+			8  => 1,
+			10 => 1,
+			15 => 1,
+			18 => 1,
+		);
+	}
+
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * @return array <int line number> => <int number of warnings>
+	 */
+	public function getWarningList() {
+		return array();
+	}
+
+}


### PR DESCRIPTION
This sniff addresses #1291 issue.

When doing an assignment to a boolean with a ternary, if the ternary is only containing boolean values, this is an overhead, as a simple test will yield a boolean.

```php
<?php

$var = 'a';
// Example of an unneeded ternary:
$is_true = $var === 'a' ? true : false;

// Can be written as:
$is_true = $var === 'a';
```

Includes unit tests.
Includes documentation.

I have added some unit tests, but I'd like to see if some more extra cases need to be addressed.