### PR TITLE
ArrayKeySpacingRestrictions: add space size check & fix errors in one go

### DIFF
--- a/WordPress/Sniffs/Arrays/ArrayKeySpacingRestrictionsSniff.php
+++ b/WordPress/Sniffs/Arrays/ArrayKeySpacingRestrictionsSniff.php
@@ -10,6 +10,7 @@
 namespace WordPressCS\WordPress\Sniffs\Arrays;
 
 use WordPressCS\WordPress\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
 
 /**
  * Check for proper spacing in array key references.
@@ -22,6 +23,7 @@ use WordPressCS\WordPress\Sniff;
  * @since   0.7.0  This sniff now has the ability to fix a number of the issues it flags.
  * @since   0.12.0 This class now extends the WordPressCS native `Sniff` class.
  * @since   0.13.0 Class name changed: this class is now namespaced.
+ * @since   2.2.0  The sniff now also checks the size of the spacing, if applicable.
  */
 class ArrayKeySpacingRestrictionsSniff extends Sniff {
 
@@ -62,7 +64,9 @@ class ArrayKeySpacingRestrictionsSniff extends Sniff {
 		$spaced2 = ( \T_WHITESPACE === $this->tokens[ ( $token['bracket_closer'] - 1 ) ]['code'] );
 
 		// It should have spaces unless if it only has strings or numbers as the key.
-		if ( false !== $need_spaces && ! ( $spaced1 && $spaced2 ) ) {
+		if ( false !== $need_spaces
+			&& ( false === $spaced1 || false === $spaced2 )
+		) {
 			$error = 'Array keys must be surrounded by spaces unless they contain a string or an integer.';
 			$fix   = $this->phpcsFile->addFixableError( $error, $stackPtr, 'NoSpacesAroundArrayKeys' );
 			if ( true === $fix ) {
@@ -82,6 +86,82 @@ class ArrayKeySpacingRestrictionsSniff extends Sniff {
 				}
 				if ( $spaced2 ) {
 					$this->phpcsFile->fixer->replaceToken( ( $token['bracket_closer'] - 1 ), '' );
+				}
+			}
+		}
+
+		// If spaces are needed, check that there is only one space.
+		if ( false !== $need_spaces && ( $spaced1 || $spaced2 ) ) {
+			if ( $spaced1 ) {
+				$ptr    = ( $stackPtr + 1 );
+				$length = 0;
+				if ( $this->tokens[ $ptr ]['line'] !== $this->tokens[ ( $ptr + 1 ) ]['line'] ) {
+					$length = 'newline';
+				} else {
+					$length = $this->tokens[ $ptr ]['length'];
+				}
+
+				if ( 1 !== $length ) {
+					$error = 'There should be exactly one space before the array key. Found: %s';
+					$data  = array( $length );
+					$fix   = $this->phpcsFile->addFixableError(
+						$error,
+						$ptr,
+						'TooMuchSpaceBeforeKey',
+						$data
+					);
+
+					if ( true === $fix ) {
+						$this->phpcsFile->fixer->beginChangeset();
+						$this->phpcsFile->fixer->replaceToken( $ptr, ' ' );
+
+						for ( $i = ( $ptr + 1 ); $i < $token['bracket_closer']; $i++ ) {
+							if ( \T_WHITESPACE !== $this->tokens[ $i ]['code'] ) {
+								break;
+							}
+
+							$this->phpcsFile->fixer->replaceToken( $i, '' );
+						}
+
+						$this->phpcsFile->fixer->endChangeset();
+					}
+				}
+			}
+
+			if ( $spaced2 ) {
+				$prev_non_empty = $this->phpcsFile->findPrevious( Tokens::$emptyTokens, ( $token['bracket_closer'] - 1 ), null, true );
+				$ptr            = ( $prev_non_empty + 1 );
+				$length         = 0;
+				if ( $this->tokens[ $ptr ]['line'] !== $this->tokens[ $token['bracket_closer'] ]['line'] ) {
+					$length = 'newline';
+				} else {
+					$length = $this->tokens[ $ptr ]['length'];
+				}
+
+				if ( 1 !== $length ) {
+					$error = 'There should be exactly one space after the array key. Found: %s';
+					$data  = array( $length );
+					$fix   = $this->phpcsFile->addFixableError(
+						$error,
+						$ptr,
+						'TooMuchSpaceAfterKey',
+						$data
+					);
+
+					if ( true === $fix ) {
+						$this->phpcsFile->fixer->beginChangeset();
+						$this->phpcsFile->fixer->replaceToken( $ptr, ' ' );
+
+						for ( $i = ( $ptr + 1 ); $i < $token['bracket_closer']; $i++ ) {
+							if ( \T_WHITESPACE !== $this->tokens[ $i ]['code'] ) {
+								break;
+							}
+
+							$this->phpcsFile->fixer->replaceToken( $i, '' );
+						}
+
+						$this->phpcsFile->fixer->endChangeset();
+					}
 				}
 			}
 		}

--- a/WordPress/Sniffs/Arrays/ArrayKeySpacingRestrictionsSniff.php
+++ b/WordPress/Sniffs/Arrays/ArrayKeySpacingRestrictionsSniff.php
@@ -82,10 +82,32 @@ class ArrayKeySpacingRestrictionsSniff extends Sniff {
 			$fix   = $this->phpcsFile->addFixableError( $error, $stackPtr, 'SpacesAroundArrayKeys' );
 			if ( true === $fix ) {
 				if ( $spaced1 ) {
+					$this->phpcsFile->fixer->beginChangeset();
 					$this->phpcsFile->fixer->replaceToken( ( $stackPtr + 1 ), '' );
+
+					for ( $i = ( $stackPtr + 2 ); $i < $token['bracket_closer']; $i++ ) {
+						if ( \T_WHITESPACE !== $this->tokens[ $i ]['code'] ) {
+							break;
+						}
+
+						$this->phpcsFile->fixer->replaceToken( $i, '' );
+					}
+
+					$this->phpcsFile->fixer->endChangeset();
 				}
 				if ( $spaced2 ) {
+					$this->phpcsFile->fixer->beginChangeset();
 					$this->phpcsFile->fixer->replaceToken( ( $token['bracket_closer'] - 1 ), '' );
+
+					for ( $i = ( $token['bracket_closer'] - 2 ); $i > $stackPtr; $i-- ) {
+						if ( \T_WHITESPACE !== $this->tokens[ $i ]['code'] ) {
+							break;
+						}
+
+						$this->phpcsFile->fixer->replaceToken( $i, '' );
+					}
+
+					$this->phpcsFile->fixer->endChangeset();
 				}
 			}
 		}

--- a/WordPress/Tests/Arrays/ArrayKeySpacingRestrictionsUnitTest.inc
+++ b/WordPress/Tests/Arrays/ArrayKeySpacingRestrictionsUnitTest.inc
@@ -41,3 +41,6 @@ $arr[
 
 
 	]; // Bad x 2.
+
+$a = $arr[    /*comment*/ 'key']; // Bad x 2.
+$a = $arr[/*comment*/ 'key'   ]; // Bad x 2.

--- a/WordPress/Tests/Arrays/ArrayKeySpacingRestrictionsUnitTest.inc
+++ b/WordPress/Tests/Arrays/ArrayKeySpacingRestrictionsUnitTest.inc
@@ -29,3 +29,15 @@ $arr[0]; // Good.
 $arr[ 0 ]; // Bad.
 $arr[-1]; // Good.
 $arr[ -1 ]; // Bad.
+
+// Space size check.
+bar( $arr[
+	'test'
+
+	   ] ); // Bad.
+bar( $arr[     $test    ] ); // Bad x 2.
+$arr[
+		FooClass::FOO_KEY
+
+
+	]; // Bad x 2.

--- a/WordPress/Tests/Arrays/ArrayKeySpacingRestrictionsUnitTest.inc.fixed
+++ b/WordPress/Tests/Arrays/ArrayKeySpacingRestrictionsUnitTest.inc.fixed
@@ -34,3 +34,6 @@ $arr[-1]; // Bad.
 bar( $arr['test'] ); // Bad.
 bar( $arr[ $test ] ); // Bad x 2.
 $arr[ FooClass::FOO_KEY ]; // Bad x 2.
+
+$a = $arr[ /*comment*/ 'key' ]; // Bad x 2.
+$a = $arr[ /*comment*/ 'key' ]; // Bad x 2.

--- a/WordPress/Tests/Arrays/ArrayKeySpacingRestrictionsUnitTest.inc.fixed
+++ b/WordPress/Tests/Arrays/ArrayKeySpacingRestrictionsUnitTest.inc.fixed
@@ -29,3 +29,8 @@ $arr[0]; // Good.
 $arr[0]; // Bad.
 $arr[-1]; // Good.
 $arr[-1]; // Bad.
+
+// Space size check.
+bar( $arr['test'] ); // Bad.
+bar( $arr[ $test ] ); // Bad x 2.
+$arr[ FooClass::FOO_KEY ]; // Bad x 2.

--- a/WordPress/Tests/Arrays/ArrayKeySpacingRestrictionsUnitTest.php
+++ b/WordPress/Tests/Arrays/ArrayKeySpacingRestrictionsUnitTest.php
@@ -41,6 +41,10 @@ class ArrayKeySpacingRestrictionsUnitTest extends AbstractSniffUnitTest {
 			26 => 1,
 			29 => 1,
 			31 => 1,
+			34 => 1,
+			38 => 2,
+			39 => 1,
+			40 => 1,
 		);
 	}
 

--- a/WordPress/Tests/Arrays/ArrayKeySpacingRestrictionsUnitTest.php
+++ b/WordPress/Tests/Arrays/ArrayKeySpacingRestrictionsUnitTest.php
@@ -45,6 +45,8 @@ class ArrayKeySpacingRestrictionsUnitTest extends AbstractSniffUnitTest {
 			38 => 2,
 			39 => 1,
 			40 => 1,
+			45 => 2,
+			46 => 2,
 		);
 	}
 


### PR DESCRIPTION
## ArrayKeySpacingRestrictions: check the size of the space on the inside of the brackets

For non-string, non-numeric array keys, WPCS demands a space on the inside of the square brackets around the array key.

Up to now, the _size_ of the whitespace on the inside of the square brackets was not checked.

This PR adds that check.

Includes unit tests.
Includes fixer.

## ArrayKeySpacingRestrictions: fix whitespace violations in one go

If the array key should not be surrounded by spaces and there was more than one whitespace token between a bracket and the array key, the fixer would take several loops to remove the consecutive whitespace tokens.

This has been changed to fixing the whitespace in one go, reducing the chance of fixer conflicts and making the sniff more efficient.

Includes unit tests.

This can be tested by running the sniff with the `-v` option. Without this fix, the sniff takes 4 loops when fixing the unit test cases in this commit, with the fix, it takes 2 loops.