### PR TITLE
ControlStructureSpacing: fix undefined index error

### DIFF
--- a/WordPress/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
@@ -346,7 +346,8 @@ class ControlStructureSpacingSniff extends Sniff {
 				if ( \T_WHITESPACE !== $this->tokens[ ( $parenthesisCloser + 1 ) ]['code']
 					&& ! ( // Do NOT flag : immediately following ) for return types declarations.
 						\T_COLON === $this->tokens[ ( $parenthesisCloser + 1 ) ]['code']
-						&& in_array( $this->tokens[ $this->tokens[ $parenthesisCloser ]['parenthesis_owner'] ]['code'], array( \T_FUNCTION, \T_CLOSURE ), true )
+						&& ( isset( $this->tokens[ $parenthesisCloser ]['parenthesis_owner'] ) === false
+							|| in_array( $this->tokens[ $this->tokens[ $parenthesisCloser ]['parenthesis_owner'] ]['code'], array( \T_FUNCTION, \T_CLOSURE ), true ) )
 					)
 					&& ( isset( $scopeOpener ) && \T_COLON !== $this->tokens[ $scopeOpener ]['code'] )
 				) {

--- a/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.1.inc
+++ b/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.1.inc
@@ -290,3 +290,18 @@ $returntype = function ( string $input ): string {}; // Ok.
 $returntype = function ( string $input ) : string {}; // Ok.
 $returntype = function ( string $input, array $inputs ): string {}; // Ok.
 $returntype = function ( string $input, array $inputs ) : string {}; // Ok.
+
+// Issue 1792.
+$matching_options = array_filter(
+	$imported_options,
+	function ( $option ) use ( $option_id ): bool {
+		return $option['id'] === $option_id;
+	}
+);
+
+$matching_options = array_filter(
+	$imported_options,
+	function ( $option ) use ( $option_id ) : bool {
+		return $option['id'] === $option_id;
+	}
+);

--- a/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.1.inc.fixed
+++ b/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.1.inc.fixed
@@ -279,3 +279,18 @@ $returntype = function ( string $input ): string {}; // Ok.
 $returntype = function ( string $input ) : string {}; // Ok.
 $returntype = function ( string $input, array $inputs ): string {}; // Ok.
 $returntype = function ( string $input, array $inputs ) : string {}; // Ok.
+
+// Issue 1792.
+$matching_options = array_filter(
+	$imported_options,
+	function ( $option ) use ( $option_id ): bool {
+		return $option['id'] === $option_id;
+	}
+);
+
+$matching_options = array_filter(
+	$imported_options,
+	function ( $option ) use ( $option_id ) : bool {
+		return $option['id'] === $option_id;
+	}
+);


### PR DESCRIPTION
Closure `use` parentheses do not have a parenthesis owner.

While this is a plaster on the wound as the sniff really needs to be split up, for now, it fixes the notice.

Fixes #1792