### PR TITLE
New CodeAnalysis/EscapedNotTranslated sniff

### DIFF
--- a/WordPress-Extra/ruleset.xml
+++ b/WordPress-Extra/ruleset.xml
@@ -168,6 +168,11 @@
 	</rule>
 
 
+	<!-- Prevent some typical mistakes people make accidentally.
+	     https://github.com/WordPress/WordPress-Coding-Standards/pull/1777 -->
+	<rule ref="WordPress.CodeAnalysis.EscapedNotTranslated"/>
+
+
 	<!--
 	#############################################################################
 	Code style sniffs for more recent PHP features and syntaxes.

--- a/WordPress/Docs/CodeAnalysis/EscapedNotTranslatedStandard.xml
+++ b/WordPress/Docs/CodeAnalysis/EscapedNotTranslatedStandard.xml
@@ -1,0 +1,20 @@
+<documentation title="Escaped Not Translated Text">
+    <standard>
+    <![CDATA[
+    Text intended for translation needs to be wrapped in a localization function call.
+    This sniff will help you find instances where text is escaped for output, but no localization function is called, even though an (unexpected) text domain argument is passed to the escape function.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: esc_html__() used to translate and escape.">
+        <![CDATA[
+echo <em>esc_html__</em>( 'text', 'domain' );
+        ]]>
+        </code>
+        <code title="Invalid: esc_html() used to only escape a string intended to be translated as well.">
+        <![CDATA[
+echo <em>esc_html</em>( 'text', 'domain' );
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/WordPress/Sniffs/CodeAnalysis/EscapedNotTranslatedSniff.php
+++ b/WordPress/Sniffs/CodeAnalysis/EscapedNotTranslatedSniff.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPressCS\WordPress\Sniffs\CodeAnalysis;
+
+use WordPressCS\WordPress\AbstractFunctionParameterSniff;
+use PHP_CodeSniffer\Util\Tokens;
+
+/**
+ * Flag calls to escaping functions which look like they may have been intended
+ * as calls to the "translate + escape" sister-function due to the presence of
+ * more than one parameter.
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   2.2.0
+ */
+class EscapedNotTranslatedSniff extends AbstractFunctionParameterSniff {
+
+	/**
+	 * The group name for this group of functions.
+	 *
+	 * @since 2.2.0
+	 *
+	 * @var string
+	 */
+	protected $group_name = 'escapednottranslated';
+
+	/**
+	 * List of functions to examine.
+	 *
+	 * @link https://developer.wordpress.org/reference/functions/esc_html/
+	 * @link https://developer.wordpress.org/reference/functions/esc_html__/
+	 * @link https://developer.wordpress.org/reference/functions/esc_attr/
+	 * @link https://developer.wordpress.org/reference/functions/esc_attr__/
+	 *
+	 * @since 2.2.0
+	 *
+	 * @var array <string function_name> => <string alternative function>
+	 */
+	protected $target_functions = array(
+		'esc_html' => 'esc_html__',
+		'esc_attr' => 'esc_attr__',
+	);
+
+	/**
+	 * Process the parameters of a matched function.
+	 *
+	 * @since 2.2.0
+	 *
+	 * @param int    $stackPtr        The position of the current token in the stack.
+	 * @param array  $group_name      The name of the group which was matched.
+	 * @param string $matched_content The token content (function name) which was matched.
+	 * @param array  $parameters      Array with information about the parameters.
+	 *
+	 * @return void
+	 */
+	public function process_parameters( $stackPtr, $group_name, $matched_content, $parameters ) {
+		if ( \count( $parameters ) === 1 ) {
+			return;
+		}
+
+		/*
+		 * We already know that there will be a valid open+close parenthesis, otherwise the sniff
+		 * would have bowed out long before.
+		 */
+		$opener = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true );
+		$closer = $this->tokens[ $opener ]['parenthesis_closer'];
+
+		$data = array(
+			$matched_content,
+			$this->target_functions[ $matched_content ],
+			$this->phpcsFile->getTokensAsString( $stackPtr, ( $closer - $stackPtr + 1 ) ),
+		);
+
+		$this->phpcsFile->addWarning(
+			'%s() expects only one parameter. Did you mean to use %s() ? Found: %s',
+			$stackPtr,
+			'Found',
+			$data
+		);
+	}
+
+}

--- a/WordPress/Tests/CodeAnalysis/EscapedNotTranslatedUnitTest.inc
+++ b/WordPress/Tests/CodeAnalysis/EscapedNotTranslatedUnitTest.inc
@@ -1,0 +1,8 @@
+<?php
+
+esc_html( 'text' );
+esc_html( $var );
+
+esc_html( 'text', 'domain' ); // Warning.
+esc_html( $foo, $bar ); // Warning.
+esc_attr( 'text', MY_DOMAIN ); // Warning.

--- a/WordPress/Tests/CodeAnalysis/EscapedNotTranslatedUnitTest.php
+++ b/WordPress/Tests/CodeAnalysis/EscapedNotTranslatedUnitTest.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Unit test class for WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPressCS\WordPress\Tests\CodeAnalysis;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+/**
+ * Unit test class for the EscapedNotTranslated sniff.
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   2.2.0
+ */
+class EscapedNotTranslatedUnitTest extends AbstractSniffUnitTest {
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * @return array <int line number> => <int number of errors>
+	 */
+	public function getErrorList() {
+		return array();
+	}
+
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * @return array <int line number> => <int number of warnings>
+	 */
+	public function getWarningList() {
+		return array(
+			6 => 1,
+			7 => 1,
+			8 => 1,
+		);
+	}
+
+}


### PR DESCRIPTION
At times, people will accidentally forget to add the `__` when they intend to use one of the "translate + escape" functions.
I've run into this a number of times now when reviewing/fixing code and found that they aren't that easy to spot visually when you're focussed on other things.

So as it was such an easy sniff to write, I figured I may as well.

AFAICS there are only two escaping functions in core which have direct "translate + escape" sister-functions.
All the same, the sniff has been set up to allow for more similar function-combis to be added.

Includes unit tests.
Includes documentation.

Sniff has been added to the `WordPress-Extra` ruleset.