### PR TITLE
CommaAfterArrayItem: add metrics for comma after last item

### DIFF
--- a/WordPress/Sniffs/Arrays/CommaAfterArrayItemSniff.php
+++ b/WordPress/Sniffs/Arrays/CommaAfterArrayItemSniff.php
@@ -103,6 +103,12 @@ class CommaAfterArrayItemSniff extends Sniff {
 			 */
 			if ( true === $single_line && $item_index === $array_item_count ) {
 
+				$this->phpcsFile->recordMetric(
+					$stackPtr,
+					'Single line array - comma after last item',
+					( true === $is_comma ? 'yes' : 'no' )
+				);
+
 				if ( true === $is_comma ) {
 					$fix = $this->phpcsFile->addFixableError(
 						'Comma not allowed after last value in single-line array declaration',
@@ -151,6 +157,14 @@ class CommaAfterArrayItemSniff extends Sniff {
 				if ( true === $fix ) {
 					$this->phpcsFile->fixer->addContent( $last_content, ',' );
 				}
+			}
+
+			if ( false === $single_line && $item_index === $array_item_count ) {
+				$this->phpcsFile->recordMetric(
+					$stackPtr,
+					'Multi-line array - comma after last item',
+					( true === $is_comma ? 'yes' : 'no' )
+				);
 			}
 
 			if ( false === $is_comma ) {


### PR DESCRIPTION
Add metrics to make it easier for people to decide whether or not to en/disable this rule.

The generated metrics will look like this and can be called up using `--report=info`:
```
PHP CODE SNIFFER INFORMATION REPORT
----------------------------------------------------------------------
Multi-line array - comma after last item:
	no    => 2,064 ( 95.82%)
	yes   =>    90 (  4.18%)
	-------------------------
	total => 2,154 (100.00%)

Single line array - comma after last item: 0 [804/804, 100%]
```