### PR TITLE
Array sniffs: ignore short lists

### DIFF
--- a/WordPress/Sniffs/Arrays/ArrayDeclarationSpacingSniff.php
+++ b/WordPress/Sniffs/Arrays/ArrayDeclarationSpacingSniff.php
@@ -87,6 +87,14 @@ class ArrayDeclarationSpacingSniff extends Sniff {
 	 * @return void
 	 */
 	public function process_token( $stackPtr ) {
+
+		if ( \T_OPEN_SHORT_ARRAY === $this->tokens[ $stackPtr ]['code']
+			&& $this->is_short_list( $stackPtr )
+		) {
+			// Short list, not short array.
+			return;
+		}
+
 		/*
 		 * Determine the array opener & closer.
 		 */

--- a/WordPress/Sniffs/Arrays/ArrayIndentationSniff.php
+++ b/WordPress/Sniffs/Arrays/ArrayIndentationSniff.php
@@ -92,6 +92,13 @@ class ArrayIndentationSniff extends Sniff {
 			$this->tab_width = PHPCSHelper::get_tab_width( $this->phpcsFile );
 		}
 
+		if ( \T_OPEN_SHORT_ARRAY === $this->tokens[ $stackPtr ]['code']
+			&& $this->is_short_list( $stackPtr )
+		) {
+			// Short list, not short array.
+			return;
+		}
+
 		/*
 		 * Determine the array opener & closer.
 		 */

--- a/WordPress/Sniffs/Arrays/CommaAfterArrayItemSniff.php
+++ b/WordPress/Sniffs/Arrays/CommaAfterArrayItemSniff.php
@@ -51,6 +51,14 @@ class CommaAfterArrayItemSniff extends Sniff {
 	 * @return void
 	 */
 	public function process_token( $stackPtr ) {
+
+		if ( \T_OPEN_SHORT_ARRAY === $this->tokens[ $stackPtr ]['code']
+			&& $this->is_short_list( $stackPtr )
+		) {
+			// Short list, not short array.
+			return;
+		}
+
 		/*
 		 * Determine the array opener & closer.
 		 */

--- a/WordPress/Sniffs/Arrays/MultipleStatementAlignmentSniff.php
+++ b/WordPress/Sniffs/Arrays/MultipleStatementAlignmentSniff.php
@@ -164,6 +164,14 @@ class MultipleStatementAlignmentSniff extends Sniff {
 	 *                  normal file processing.
 	 */
 	public function process_token( $stackPtr ) {
+
+		if ( \T_OPEN_SHORT_ARRAY === $this->tokens[ $stackPtr ]['code']
+			&& $this->is_short_list( $stackPtr )
+		) {
+			// Short list, not short array.
+			return;
+		}
+
 		/*
 		 * Determine the array opener & closer.
 		 */

--- a/WordPress/Tests/Arrays/ArrayDeclarationSpacingUnitTest.2.inc
+++ b/WordPress/Tests/Arrays/ArrayDeclarationSpacingUnitTest.2.inc
@@ -107,3 +107,29 @@ $bad = [
 	end */
 	'key4' => 'value4'
 ];
+
+/*
+ * Issue #1692: Test distinguishing between short array and short list.
+ *
+ * Note: these short lists should all contain "violations" against the array
+ * declaration sniff if they would be recognized as short array to make sure
+ * they are correctly recognized as short lists.
+ */
+// Empty list, not allowed since PHP 7.0, but not our concern.
+[  ] = $array; // OK.
+[, ,] = $array; // OK.
+
+[$var1, $var2] = $array; // OK.
+
+// Keyed list.
+[$foo => $bar] = $bar; // OK.
+['enabled' => $enabled, 'compression' => $compression] = [ 'enabled' => true, 'compression' => 'gzip' ]; // Bad x 1 - only for the short array, not the short list.
+
+// Nested short lists.
+[$var1, , [$var2, $var3,], $var4] = $array; // OK.
+[ 'o' => [[ $one, $two, $three ], [ 'what' => $what ]] ] = $x; // OK.
+
+// Destructuring - multiline.
+[
+	'prop1' => $prop1, 'prop2' => $prop2, // OK.
+] = $some_var;

--- a/WordPress/Tests/Arrays/ArrayDeclarationSpacingUnitTest.2.inc.fixed
+++ b/WordPress/Tests/Arrays/ArrayDeclarationSpacingUnitTest.2.inc.fixed
@@ -164,3 +164,32 @@ $bad = [
 	end */
 	'key4' => 'value4'
 ];
+
+/*
+ * Issue #1692: Test distinguishing between short array and short list.
+ *
+ * Note: these short lists should all contain "violations" against the array
+ * declaration sniff if they would be recognized as short array to make sure
+ * they are correctly recognized as short lists.
+ */
+// Empty list, not allowed since PHP 7.0, but not our concern.
+[  ] = $array; // OK.
+[, ,] = $array; // OK.
+
+[$var1, $var2] = $array; // OK.
+
+// Keyed list.
+[$foo => $bar] = $bar; // OK.
+['enabled' => $enabled, 'compression' => $compression] = [
+'enabled' => true,
+'compression' => 'gzip'
+]; // Bad x 1 - only for the short array, not the short list.
+
+// Nested short lists.
+[$var1, , [$var2, $var3,], $var4] = $array; // OK.
+[ 'o' => [[ $one, $two, $three ], [ 'what' => $what ]] ] = $x; // OK.
+
+// Destructuring - multiline.
+[
+	'prop1' => $prop1, 'prop2' => $prop2, // OK.
+] = $some_var;

--- a/WordPress/Tests/Arrays/ArrayDeclarationSpacingUnitTest.php
+++ b/WordPress/Tests/Arrays/ArrayDeclarationSpacingUnitTest.php
@@ -93,6 +93,7 @@ class ArrayDeclarationSpacingUnitTest extends AbstractSniffUnitTest {
 					91  => 1,
 					92  => 1,
 					104 => 1,
+					126 => 1,
 				);
 
 			default:

--- a/WordPress/Tests/Arrays/ArrayIndentationUnitTest.1.inc
+++ b/WordPress/Tests/Arrays/ArrayIndentationUnitTest.1.inc
@@ -428,3 +428,11 @@ $my_array = [
 // B
 	'something_else',
 ];
+
+/*
+ * Issue #1692: Test distinguishing between short array and short list.
+ */
+[
+'prop1' => $prop1,
+			'prop2' => $prop2,
+] = $some_var;

--- a/WordPress/Tests/Arrays/ArrayIndentationUnitTest.1.inc.fixed
+++ b/WordPress/Tests/Arrays/ArrayIndentationUnitTest.1.inc.fixed
@@ -428,3 +428,11 @@ $my_array = [
 // B
 	'something_else',
 ];
+
+/*
+ * Issue #1692: Test distinguishing between short array and short list.
+ */
+[
+'prop1' => $prop1,
+			'prop2' => $prop2,
+] = $some_var;

--- a/WordPress/Tests/Arrays/ArrayIndentationUnitTest.2.inc
+++ b/WordPress/Tests/Arrays/ArrayIndentationUnitTest.2.inc
@@ -429,4 +429,12 @@ $my_array = [
     'something_else',
 ];
 
+/*
+ * Issue #1692: Test distinguishing between short array and short list.
+ */
+[
+'prop1' => $prop1,
+			'prop2' => $prop2,
+] = $some_var;
+
 // phpcs:set WordPress.Arrays.ArrayIndentation tabIndent true

--- a/WordPress/Tests/Arrays/ArrayIndentationUnitTest.2.inc.fixed
+++ b/WordPress/Tests/Arrays/ArrayIndentationUnitTest.2.inc.fixed
@@ -429,4 +429,12 @@ $my_array = [
     'something_else',
 ];
 
+/*
+ * Issue #1692: Test distinguishing between short array and short list.
+ */
+[
+'prop1' => $prop1,
+			'prop2' => $prop2,
+] = $some_var;
+
 // phpcs:set WordPress.Arrays.ArrayIndentation tabIndent true

--- a/WordPress/Tests/Arrays/CommaAfterArrayItemUnitTest.inc
+++ b/WordPress/Tests/Arrays/CommaAfterArrayItemUnitTest.inc
@@ -190,3 +190,23 @@ $bad = array(
          'second'
          // phpcs:enable Standard.Category.Sniff
         );
+
+/*
+ * Issue #1692: Test distinguishing between short array and short list.
+ */
+// Empty list, not allowed since PHP 7.0, but not our concern.
+[,,] = $array; // OK.
+
+[$var1, $var2,] = $array; // OK.
+
+// Keyed list.
+['enabled' => $enabled, 'compression' => $compression,] = [ 'enabled' => true, 'compression' => 'gzip', ]; // Bad x 1 - only for the short array, not the short list.
+
+// Nested short lists.
+[$var1, , [$var2, $var3,], $var4,] = $array; // OK.
+
+// Destructuring - multiline.
+[
+	'prop1' => $prop1,
+	'prop2' => $prop2
+] = $some_var;

--- a/WordPress/Tests/Arrays/CommaAfterArrayItemUnitTest.inc.fixed
+++ b/WordPress/Tests/Arrays/CommaAfterArrayItemUnitTest.inc.fixed
@@ -179,3 +179,23 @@ $bad = array(
          'second',
          // phpcs:enable Standard.Category.Sniff
         );
+
+/*
+ * Issue #1692: Test distinguishing between short array and short list.
+ */
+// Empty list, not allowed since PHP 7.0, but not our concern.
+[,,] = $array; // OK.
+
+[$var1, $var2,] = $array; // OK.
+
+// Keyed list.
+['enabled' => $enabled, 'compression' => $compression,] = [ 'enabled' => true, 'compression' => 'gzip' ]; // Bad x 1 - only for the short array, not the short list.
+
+// Nested short lists.
+[$var1, , [$var2, $var3,], $var4,] = $array; // OK.
+
+// Destructuring - multiline.
+[
+	'prop1' => $prop1,
+	'prop2' => $prop2
+] = $some_var;

--- a/WordPress/Tests/Arrays/CommaAfterArrayItemUnitTest.php
+++ b/WordPress/Tests/Arrays/CommaAfterArrayItemUnitTest.php
@@ -74,6 +74,7 @@ class CommaAfterArrayItemUnitTest extends AbstractSniffUnitTest {
 			184 => 2,
 			185 => 2,
 			190 => 1,
+			203 => 1,
 		);
 	}
 

--- a/WordPress/Tests/Arrays/MultipleStatementAlignmentUnitTest.1.inc
+++ b/WordPress/Tests/Arrays/MultipleStatementAlignmentUnitTest.1.inc
@@ -571,4 +571,12 @@ $deprecated_functions = array(
 					string', // Bad.
 );
 
+/*
+ * This isn't actually testing something, but is the long version of the "short list" test.
+ */
+list(
+	'prop1' => $prop1,
+	'prop2'    => $prop2,
+) = $some_var;
+
 // phpcs:set WordPress.Arrays.MultipleStatementAlignment alignMultilineItems always

--- a/WordPress/Tests/Arrays/MultipleStatementAlignmentUnitTest.1.inc.fixed
+++ b/WordPress/Tests/Arrays/MultipleStatementAlignmentUnitTest.1.inc.fixed
@@ -557,4 +557,12 @@ $deprecated_functions = array(
 					string', // Bad.
 );
 
+/*
+ * This isn't actually testing something, but is the long version of the "short list" test.
+ */
+list(
+	'prop1' => $prop1,
+	'prop2'    => $prop2,
+) = $some_var;
+
 // phpcs:set WordPress.Arrays.MultipleStatementAlignment alignMultilineItems always

--- a/WordPress/Tests/Arrays/MultipleStatementAlignmentUnitTest.2.inc
+++ b/WordPress/Tests/Arrays/MultipleStatementAlignmentUnitTest.2.inc
@@ -571,4 +571,12 @@ $deprecated_functions = [
                     string', // Bad.
 ];
 
+/*
+ * Issue #1692: Test distinguishing between short array and short list.
+ */
+[
+	'prop1' => $prop1,
+	'prop2'    => $prop2,
+] = $some_var;
+
 // phpcs:set WordPress.Arrays.MultipleStatementAlignment alignMultilineItems always

--- a/WordPress/Tests/Arrays/MultipleStatementAlignmentUnitTest.2.inc.fixed
+++ b/WordPress/Tests/Arrays/MultipleStatementAlignmentUnitTest.2.inc.fixed
@@ -557,4 +557,12 @@ $deprecated_functions = [
                     string', // Bad.
 ];
 
+/*
+ * Issue #1692: Test distinguishing between short array and short list.
+ */
+[
+	'prop1' => $prop1,
+	'prop2'    => $prop2,
+] = $some_var;
+
 // phpcs:set WordPress.Arrays.MultipleStatementAlignment alignMultilineItems always


### PR DESCRIPTION
While we should probably define rules for long/short list constructs, WPCS at this time, does not have a opinion on the formatting of these.

The `Arrays` sniffs, however, would all treat _short lists_ as if they were _short arrays_ and apply the array rules on them.

This PR fixes this by bowing out early if a short array is in actual fact a short list.

Includes unit tests in each of the sniffs in the `Arrays` category affected by this issue.

Fixes #1692

---

This PR also adds a new `Sniff::is_short_list()` utility method to determine whether a _short array_ token is in actual fact representing a PHP 7.1+ short list.

This method will be short-lived in WPCS as it will be introduced in WPCS 3.5.0 and can be deprecated/removed once the minimum required PHPCS version goes up.

