### PR TITLE
Update default minimum supported WP version

### DIFF
--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -82,7 +82,7 @@ abstract class Sniff implements PHPCS_Sniff {
 	 *
 	 * @var string WordPress version.
 	 */
-	public $minimum_supported_version = '4.9';
+	public $minimum_supported_version = '5.0';
 
 	/**
 	 * Custom list of classes which test classes can extend.

--- a/WordPress/Tests/WP/DeprecatedClassesUnitTest.inc
+++ b/WordPress/Tests/WP/DeprecatedClassesUnitTest.inc
@@ -13,10 +13,12 @@ echo \WP_User_Search::prepare_query();
 class My_User_Search extends WP_User_Search {}
 class Our_User_Search implements WP_User_Search {}
 $a = (new WP_User_Search())->query();
+/* ============ WP 4.9 ============ */
+class Prefix_Menu_section extends Customize_New_Menu_Section {}
+WP_Customize_New_Menu_Control::foo();
 
 /*
  * Warning.
  */
-class Prefix_Menu_section extends Customize_New_Menu_Section {}
-WP_Customize_New_Menu_Control::foo();
+/* ============ WP 5.3 ============ */
 $json = new Services_JSON;

--- a/WordPress/Tests/WP/DeprecatedClassesUnitTest.php
+++ b/WordPress/Tests/WP/DeprecatedClassesUnitTest.php
@@ -27,7 +27,12 @@ class DeprecatedClassesUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of errors>
 	 */
 	public function getErrorList() {
-		return array_fill( 9, 7, 1 );
+		$errors = array_fill( 9, 10, 1 );
+
+		// Unset the lines related to version comments.
+		unset( $errors[16] );
+
+		return $errors;
 	}
 
 	/**
@@ -36,7 +41,7 @@ class DeprecatedClassesUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of warnings>
 	 */
 	public function getWarningList() {
-		return array_fill( 20, 3, 1 );
+		return array_fill( 24, 1, 1 );
 	}
 
 }

--- a/WordPress/Tests/WP/DeprecatedFunctionsUnitTest.inc
+++ b/WordPress/Tests/WP/DeprecatedFunctionsUnitTest.inc
@@ -329,15 +329,15 @@ wp_get_network();
 wp_kses_js_entities();
 /* ============ WP 4.8 ============ */
 wp_dashboard_plugins_output();
-
-/*
- * Warning.
- */
 /* ============ WP 4.9 ============ */
 get_shortcut_link();
 is_user_option_local();
 wp_ajax_press_this_add_category();
 wp_ajax_press_this_save_post();
+
+/*
+ * Warning.
+ */
 /* ============ WP 5.1 ============ */
 insert_blog();
 install_blog();

--- a/WordPress/Tests/WP/DeprecatedFunctionsUnitTest.php
+++ b/WordPress/Tests/WP/DeprecatedFunctionsUnitTest.php
@@ -28,7 +28,7 @@ class DeprecatedFunctionsUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getErrorList() {
 
-		$errors = array_fill( 8, 324, 1 );
+		$errors = array_fill( 8, 329, 1 );
 
 		// Unset the lines related to version comments.
 		unset(
@@ -62,7 +62,8 @@ class DeprecatedFunctionsUnitTest extends AbstractSniffUnitTest {
 			$errors[311],
 			$errors[319],
 			$errors[323],
-			$errors[330]
+			$errors[330],
+			$errors[332]
 		);
 
 		return $errors;
@@ -75,10 +76,10 @@ class DeprecatedFunctionsUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getWarningList() {
 
-		$warnings = array_fill( 337, 11, 1 );
+		$warnings = array_fill( 342, 6, 1 );
 
 		// Unset the lines related to version comments.
-		unset( $warnings[341], $warnings[344] );
+		unset( $warnings[344] );
 
 		return $warnings;
 	}


### PR DESCRIPTION
What with the target release date for WPCS 2.2.0 being November 11 and the target release date of WP 5.3 being November 12, updating this property before the release is probably a good idea.