### PR TITLE
EscapeOutput: add highlight_string() to escaping functions

### DIFF
--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -149,6 +149,7 @@ abstract class Sniff implements PHPCS_Sniff {
 		'filter_input'         => true,
 		'filter_var'           => true,
 		'floatval'             => true,
+		'highlight_string'     => true,
 		'intval'               => true,
 		'json_encode'          => true,
 		'like_escape'          => true,


### PR DESCRIPTION
While intended for code highlighting of PHP code, based on some tests I've run, the output of the PHP native `highlight_string()` function does appear to be safe, so I'm proposing to add this to the list of `$escapingFunctions`.

Note: I'd appreciate some scrutiny of this PR. I wouldn't want to inadvertently add an unsafe function to the list.

Refs:
* https://3v4l.org/mYK5A
* https://www.php.net/manual/en/function.highlight-string.php