### PR TITLE
Fix off-by-one error when $treat_files_as_scoped is true

### DIFF
--- a/WordPress/Sniffs/WP/GlobalVariablesOverrideSniff.php
+++ b/WordPress/Sniffs/WP/GlobalVariablesOverrideSniff.php
@@ -351,7 +351,7 @@ class GlobalVariablesOverrideSniff extends Sniff {
 			$end = $this->tokens[ $scope_cond ]['scope_closer'];
 		} else {
 			// Global statement in the global namespace with file is being treated as scoped.
-			$end = ( $this->phpcsFile->numTokens + 1 );
+			$end = $this->phpcsFile->numTokens;
 		}
 
 		for ( $ptr = $start; $ptr < $end; $ptr++ ) {

--- a/WordPress/Tests/WP/GlobalVariablesOverrideUnitTest.6.inc
+++ b/WordPress/Tests/WP/GlobalVariablesOverrideUnitTest.6.inc
@@ -1,0 +1,7 @@
+<?php
+
+// phpcs:set WordPress.WP.GlobalVariablesOverride treat_files_as_scoped true
+
+global $post;
+
+// phpcs:set WordPress.WP.GlobalVariablesOverride treat_files_as_scoped false


### PR DESCRIPTION
Fixes #1847.

I would have added a unit test, but it wasn't clear how to add a new case while setting `$treat_files_as_scoped` to `true`.