### PR TITLE
OneObjectStructurePerFile: move from `Extra` to `Core`

### DIFF
--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -517,6 +517,12 @@
 		<severity>0</severity>
 	</rule>
 
+	<!-- Encourage having only one class/interface/trait per file.
+		 Moved from Extra to Core after discussion on Slack. -->
+	<rule ref="Generic.Files.OneObjectStructurePerFile">
+		<message>Best practices: Declare only one class/interface/trait in a file.</message>
+	</rule>
+
 	<!--
 	#############################################################################
 	Not in the coding standard handbook: WP specific sniffs.

--- a/WordPress-Extra/ruleset.xml
+++ b/WordPress-Extra/ruleset.xml
@@ -56,12 +56,6 @@
 	<!-- https://github.com/WordPress/WordPress-Coding-Standards/pull/382#discussion_r29981655 -->
 	<!--<rule ref="Generic.CodeAnalysis.UnusedFunctionParameter"/>-->
 
-	<!-- Encourage having only one class/interface/trait per file. -->
-	<rule ref="Generic.Files.OneObjectStructurePerFile">
-		<type>warning</type>
-		<message>Best practice suggestion: Declare only one class/interface/trait in a file.</message>
-	</rule>
-
 	<!-- Verify modifier keywords for declared methods and properties in classes.
 		 https://github.com/WordPress/WordPress-Coding-Standards/issues/1101 -->
 	<rule ref="Squiz.Scope.MethodScope"/>


### PR DESCRIPTION
Pulling this after @GaryJones brought this up as [a suggestion on Slack](https://wordpress.slack.com/archives/C5VCTJGH3/p1568550568000300).
WP Core currently has 27 violations against this rule - 3 in `src`, the rest in `tests`.

All the same, it would be a good thing to move this sniff to the `Core` ruleset. /cc @pento 

Open questions:
* The `Extra` configuration downgraded this to a `warning`. Should this be an `error` or a `warning` now it's moving to `Core` ?
* The `Extra` configuration also adjusted the error message. Is this still necessary or should we just use the default message from the sniff ?

Location | Message
--------- | -------
Original sniff error message | `Only one object structure is allowed in a file`.
Message as it was in `Extra` | `Best practice suggestion: Declare only one class/interface/trait in a file.`
Message proposed for `Core` | `Best practices: Declare only one class/interface/trait in a file.`

To do before this can be merged:
- [ ] Add a rule to this effect to the handbook.
- [ ] Adjust the `Core` ruleset to place the sniff in the right place with the text from the handbook.