### PR TITLE
Adds documentation for the WordPress.WP.CapitalPDangit sniff.

### DIFF
--- a/WordPress/Docs/WP/CapitalPDangitStandard.xml
+++ b/WordPress/Docs/WP/CapitalPDangitStandard.xml
@@ -1,0 +1,41 @@
+<documentation title="Capital P Dangit">
+    <standard>
+    <![CDATA[
+The correct spelling of `WordPress` should be used in text strings, comments and object names.
+
+When part of an identifier or a URL, WordPress does not have to be capitalized.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: WordPress is correctly capitalized.">
+        <![CDATA[
+class <em>WordPress</em>Example {
+
+        /**
+         * This function is about <em>WordPress</em>.
+         */
+        public function explain() {
+                $is_wordpress_awesome = true;
+                echo 'This is an explanation 
+                      about <em>WordPress</em>.';
+        }
+}
+        ]]>
+        </code>
+        <code title="Invalid: WordPress is not correctly capitalized.">
+        <![CDATA[
+class <em>WordpressExample</em> {
+
+        /**
+         * This function is about <em>Wordpress</em>.
+         */
+        public function explain() {
+                $is_wordpress_awesome = true;
+                echo 'This is an explanation 
+                      about <em>wordpress</em>.';
+        }
+}
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/WordPress/Docs/WP/CapitalPDangitStandard.xml
+++ b/WordPress/Docs/WP/CapitalPDangitStandard.xml
@@ -1,39 +1,37 @@
 <documentation title="Capital P Dangit">
     <standard>
     <![CDATA[
-The correct spelling of `WordPress` should be used in text strings, comments and object names.
+The correct spelling of "WordPress" should be used in text strings, comments and object names.
 
-When part of an identifier or a URL, WordPress does not have to be capitalized.
+In select cases, when part of an identifier or a URL, WordPress does not have to be capitalized.
     ]]>
     </standard>
     <code_comparison>
         <code title="Valid: WordPress is correctly capitalized.">
         <![CDATA[
-class <em>WordPress</em>Example {
+class <em>WordPress</em>_Example {
 
-        /**
-         * This function is about <em>WordPress</em>.
-         */
-        public function explain() {
-                $is_wordpress_awesome = true;
-                echo 'This is an explanation 
-                      about <em>WordPress</em>.';
-        }
+    /**
+     * This function is about <em>WordPress</em>.
+     */
+    public function explain() {
+        echo 'This is an explanation
+            about <em>WordPress</em>.';
+    }
 }
         ]]>
         </code>
         <code title="Invalid: WordPress is not correctly capitalized.">
         <![CDATA[
-class <em>WordpressExample</em> {
+class <em>Wordpress_Example</em> {
 
-        /**
-         * This function is about <em>Wordpress</em>.
-         */
-        public function explain() {
-                $is_wordpress_awesome = true;
-                echo 'This is an explanation 
-                      about <em>wordpress</em>.';
-        }
+    /**
+     * This function is about <em>Wordpress</em>.
+     */
+    public function explain() {
+        echo 'This is an explanation
+            about <em>wordpress</em>.';
+    }
 }
         ]]>
         </code>


### PR DESCRIPTION
Note I used 'Discouraged:' in the second standard code example.
This is because it is not necesserily invalid, but I still want
to mention the opposite of the 'correct'/'valid' use.

Opinions on this?

Related to #1722