### PR TITLE
PrefixAllGlobals/GlobalVariablesOverride: detect variables being set via list()

### DIFF
--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -2740,10 +2740,7 @@ abstract class Sniff implements PHPCS_Sniff {
 		} else {
 			// Short array syntax.
 			$opener = $stackPtr;
-
-			if ( isset( $this->tokens[ $stackPtr ]['bracket_closer'] ) ) {
-				$closer = $this->tokens[ $stackPtr ]['bracket_closer'];
-			}
+			$closer = $this->tokens[ $stackPtr ]['bracket_closer'];
 		}
 
 		if ( isset( $opener, $closer ) ) {

--- a/WordPress/Sniffs/WP/GlobalVariablesOverrideSniff.php
+++ b/WordPress/Sniffs/WP/GlobalVariablesOverrideSniff.php
@@ -24,6 +24,7 @@ use PHP_CodeSniffer\Util\Tokens;
  * @since   1.0.0  This sniff has been moved from the `Variables` category to the `WP`
  *                 category and renamed from `GlobalVariables` to `GlobalVariablesOverride`.
  * @since   1.1.0  The sniff now also detects variables being overriden in the global namespace.
+ * @since   2.2.0  The sniff now also detects variable assignments via the list() construct.
  *
  * @uses    \WordPressCS\WordPress\Sniff::$custom_test_class_whitelist
  */
@@ -88,6 +89,8 @@ class GlobalVariablesOverrideSniff extends Sniff {
 		$targets = array(
 			\T_GLOBAL,
 			\T_VARIABLE,
+			\T_LIST,
+			\T_OPEN_SHORT_ARRAY,
 		);
 
 		// Only used to skip over test classes.
@@ -129,12 +132,19 @@ class GlobalVariablesOverrideSniff extends Sniff {
 		/*
 		 * Examine variables within a function scope based on a `global` statement in the
 		 * function.
-		 * Examine variable not within a function scope and access to the `$GLOBALS`
+		 * Examine variables not within a function scope, but within a list construct, based
+		 * on that.
+		 * Examine variables not within a function scope and access to the `$GLOBALS`
 		 * variable based on the variable token.
 		 */
 		$in_function_scope = $this->phpcsFile->hasCondition( $stackPtr, array( \T_FUNCTION, \T_CLOSURE ) );
 
-		if ( \T_VARIABLE === $token['code']
+		if ( ( \T_LIST === $token['code'] || \T_OPEN_SHORT_ARRAY === $token['code'] )
+			&& false === $in_function_scope
+			&& false === $this->treat_files_as_scoped
+		) {
+			return $this->process_list_assignment( $stackPtr );
+		} elseif ( \T_VARIABLE === $token['code']
 			&& ( '$GLOBALS' === $token['content']
 				|| ( false === $in_function_scope && false === $this->treat_files_as_scoped ) )
 		) {
@@ -147,15 +157,46 @@ class GlobalVariablesOverrideSniff extends Sniff {
 	}
 
 	/**
+	 * Check that global variables declared via a list construct are prefixed.
+	 *
+	 * @internal No need to take special measures for nested lists. Nested or not,
+	 * each list part can only contain one variable being written to.
+	 *
+	 * @since 2.2.0
+	 *
+	 * @param int $stackPtr The position of the current token in the stack.
+	 *
+	 * @return int|void Integer stack pointer to skip forward or void to continue
+	 *                  normal file processing.
+	 */
+	protected function process_list_assignment( $stackPtr ) {
+		$list_open_close = $this->find_list_open_close( $stackPtr );
+		if ( false === $list_open_close ) {
+			// Short array, not short list.
+			return;
+		}
+
+		$var_pointers = $this->get_list_variables( $stackPtr, $list_open_close );
+		foreach ( $var_pointers as $ptr ) {
+			$this->process_variable_assignment( $ptr, true );
+		}
+
+		// No need to re-examine these variables.
+		return $list_open_close['closer'];
+	}
+
+	/**
 	 * Check that defined global variables are prefixed.
 	 *
 	 * @since 1.1.0 Logic was previously contained in the process_token() method.
 	 *
-	 * @param int $stackPtr The position of the current token in the stack.
+	 * @param int  $stackPtr The position of the current token in the stack.
+	 * @param bool $in_list  Whether or not this is a variable in a list assignment.
+	 *                       Defaults to false.
 	 *
 	 * @return void
 	 */
-	protected function process_variable_assignment( $stackPtr ) {
+	protected function process_variable_assignment( $stackPtr, $in_list = false ) {
 
 		if ( $this->has_whitelist_comment( 'override', $stackPtr ) === true ) {
 			return;
@@ -219,7 +260,8 @@ class GlobalVariablesOverrideSniff extends Sniff {
 		/*
 		 * Check if the variable value is being changed.
 		 */
-		if ( false === $this->is_assignment( $stackPtr )
+		if ( false === $in_list
+			&& false === $this->is_assignment( $stackPtr )
 			&& false === $this->is_foreach_as( $stackPtr )
 		) {
 			return;
@@ -229,7 +271,7 @@ class GlobalVariablesOverrideSniff extends Sniff {
 		 * Function parameters with the same name as a WP global variable are fine,
 		 * including when they are being assigned a default value.
 		 */
-		if ( isset( $this->tokens[ $stackPtr ]['nested_parenthesis'] ) ) {
+		if ( false === $in_list && isset( $this->tokens[ $stackPtr ]['nested_parenthesis'] ) ) {
 			foreach ( $this->tokens[ $stackPtr ]['nested_parenthesis'] as $opener => $closer ) {
 				if ( isset( $this->tokens[ $opener ]['parenthesis_owner'] )
 					&& ( \T_FUNCTION === $this->tokens[ $this->tokens[ $opener ]['parenthesis_owner'] ]['code']
@@ -244,7 +286,7 @@ class GlobalVariablesOverrideSniff extends Sniff {
 		/*
 		 * Class property declarations with the same name as WP global variables are fine.
 		 */
-		if ( true === $this->is_class_property( $stackPtr ) ) {
+		if ( false === $in_list && true === $this->is_class_property( $stackPtr ) ) {
 			return;
 		}
 
@@ -322,6 +364,34 @@ class GlobalVariablesOverrideSniff extends Sniff {
 				}
 
 				$ptr = $this->tokens[ $ptr ]['scope_closer'];
+				continue;
+			}
+
+			// Make sure to recognize assignments to variables in a list construct.
+			if ( \T_LIST === $this->tokens[ $ptr ]['code']
+				|| \T_OPEN_SHORT_ARRAY === $this->tokens[ $ptr ]['code']
+			) {
+				$list_open_close = $this->find_list_open_close( $ptr );
+
+				if ( false === $list_open_close ) {
+					// Short array, not short list.
+					continue;
+				}
+
+				$var_pointers = $this->get_list_variables( $ptr, $list_open_close );
+				foreach ( $var_pointers as $ptr ) {
+					$var_name = $this->tokens[ $ptr ]['content'];
+					if ( '$GLOBALS' === $var_name ) {
+						$var_name = '$' . $this->strip_quotes( $this->get_array_access_key( $ptr ) );
+					}
+
+					if ( \in_array( $var_name, $search, true ) ) {
+						$this->process_variable_assignment( $ptr, true );
+					}
+				}
+
+				// No need to re-examine these variables.
+				$ptr = $list_open_close['closer'];
 				continue;
 			}
 

--- a/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.1.inc
+++ b/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.1.inc
@@ -429,4 +429,46 @@ function acronym_content_width() {
 	$GLOBALS['content_width'] = apply_filters( 'acronym_content_width', 640 );
 }
 
+/*
+ * Issue #1774: detect variables being set via the list() construct.
+ */
+// Empty list, not allowed since PHP 7.0, but not our concern.
+list() = $array; // OK.
+list(, ,) = $array; // OK.
+
+// Ordinary list.
+list( $var1, , $var2 )               = $array; // Bad x 2.
+list( $acronym_var1, $acronym_var2 ) = $array; // OK.
+
+// Short list.
+[ $var1, $var2 ]                 = $array; // Bad x 2.
+[ $acronym_var1, $acronym_var2 ] = $array; // OK.
+
+// Keyed list. Keys are not assignments.
+list((string)$a => $store["B"], (string)$c => $store["D"]) = $e->getIndexable(); // Bad x 2.
+[$foo => $GLOBALS['bar']] = $bar; // Bad x 1.
+
+// Nested list.
+list( $var1, , list( $var2, $var3, ), $var4 ) = $array; // Bad x 4.
+
+// List with array assignments.
+list( $foo['key'], $foo[ $bar ] ) = $array; // Bad x 2. Variable array key should be ignored.
+
+function acronym_lists_in_function_scope() {
+	global $store, $c;
+
+	list( $var1, , $var2 ) = $array; // OK.
+	[ $var1, $var2 ]       = $array; // OK.
+
+	// Keyed list. Keys are not assignments.
+	list((string)$a => $store["B"], (string)$c => $store["D"]) = $e->getIndexable(); // Bad x 2.
+	[$foo => $GLOBALS['bar']] = $bar; // Bad x 1.
+
+	// Nested list.
+	list( $var1, , list( $c, $var3, ), $var4 ) = $array; // Bad x 1 - $c.
+
+	// List with array assignments.
+	list( $foo['key'], $foo[ $c ] ) = $array; // OK. Variable array key should be ignored.
+}
+
 // phpcs:set WordPress.NamingConventions.PrefixAllGlobals prefixes[]

--- a/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.php
+++ b/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.php
@@ -70,6 +70,15 @@ class PrefixAllGlobalsUnitTest extends AbstractSniffUnitTest {
 					403 => 1,
 					415 => 1,
 					423 => 1,
+					440 => 2,
+					444 => 2,
+					448 => 2,
+					449 => 1,
+					452 => 4,
+					455 => 2,
+					464 => 2,
+					465 => 1,
+					468 => 1,
 				);
 
 			case 'PrefixAllGlobalsUnitTest.4.inc':

--- a/WordPress/Tests/WP/GlobalVariablesOverrideUnitTest.1.inc
+++ b/WordPress/Tests/WP/GlobalVariablesOverrideUnitTest.1.inc
@@ -223,3 +223,20 @@ function global_content_width() {
 }
 
 $content_width = 1000;
+
+// Issue #1743: detect var override via list construct.
+function acronym_prepare_items() {
+	global $wp_query, $post_mime_types, $avail_post_mime_types, $mode;
+	list( $post_mime_types, $avail_post_mime_types ) = get_an_array(); // Bad x 2.
+	[ $post_mime_types, $avail_post_mime_types ]     = get_an_array(); // PHP 7.1 short list syntax, bad x 2.
+
+	// Keyed list. Keys are not assignments.
+	list( (string) $wp_query => $GLOBALS['mode']["B"], (string) $c => $mode["D"] ) = $e->getIndexable(); // Bad x 2.
+	[ $mode => $not_global ] = $bar; // OK.
+}
+
+// Nested list.
+list( $active_signup, list( $s => $typenow, $GLOBALS['status'], ), $ignore ) = $array; // Bad x 3.
+
+// List with array assignments.
+[ $path[ $type ], , ] = $array; // Bad x 1.

--- a/WordPress/Tests/WP/GlobalVariablesOverrideUnitTest.php
+++ b/WordPress/Tests/WP/GlobalVariablesOverrideUnitTest.php
@@ -56,6 +56,11 @@ class GlobalVariablesOverrideUnitTest extends AbstractSniffUnitTest {
 					181 => 1,
 					198 => 1,
 					212 => 4,
+					230 => 2,
+					231 => 2,
+					234 => 2,
+					239 => 3,
+					242 => 1,
 				);
 
 			case 'GlobalVariablesOverrideUnitTest.2.inc':


### PR DESCRIPTION
Global variables to which an assignment is made via the long/short `list()` construct should also be prefixed (`PrefixAllGlobals`), unless they are WordPress native global variables, in which case the `GlobalVariablesOverride` sniff should kick in and throw an error about overwriting WP globals.

Includes unit tests for both sniffs.

Fixes #1774 
Loosely related to #764 (short lists, keyed lists)

---

This PR includes adding two new utility methods to the `Sniff` class:
* `Sniff::find_list_open_close()` - Sister-method to the `find_array_open_close()` utility method to find the opener and closer for `list()` constructs, including short lists.
* `Sniff::get_list_variables()`  - A utility method which will retrieve an array with the token pointers to the variables which are being assigned to in a `list()` construct, whether short or long list.
    This utility method takes all currently supported list features in PHP into account and handles the following correctly:
    * Nested lists
    * Empty list items
    * Trailing comma's in lists
    * Empty lists (no longer allowed as of PHP 7.0.0)
    * Short lists (PHP 7.1.0+)
    * Keyed lists (PHP 7.1.0+)
