### PR TITLE
EscapeOutput: improve the error message for non-escaped variables

### DIFF
--- a/WordPress/Sniffs/Security/EscapeOutputSniff.php
+++ b/WordPress/Sniffs/Security/EscapeOutputSniff.php
@@ -443,6 +443,15 @@ class EscapeOutputSniff extends Sniff {
 				$ptr     = $i;
 			}
 
+			// Make the error message a little more informative for array access variables.
+			if ( \T_VARIABLE === $this->tokens[ $ptr ]['code'] ) {
+				$array_keys = $this->get_array_access_keys( $ptr );
+
+				if ( ! empty( $array_keys ) ) {
+					$content .= '[' . implode( '][', $array_keys ) . ']';
+				}
+			}
+
 			$this->phpcsFile->addError(
 				"All output should be run through an escaping function (see the Security sections in the WordPress Developer Handbooks), found '%s'.",
 				$ptr,


### PR DESCRIPTION
This improved the error message output when array variables are being accessed.

```php
echo $strings['update-available'];
```

**Old output:**
`All output should be run through an escaping function (see the Security sections in the WordPress Developer Handbooks), found '$strings'.`

**New output:**
`All output should be run through an escaping function (see the Security sections in the WordPress Developer Handbooks), found '$strings['update-available']'.`

No unit tests added as the unit tests don't test the message thrown.

The effect can be tested & confirmed though by running the sniff over the above code snippet.

Partially fixes #749