### PR TITLE
Fixing return of ignore_annotations()

### DIFF
--- a/WordPress/PHPCSHelper.php
+++ b/WordPress/PHPCSHelper.php
@@ -98,12 +98,14 @@ class PHPCSHelper {
 	public static function ignore_annotations( File $phpcsFile = null ) {
 		if ( isset( $phpcsFile, $phpcsFile->config->annotations ) ) {
 			return ! $phpcsFile->config->annotations;
-		} else {
-			$annotations = Config::getConfigData( 'annotations' );
-			if ( isset( $annotations ) ) {
-				return ! $annotations;
-			}
 		}
+
+		$annotations = Config::getConfigData( 'annotations' );
+		if ( isset( $annotations ) ) {
+			return ! $annotations;
+		}
+
+		return false;
 	}
 
 }


### PR DESCRIPTION
While doing static analysis, @phpstan discovered a _jungle of return type problems_ in `return` statements, missing `return`-s, incorrect `@return` in PHPDoc blocks.

phpstan.neon.dist

```yaml
# Add this to composer.json
#       "autoload-dev": {
#               "psr-4": {
#                       "WordPressCS\\WordPress\\": "WordPress/"
#               }
#       },

# Start: phpstan analyze

includes:
    - phar://phpstan.phar/conf/bleedingEdge.neon
parameters:
    #level: max
    level: 4
    inferPrivatePropertyTypeFromConstructor: true
    paths:
        - %currentWorkingDirectory%/WordPress/
    excludes_analyse:
        - %currentWorkingDirectory%/WordPress/Tests/
    autoload_files:
        - %currentWorkingDirectory%/vendor/squizlabs/php_codesniffer/autoload.php
    ignoreErrors:
#        - '#^Result of method WordPressCS\S+ \(void\) is used\.$#'
#        - '#^PHPDoc tag @var has invalid value \(array <.*> => <.*>\): Unexpected token#'
```

What do you think about it?
