### PR TITLE
NoSilencedErrors: improve consistency metrics

### DIFF
--- a/WordPress/Sniffs/PHP/NoSilencedErrorsSniff.php
+++ b/WordPress/Sniffs/PHP/NoSilencedErrorsSniff.php
@@ -179,22 +179,24 @@ class NoSilencedErrorsSniff extends Sniff {
 		$this->custom_whitelist = $this->merge_custom_array( $this->custom_whitelist, array(), false );
 		$this->custom_whitelist = array_map( 'strtolower', $this->custom_whitelist );
 
-		if ( true === $this->use_default_whitelist || ! empty( $this->custom_whitelist ) ) {
-			/*
-			 * Check if the error silencing is done for one of the whitelisted functions.
-			 */
-			$next_non_empty = $this->phpcsFile->findNext( $this->empty_tokens, ( $stackPtr + 1 ), null, true, null, true );
-			if ( false !== $next_non_empty && \T_STRING === $this->tokens[ $next_non_empty ]['code'] ) {
-				$has_parenthesis = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $next_non_empty + 1 ), null, true, null, true );
-				if ( false !== $has_parenthesis && \T_OPEN_PARENTHESIS === $this->tokens[ $has_parenthesis ]['code'] ) {
-					$function_name = strtolower( $this->tokens[ $next_non_empty ]['content'] );
-					if ( ( true === $this->use_default_whitelist
-						&& isset( $this->function_whitelist[ $function_name ] ) === true )
-						|| in_array( $function_name, $this->custom_whitelist, true ) === true
-					) {
-						$this->phpcsFile->recordMetric( $stackPtr, 'Error silencing', 'whitelisted function call: ' . $function_name );
-						return;
-					}
+		/*
+		 * Check if the error silencing is done for one of the whitelisted functions.
+		 *
+		 * @internal The function call name determination is done even when there is no whitelist active
+		 * to allow the metrics to be more informative.
+		 */
+		$next_non_empty = $this->phpcsFile->findNext( $this->empty_tokens, ( $stackPtr + 1 ), null, true, null, true );
+		if ( false !== $next_non_empty && \T_STRING === $this->tokens[ $next_non_empty ]['code'] ) {
+			$has_parenthesis = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $next_non_empty + 1 ), null, true, null, true );
+			if ( false !== $has_parenthesis && \T_OPEN_PARENTHESIS === $this->tokens[ $has_parenthesis ]['code'] ) {
+				$function_name = strtolower( $this->tokens[ $next_non_empty ]['content'] );
+				if ( ( true === $this->use_default_whitelist
+					&& isset( $this->function_whitelist[ $function_name ] ) === true )
+					|| ( ! empty( $this->custom_whitelist )
+					&& in_array( $function_name, $this->custom_whitelist, true ) === true )
+				) {
+					$this->phpcsFile->recordMetric( $stackPtr, 'Error silencing', 'whitelisted function call: ' . $function_name );
+					return;
 				}
 			}
 		}
@@ -228,7 +230,7 @@ class NoSilencedErrorsSniff extends Sniff {
 		);
 
 		if ( isset( $function_name ) ) {
-			$this->phpcsFile->recordMetric( $stackPtr, 'Error silencing', $function_name );
+			$this->phpcsFile->recordMetric( $stackPtr, 'Error silencing', '@' . $function_name );
 		} else {
 			$this->phpcsFile->recordMetric( $stackPtr, 'Error silencing', $found );
 		}


### PR DESCRIPTION
The metrics for this sniff would be different depending on whether or not a (custom/default) whitelist was used.

If `use_default_whitelist` was set to `false` and no custom whitelist was passed, the metrics would look something like this:
```
Error silencing:
        @header( 'Content-Type: ' ...                 => 1 ( 12.50%)
        @header( 'Content-type: application/json' ... => 1 ( 12.50%)
        @header( 'X-Robots-Tag: noindex' ...          => 1 ( 12.50%)
        @ignore_user_abort( true ...                  => 1 ( 12.50%)
        @include_once $converter_file...              => 1 ( 12.50%)
        @ini_get( 'disable_functions' ...             => 1 ( 12.50%)
        @ini_set( $key,...                            => 1 ( 12.50%)
        @is_file( $this->...                          => 1 ( 12.50%)
        -------------------------------------------------------------
        total                                         => 8 (100.00%)
```

... while if `use_default_whitelist` was set to `true` òr a custom whitelist was passed, those same metrics would look something like this:
```
PHP CODE SNIFFER INFORMATION REPORT
----------------------------------------------------------------------
Error silencing:
        header                             => 3 ( 37.50%)
        @include_once $converter_file...   => 1 ( 12.50%)
        ignore_user_abort                  => 1 ( 12.50%)
        ini_get                            => 1 ( 12.50%)
        ini_set                            => 1 ( 12.50%)
        whitelisted function call: is_file => 1 ( 12.50%)
        --------------------------------------------------
        total                              => 8 (100.00%)

----------------------------------------------------------------------
```

The change now made will make it so:
* the grouping by function name (in case of a function call) will always happen;
* function calls will consistently be prefixed with a `@`, unless whitelisted, in which case they are prefixed with `whitelisted function call: ` (like before).

The improved metrics will look something like this:

```
PHP CODE SNIFFER INFORMATION REPORT
----------------------------------------------------------------------
Error silencing:
        @header                            => 3 ( 37.50%)
        @ignore_user_abort                 => 1 ( 12.50%)
        @include_once $converter_file...   => 1 ( 12.50%)
        @ini_get                           => 1 ( 12.50%)
        @ini_set                           => 1 ( 12.50%)
        whitelisted function call: is_file => 1 ( 12.50%)
        --------------------------------------------------
        total                              => 8 (100.00%)

----------------------------------------------------------------------
```