### PR TITLE
PrefixAllGlobals: add "php" to the list of blacklisted prefixes

### DIFF
--- a/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
+++ b/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
@@ -65,6 +65,7 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 		'wordpress' => true,
 		'wp'        => true,
 		'_'         => true,
+		'php'       => true, // See #1728, the 'php' prefix is reserved by PHP itself.
 	);
 
 	/**


### PR DESCRIPTION
The `php` prefix is reserved for PHP itself.

No unit tests added as the logic for this blacklist is already sufficiently unit tested.

Fixes #1728