### PR TITLE
[ON HOLD] Move `date` function group from `RestrictedPHPFunctions` to `TimezoneChange`

### DIFF
--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -519,4 +519,8 @@
 	<!-- Check for correct spelling of WordPress. -->
 	<rule ref="WordPress.WP.CapitalPDangit"/>
 
+	<!-- Use gmdate() not date().
+		 See: https://github.com/WordPress/WordPress-Coding-Standards/issues/1713 -->
+	<rule ref="WordPress.WP.TimezoneChange.date_date"/>
+
 </ruleset>

--- a/WordPress-Extra/ruleset.xml
+++ b/WordPress-Extra/ruleset.xml
@@ -145,7 +145,9 @@
 	<rule ref="WordPress.Security.PluginMenuSlug"/>
 	<rule ref="WordPress.WP.CronInterval"/>
 	<rule ref="WordPress.WP.PostsPerPage"/>
-	<rule ref="WordPress.WP.TimezoneChange"/>
+	<rule ref="WordPress.WP.TimezoneChange">
+		<severity>5</severity>
+	</rule>
 
 	<!-- Verify some regex best practices.
 		 https://github.com/WordPress/WordPress-Coding-Standards/issues/1371 -->

--- a/WordPress/Sniffs/PHP/RestrictedPHPFunctionsSniff.php
+++ b/WordPress/Sniffs/PHP/RestrictedPHPFunctionsSniff.php
@@ -17,7 +17,6 @@ use WordPressCS\WordPress\AbstractFunctionRestrictionsSniff;
  * @package WPCS\WordPressCodingStandards
  *
  * @since   0.14.0
- * @since   2.2.0  New group `date` added.
  */
 class RestrictedPHPFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 
@@ -41,13 +40,6 @@ class RestrictedPHPFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 				'message'   => '%s() is deprecated as of PHP 7.2, please use full fledged functions or anonymous functions instead.',
 				'functions' => array(
 					'create_function',
-				),
-			),
-			'date' => array(
-				'type'      => 'error',
-				'message'   => '%s() is affected by runtime timezone changes which can cause date/time to be incorrectly displayed. Use gmdate() instead.',
-				'functions' => array(
-					'date',
 				),
 			),
 		);

--- a/WordPress/Sniffs/WP/TimezoneChangeSniff.php
+++ b/WordPress/Sniffs/WP/TimezoneChangeSniff.php
@@ -12,9 +12,8 @@ namespace WordPressCS\WordPress\Sniffs\WP;
 use WordPressCS\WordPress\AbstractFunctionRestrictionsSniff;
 
 /**
- * Disallow the changing of timezone.
- *
- * @link    https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/#manipulating-the-timezone-server-side
+ * Disallow changing the timezone and use of selective date/time functions which lead to
+ * timezone related bugs.
  *
  * @package WPCS\WordPressCodingStandards
  *
@@ -23,6 +22,7 @@ use WordPressCS\WordPress\AbstractFunctionRestrictionsSniff;
  *                 class instead of the upstream `Generic.PHP.ForbiddenFunctions` sniff.
  * @since   0.13.0 Class name changed: this class is now namespaced.
  * @since   1.0.0  This sniff has been moved from the `VIP` category to the `WP` category.
+ * @since   2.2.0  New group `date` added.
  */
 class TimezoneChangeSniff extends AbstractFunctionRestrictionsSniff {
 
@@ -41,11 +41,31 @@ class TimezoneChangeSniff extends AbstractFunctionRestrictionsSniff {
 	 */
 	public function getGroups() {
 		return array(
+
+			/*
+			 * Don't change the PHP time zone.
+			 *
+			 * @link https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/#manipulating-the-timezone-server-side
+			 */
 			'timezone_change' => array(
 				'type'      => 'error',
 				'message'   => 'Using %s() and similar isn\'t allowed, instead use WP internal timezone support.',
 				'functions' => array(
 					'date_default_timezone_set',
+				),
+			),
+
+			/*
+			 * Use gmdate(), not date().
+			 *
+			 * @link https://core.trac.wordpress.org/ticket/46438
+			 * @link https://github.com/WordPress/WordPress-Coding-Standards/issues/1713
+			 */
+			'date' => array(
+				'type'      => 'error',
+				'message'   => '%s() is affected by runtime timezone changes which can cause date/time to be incorrectly displayed. Use gmdate() instead.',
+				'functions' => array(
+					'date',
 				),
 			),
 		);

--- a/WordPress/Tests/PHP/RestrictedPHPFunctionsUnitTest.inc
+++ b/WordPress/Tests/PHP/RestrictedPHPFunctionsUnitTest.inc
@@ -3,6 +3,3 @@
 add_action( 'widgets_init', create_function( '', // Error.
 	'return register_widget( "time_more_on_time_widget" );'
 ) );
-
-$post_data['post_title'] = sprintf( __( 'Draft created on %1$s at %2$s' ), date( __( 'F j, Y' ), $now ), date( __( 'g:i a' ), $now ) ); // Error.
-$post_data['post_title'] = sprintf( __( 'Draft created on %1$s at %2$s' ), gmdate( __( 'F j, Y' ), $now ), gmdate( __( 'g:i a' ), $now ) ); // OK.

--- a/WordPress/Tests/PHP/RestrictedPHPFunctionsUnitTest.php
+++ b/WordPress/Tests/PHP/RestrictedPHPFunctionsUnitTest.php
@@ -28,7 +28,6 @@ class RestrictedPHPFunctionsUnitTest extends AbstractSniffUnitTest {
 	public function getErrorList() {
 		return array(
 			3 => 1,
-			7 => 2,
 		);
 	}
 

--- a/WordPress/Tests/WP/TimezoneChangeUnitTest.inc
+++ b/WordPress/Tests/WP/TimezoneChangeUnitTest.inc
@@ -4,3 +4,6 @@ date_default_timezone_set( 'Foo/Bar' ); // Bad.
 
 $date = new DateTime();
 $date->setTimezone( new DateTimeZone( 'America/Toronto' ) ); // Yay!
+
+$post_data['post_title'] = sprintf( __( 'Draft created on %1$s at %2$s' ), date( __( 'F j, Y' ), $now ), date( __( 'g:i a' ), $now ) ); // Error.
+$post_data['post_title'] = sprintf( __( 'Draft created on %1$s at %2$s' ), gmdate( __( 'F j, Y' ), $now ), gmdate( __( 'g:i a' ), $now ) ); // OK.

--- a/WordPress/Tests/WP/TimezoneChangeUnitTest.php
+++ b/WordPress/Tests/WP/TimezoneChangeUnitTest.php
@@ -30,6 +30,7 @@ class TimezoneChangeUnitTest extends AbstractSniffUnitTest {
 	public function getErrorList() {
 		return array(
 			3 => 1,
+			8 => 2,
 		);
 	}
 


### PR DESCRIPTION
Follow up on PR #1714 which fixed #1713.

As per the discussion in https://github.com/WordPress/WordPress-Coding-Standards/pull/1731#discussion_r301840793. moving the check for use of the `date()` to the `TimezoneChange` sniff.

As the `date` function group has not been in a released version (yet), we can still safely make this change without concerns about introducing breaking changes (error code change).

As that sniff is not part of the `Core` ruleset, I'm explicitly adding this particular error code to the `Core` ruleset.

Note: we may want to consider renaming this sniff as the name does not seem to be 100% correct anymore.

Suggestions for a better name welcome. If we go down that road, I'd deprecate the `TimezoneChange` sniff to be removed in the next major release.