### PR TITLE
Travis: test against PHP 7.4, not snapshot

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,8 @@ php:
     - 7.1
     - 7.2
     - 7.3
-    - "7.4snapshot"
+    - 7.4
+    - "nightly"
 
 env:
   # `master` is now 3.x.
@@ -110,6 +111,10 @@ jobs:
       env: PHPCS_BRANCH="dev-master" LINT=1
     - php: 5.4
       env: PHPCS_BRANCH="3.3.1"
+
+  allow_failures:
+    # Allow failures for unstable builds.
+    - php: "nightly"
 
 before_install:
     # Speed up build time by disabling Xdebug.


### PR DESCRIPTION
Looks like Travis (finally) has got a "normal" PHP 7.4 image available.

While we're at it, let's add a build against `nightly` (PHP 8) back which is allowed to fail.