### PR TITLE
ValidHookName: improve error messages

### DIFF
--- a/WordPress/Sniffs/NamingConventions/ValidHookNameSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidHookNameSniff.php
@@ -105,6 +105,11 @@ class ValidHookNameSniff extends AbstractFunctionParameterSniff {
 		$expected    = array();
 
 		for ( $i = $parameters[1]['start']; $i <= $parameters[1]['end']; $i++ ) {
+			// Skip past comment tokens.
+			if ( isset( Tokens::$commentTokens[ $this->tokens[ $i ]['code'] ] ) !== false ) {
+				continue;
+			}
+
 			$content[ $i ]  = $this->tokens[ $i ]['content'];
 			$expected[ $i ] = $this->tokens[ $i ]['content'];
 
@@ -165,18 +170,25 @@ class ValidHookNameSniff extends AbstractFunctionParameterSniff {
 			}
 		}
 
+		$first_non_empty = $this->phpcsFile->findNext(
+			Tokens::$emptyTokens,
+			$parameters[1]['start'],
+			( $parameters[1]['end'] + 1 ),
+			true
+		);
+
 		$data = array(
-			implode( '', $expected ),
-			implode( '', $content ),
+			trim( implode( '', $expected ) ),
+			trim( implode( '', $content ) ),
 		);
 
 		if ( $case_errors > 0 ) {
 			$error = 'Hook names should be lowercase. Expected: %s, but found: %s.';
-			$this->phpcsFile->addError( $error, $stackPtr, 'NotLowercase', $data );
+			$this->phpcsFile->addError( $error, $first_non_empty, 'NotLowercase', $data );
 		}
 		if ( $underscores > 0 ) {
 			$error = 'Words in hook names should be separated using underscores. Expected: %s, but found: %s.';
-			$this->phpcsFile->addWarning( $error, $stackPtr, 'UseUnderscores', $data );
+			$this->phpcsFile->addWarning( $error, $first_non_empty, 'UseUnderscores', $data );
 		}
 	}
 

--- a/WordPress/Tests/NamingConventions/ValidHookNameUnitTest.1.inc
+++ b/WordPress/Tests/NamingConventions/ValidHookNameUnitTest.1.inc
@@ -88,3 +88,9 @@ apply_filters_deprecated( "admin_Head_$Post->ID admin_Head_$Post->ID" ); // Ok.
 do_action( 'prefix_block_' . $block['blockName'] ); // Ok.
 do_action( 'prefix_block_' . $block  [  'blockName'  ] . '_More_hookname' ); // Error - use lowercase (second part of the hook name).
 do_action( "prefix_block_{$block['blockName']}" ); // Ok.
+
+// Don't include comments in the suggestion.
+do_action(
+	// phpcs:ignore Stnd.Cat.Sniff -- For reasons.
+	'prefix_hook-name' /* comment */
+);

--- a/WordPress/Tests/NamingConventions/ValidHookNameUnitTest.php
+++ b/WordPress/Tests/NamingConventions/ValidHookNameUnitTest.php
@@ -39,7 +39,7 @@ class ValidHookNameUnitTest extends AbstractSniffUnitTest {
 					28 => 1,
 					29 => 1,
 					30 => 1,
-					32 => 1,
+					33 => 1,
 					53 => 1,
 					54 => 1,
 					55 => 1,
@@ -96,6 +96,7 @@ class ValidHookNameUnitTest extends AbstractSniffUnitTest {
 					68 => 1,
 					72 => 1,
 					77 => 1,
+					95 => 1,
 				);
 
 			case 'ValidHookNameUnitTest.2.inc':


### PR DESCRIPTION
* Trim whitespace off the "expected" and "found" values which are used in the error messages.
* Ignore comments and PHPCS annotations when building up the "expected" and "found" values.
* Improve line precision by throwing the error on the line where the hook name starts, not the line containing the function call.

Includes unit test.

The unit test basically only tests part 3 of the change. The error message improvement needs visual inspection as the message content is not tested.