### PR TITLE
EscapeOutput: allow for typical pattern with `_deprecated_file()`

### DIFF
--- a/WordPress/Sniffs/Security/EscapeOutputSniff.php
+++ b/WordPress/Sniffs/Security/EscapeOutputSniff.php
@@ -198,6 +198,20 @@ class EscapeOutputSniff extends Sniff {
 				$end_of_statement = ( $first_param['end'] + 1 );
 				unset( $first_param );
 			}
+
+			/*
+			 * If the first param to `_deprecated_file()` follows the typical `basename( __FILE__ )`
+			 * pattern, it doesn't need to be escaped.
+			 */
+			if ( '_deprecated_file' === $function ) {
+				$first_param = $this->get_function_call_parameter( $stackPtr, 1 );
+
+				// Quick check. This disregards comments.
+				if ( preg_match( '`^basename\s*\(\s*__FILE__\s*\)$`', $first_param['raw'] ) === 1 ) {
+					$stackPtr = ( $first_param['end'] + 2 );
+				}
+				unset( $first_param );
+			}
 		}
 
 		// Checking for the ignore comment, ex: //xss ok.

--- a/WordPress/Tests/Security/EscapeOutputUnitTest.inc
+++ b/WordPress/Tests/Security/EscapeOutputUnitTest.inc
@@ -292,3 +292,6 @@ echo esc_html( get_the_title() ); // Ok.
 
 echo implode( '<br>', map_deep( $items, 'esc_html' ) ); // Ok.
 echo implode( '<br>', map_deep( $items, 'foo' ) ); // Bad.
+
+_deprecated_file( basename( __FILE__ ), '1.3.0' ); // Ok.
+_deprecated_file( $file, '1.3.0' ); // Error.

--- a/WordPress/Tests/Security/EscapeOutputUnitTest.php
+++ b/WordPress/Tests/Security/EscapeOutputUnitTest.php
@@ -80,6 +80,7 @@ class EscapeOutputUnitTest extends AbstractSniffUnitTest {
 			266 => 1,
 			289 => 1,
 			294 => 1,
+			297 => 1,
 		);
 	}
 


### PR DESCRIPTION
The first parameter passed to [`_deprecated_file()`](https://developer.wordpress.org/reference/functions/_deprecated_file/) generally is `basename( __FILE__ )` based on the code currently in WP Core.
As the result of that function call is safe, I'm proposing making an exception for that particular code pattern when used as the first param in a call to `deprecated_file()`.

Includes unit tests.

Note: the current code does not allow for comments in the first parameter. This would be rare encounter in these function calls anyway and allowance for it can be added later if needs be.