### PR TITLE
EscapeOutput: add sanitize_key() to escaping functions

### DIFF
--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -155,6 +155,7 @@ abstract class Sniff implements PHPCS_Sniff {
 		'number_format'        => true,
 		'rawurlencode'         => true,
 		'sanitize_html_class'  => true,
+		'sanitize_key'         => true,
 		'sanitize_user_field'  => true,
 		'tag_escape'           => true,
 		'urlencode_deep'       => true,


### PR DESCRIPTION
`sanitize_key()` only allows for lowercase characters, numbers, underscore and dash characters. So a variable run through `sanitize_key()` can be considered just as safe, if not more so, than a variable run through one of the escaping functions.

Ref:
* https://developer.wordpress.org/reference/functions/sanitize_key/