### PR TITLE
DeprecatedFunctions: update function list

### DIFF
--- a/WordPress/Sniffs/WP/DeprecatedFunctionsSniff.php
+++ b/WordPress/Sniffs/WP/DeprecatedFunctionsSniff.php
@@ -1345,6 +1345,20 @@ class DeprecatedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 			'alt'     => '',
 			'version' => '5.1.0',
 		),
+
+		// WP 5.3.0.
+		'_wp_json_prepare_data' => array(
+			'alt'     => '',
+			'version' => '5.3.0',
+		),
+		'_wp_privacy_requests_screen_options' => array(
+			'alt'     => '',
+			'version' => '5.3.0',
+		),
+		'update_user_status' => array(
+			'alt'     => 'wp_update_user()',
+			'version' => '5.3.0',
+		),
 	);
 
 	/**

--- a/WordPress/Tests/WP/DeprecatedFunctionsUnitTest.inc
+++ b/WordPress/Tests/WP/DeprecatedFunctionsUnitTest.inc
@@ -341,3 +341,7 @@ wp_ajax_press_this_save_post();
 /* ============ WP 5.1 ============ */
 insert_blog();
 install_blog();
+/* ============ WP 5.3 ============ */
+_wp_json_prepare_data();
+_wp_privacy_requests_screen_options();
+update_user_status();

--- a/WordPress/Tests/WP/DeprecatedFunctionsUnitTest.php
+++ b/WordPress/Tests/WP/DeprecatedFunctionsUnitTest.php
@@ -75,10 +75,10 @@ class DeprecatedFunctionsUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getWarningList() {
 
-		$warnings = array_fill( 337, 7, 1 );
+		$warnings = array_fill( 337, 11, 1 );
 
 		// Unset the lines related to version comments.
-		unset( $warnings[341] );
+		unset( $warnings[341], $warnings[344] );
 
 		return $warnings;
 	}


### PR DESCRIPTION
... with functions which will be deprecated in WP 5.3.

Not updating the `Sniff::$minimum_supported_version` property yet as WP 5.3 has not yet been released.