### PR TITLE
PHP 7.4 compatibility / defensive coding

### DIFF
--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -1338,6 +1338,10 @@ abstract class Sniff implements PHPCS_Sniff {
 
 		// Does the class/trait extend one of the whitelisted test classes ?
 		$extendedClassName = $this->phpcsFile->findExtendedClassName( $stackPtr );
+		if ( false === $extendedClassName ) {
+			return false;
+		}
+
 		if ( '\\' === $extendedClassName[0] ) {
 			if ( isset( $whitelist[ substr( $extendedClassName, 1 ) ] ) ) {
 				return true;
@@ -1480,8 +1484,8 @@ abstract class Sniff implements PHPCS_Sniff {
 		// Check if we've looked here before.
 		$filename = $this->phpcsFile->getFilename();
 
-		if (
-			$filename === $last['file']
+		if ( is_array( $last )
+			&& $filename === $last['file']
 			&& $start === $last['start']
 		) {
 


### PR DESCRIPTION
WPCS is running into two PHP 7.4 issues where we use array access on a non-array value.
This PR fixes both.

Refs:
* https://wiki.php.net/rfc/deprecate_curly_braces_array_access

Build showing the issues:
* https://travis-ci.com/WordPress/WordPress-Coding-Standards/jobs/218025587