### PR TITLE
I18n: Add check to detect string wrapped in HTML

### DIFF
--- a/WordPress/Sniffs/WP/I18nSniff.php
+++ b/WordPress/Sniffs/WP/I18nSniff.php
@@ -639,7 +639,7 @@ class I18nSniff extends AbstractFunctionRestrictionsSniff {
 		}
 
 		/*
-		 * NoHtmlWrappedStrings.
+		 * NoHtmlWrappedStrings and NoAHrefWrappedStrings.
 		 *
 		 * Strip surrounding quotes.
 		 */
@@ -659,7 +659,15 @@ class I18nSniff extends AbstractFunctionRestrictionsSniff {
 			}
 		}
 
-		// Is this all there is?
+		// Dedicated rule for cases where strings are wrapped in '<a href="...">...</a>'.
+		// The link target might actually need localization.
+		// Using a separate rule here allows codebases to disable it independently of the NoHtmlWrappedStrings rule.
+		if ( $reader->name === 'a' && $reader->getAttribute( 'href' ) ) {
+			$this->phpcsFile->addWarning( 'Strings should not be wrapped in <a href="...">...</a>', $stack_ptr, 'NoAHrefWrappedStrings' );
+			return;
+		}
+
+		// Does the entire string only consist of this HTML node?
 		if ( $reader->readOuterXml() === $content_without_surrounding_quotes ) {
 			$this->phpcsFile->addWarning( 'Strings should not be wrapped in HTML', $stack_ptr, 'NoHtmlWrappedStrings' );
 		}

--- a/WordPress/Sniffs/WP/I18nSniff.php
+++ b/WordPress/Sniffs/WP/I18nSniff.php
@@ -639,7 +639,7 @@ class I18nSniff extends AbstractFunctionRestrictionsSniff {
 		}
 
 		/*
-		 * NoHtmlWrappedStrings and NoAHrefWrappedStrings.
+		 * NoHtmlWrappedStrings
 		 *
 		 * Strip surrounding quotes.
 		 */
@@ -659,11 +659,8 @@ class I18nSniff extends AbstractFunctionRestrictionsSniff {
 			}
 		}
 
-		// Dedicated rule for cases where strings are wrapped in '<a href="...">...</a>'.
-		// The link target might actually need localization.
-		// Using a separate rule here allows codebases to disable it independently of the NoHtmlWrappedStrings rule.
+		// We don't flag strings wrapped in `<a href="...">...</a>`, as the link target might actually need localization.
 		if ( 'a' === $reader->name && $reader->getAttribute( 'href' ) ) {
-			$this->phpcsFile->addWarning( 'Strings should not be wrapped in <a href="...">...</a>', $stack_ptr, 'NoAHrefWrappedStrings' );
 			return;
 		}
 

--- a/WordPress/Sniffs/WP/I18nSniff.php
+++ b/WordPress/Sniffs/WP/I18nSniff.php
@@ -662,7 +662,7 @@ class I18nSniff extends AbstractFunctionRestrictionsSniff {
 		// Dedicated rule for cases where strings are wrapped in '<a href="...">...</a>'.
 		// The link target might actually need localization.
 		// Using a separate rule here allows codebases to disable it independently of the NoHtmlWrappedStrings rule.
-		if ( $reader->name === 'a' && $reader->getAttribute( 'href' ) ) {
+		if ( 'a' === $reader->name && $reader->getAttribute( 'href' ) ) {
 			$this->phpcsFile->addWarning( 'Strings should not be wrapped in <a href="...">...</a>', $stack_ptr, 'NoAHrefWrappedStrings' );
 			return;
 		}

--- a/WordPress/Sniffs/WP/I18nSniff.php
+++ b/WordPress/Sniffs/WP/I18nSniff.php
@@ -630,11 +630,38 @@ class I18nSniff extends AbstractFunctionRestrictionsSniff {
 		 *
 		 * Strip placeholders and surrounding quotes.
 		 */
-		$non_placeholder_content = trim( $this->strip_quotes( $content ) );
-		$non_placeholder_content = preg_replace( self::SPRINTF_PLACEHOLDER_REGEX, '', $non_placeholder_content );
+		$content_without_surrounding_quotes = trim( $this->strip_quotes( $content ) );
+		$non_placeholder_content = preg_replace( self::SPRINTF_PLACEHOLDER_REGEX, '', $content_without_surrounding_quotes );
 
 		if ( '' === $non_placeholder_content ) {
 			$this->phpcsFile->addError( 'Strings should have translatable content', $stack_ptr, 'NoEmptyStrings' );
+			return;
+		}
+
+		/*
+		 * NoHtmlWrappedStrings.
+		 *
+		 * Strip surrounding quotes.
+		 */
+		$reader = new \XMLReader();
+		$reader->XML( $content_without_surrounding_quotes, 'UTF-8', LIBXML_NOERROR | LIBXML_ERR_NONE | LIBXML_NOWARNING );
+
+		// Is the first node an HTML element?
+		if ( ! $reader->read() || \XMLReader::ELEMENT !== $reader->nodeType ) {
+			return;
+		}
+
+		// If the opening HTML element includes placeholders in its attributes, we don't warn.
+		// E.g. '<option id="%1$s" value="%2$s">Translatable option name</option>'.
+		for ( $i = 0; $attr = $reader->getAttributeNo( $i ); $i++ ) {
+			if ( preg_match( self::SPRINTF_PLACEHOLDER_REGEX, $attr ) ) {
+				return;
+			}
+		}
+
+		// Is this all there is?
+		if ( $reader->readOuterXml() === $content_without_surrounding_quotes ) {
+			$this->phpcsFile->addWarning( 'Strings should not be wrapped in HTML', $stack_ptr, 'NoHtmlWrappedStrings' );
 		}
 	}
 

--- a/WordPress/Tests/WP/I18nUnitTest.1.inc
+++ b/WordPress/Tests/WP/I18nUnitTest.1.inc
@@ -206,9 +206,10 @@ __( '<<>>123</<>', 'my-slug' );
 
 // Strings wrapped in '<a href="...">...</a>'. These get a different warning, as the link target might actually be localized.
 // phpcs:disable WordPress.WP.I18n.NoHtmlWrappedStrings
-__( '<a href="http://wordpress.org">WordPress</a>', 'my-slug' ); // Bad, strings shouldn't be wrapped in <a href="...">...</a>
-__( '<a id="anchor">translatable text</a>', 'my-slug' ) // Good, since we have disabled the NoHtmlWrappedStrings rule here
-__( '<a>translatable text</a>', 'my-slug' ) // Good, since we have disabled the NoHtmlWrappedStrings rule here
+__( '<a href="http://wordpress.org">WordPress</a>', 'my-slug' ); // Bad, strings shouldn't be wrapped in <a href="...">...</a>.
+__( '<a id="anchor">translatable text</a>', 'my-slug' ) // Good, since we have disabled the NoHtmlWrappedStrings rule here.
+__( '<a>translatable text</a>', 'my-slug' ) // Good, since we have disabled the NoHtmlWrappedStrings rule here.
+__( '<a href="%s">translatable text</a>', 'my-slug' ) // Good, contains a placeholder in the href attribute.
 // phpcs:enable WordPress.WP.I18n.NoHtmlWrappedStrings
 
 // phpcs:set WordPress.WP.I18n text_domain[]

--- a/WordPress/Tests/WP/I18nUnitTest.1.inc
+++ b/WordPress/Tests/WP/I18nUnitTest.1.inc
@@ -196,6 +196,7 @@ __( '<div>text to translate', 'my-slug' );
 __( 'text to <div>translate', 'my-slug' );
 __( 'text < to translate', 'my-slug' );
 __( 'text to > translate', 'my-slug' );
+__( '<div data-type=">foo">my address</div>', 'my-slug' );
 
 // phpcs:set WordPress.WP.I18n text_domain[]
 // phpcs:set WordPress.WP.I18n check_translator_comments true

--- a/WordPress/Tests/WP/I18nUnitTest.1.inc
+++ b/WordPress/Tests/WP/I18nUnitTest.1.inc
@@ -195,9 +195,9 @@ __( '<foo>Foo</foo>', 'my-slug' ); // Good
 
 // Strings wrapped in `<a href="...">...</a>` aren't flagged, since the link target might require localization.
 __( '<a href="http://wordpress.org">WordPress</a>', 'my-slug' ); // Good
-__( '<a id="anchor">translatable text</a>', 'my-slug' ) // Bad, since no href.
-__( '<a>translatable text</a>', 'my-slug' ) // Bad, since no href.
-__( '<a href="%s">translatable text</a>', 'my-slug' ) // Good, contains a placeholder in the href attribute.
+__( '<a id="anchor">translatable text</a>', 'my-slug' ) // Bad, since no href
+__( '<a>translatable text</a>', 'my-slug' ) // Bad, since no href
+__( '<a href="%s">translatable text</a>', 'my-slug' ) // Good
 
 // Strings containing malformed XML, to make sure we're able to parse them. No warnings should be thrown.
 __( '<div>text to translate', 'my-slug' );

--- a/WordPress/Tests/WP/I18nUnitTest.1.inc
+++ b/WordPress/Tests/WP/I18nUnitTest.1.inc
@@ -191,5 +191,11 @@ __( '<span>Text</span> More text <span>Text</span>', 'my-slug' ); // Good, we're
 __( '<div class="my-class">Translatable content</div>', 'my-slug' ); // Bad
 __( '<option id="%1$s" value="%2$s">Translatable option name</option>', 'my-slug' ); // Wrapping is okay, since there are placeholders
 
+// Strings containing malformed XML, to make sure we're able to parse them. No warnings should be thrown.
+__( '<div>text to translate', 'my-slug' );
+__( 'text to <div>translate', 'my-slug' );
+__( 'text < to translate', 'my-slug' );
+__( 'text to > translate', 'my-slug' );
+
 // phpcs:set WordPress.WP.I18n text_domain[]
 // phpcs:set WordPress.WP.I18n check_translator_comments true

--- a/WordPress/Tests/WP/I18nUnitTest.1.inc
+++ b/WordPress/Tests/WP/I18nUnitTest.1.inc
@@ -204,5 +204,12 @@ __( '<div><div>', 'my-slug' );
 __( '<<>>text to translate<<>', 'my-slug' );
 __( '<<>>123</<>', 'my-slug' );
 
+// Strings wrapped in '<a href="...">...</a>'. These get a different warning, as the link target might actually be localized.
+// phpcs:disable WordPress.WP.I18n.NoHtmlWrappedStrings
+__( '<a href="http://wordpress.org">WordPress</a>', 'my-slug' ); // Bad, strings shouldn't be wrapped in <a href="...">...</a>
+__( '<a id="anchor">translatable text</a>', 'my-slug' ) // Good, since we have disabled the NoHtmlWrappedStrings rule here
+__( '<a>translatable text</a>', 'my-slug' ) // Good, since we have disabled the NoHtmlWrappedStrings rule here
+// phpcs:enable WordPress.WP.I18n.NoHtmlWrappedStrings
+
 // phpcs:set WordPress.WP.I18n text_domain[]
 // phpcs:set WordPress.WP.I18n check_translator_comments true

--- a/WordPress/Tests/WP/I18nUnitTest.1.inc
+++ b/WordPress/Tests/WP/I18nUnitTest.1.inc
@@ -209,13 +209,11 @@ __( '<b><i>Foo</b></i>', 'my-slug' );
 __( '<b><i>Foo</b></i></b>', 'my-slug' );
 __( '<foo>Foo</bar>', 'my-slug' );
 
-// Strings wrapped in '<a href="...">...</a>'. These get a different warning, as the link target might actually be localized.
-// phpcs:disable WordPress.WP.I18n.NoHtmlWrappedStrings
-__( '<a href="http://wordpress.org">WordPress</a>', 'my-slug' ); // Bad, strings shouldn't be wrapped in <a href="...">...</a>.
-__( '<a id="anchor">translatable text</a>', 'my-slug' ) // Good, since we have disabled the NoHtmlWrappedStrings rule here.
-__( '<a>translatable text</a>', 'my-slug' ) // Good, since we have disabled the NoHtmlWrappedStrings rule here.
+// Strings wrapped in `<a href="...">...</a>` aren't flagged, since the link target might require localization.
+__( '<a href="http://wordpress.org">WordPress</a>', 'my-slug' ); // Good
+__( '<a id="anchor">translatable text</a>', 'my-slug' ) // Bad, since no href.
+__( '<a>translatable text</a>', 'my-slug' ) // Bad, since no href.
 __( '<a href="%s">translatable text</a>', 'my-slug' ) // Good, contains a placeholder in the href attribute.
-// phpcs:enable WordPress.WP.I18n.NoHtmlWrappedStrings
 
 // phpcs:set WordPress.WP.I18n text_domain[]
 // phpcs:set WordPress.WP.I18n check_translator_comments true

--- a/WordPress/Tests/WP/I18nUnitTest.1.inc
+++ b/WordPress/Tests/WP/I18nUnitTest.1.inc
@@ -197,6 +197,12 @@ __( 'text to <div>translate', 'my-slug' );
 __( 'text < to translate', 'my-slug' );
 __( 'text to > translate', 'my-slug' );
 __( '<div data-type=">foo">my address</div>', 'my-slug' );
+__( '<div>text to translate<div>', 'my-slug' );
+__( '<>text to translate</>', 'my-slug' );
+__( '<>text to translate<>', 'my-slug' );
+__( '<div><div>', 'my-slug' );
+__( '<<>>text to translate<<>', 'my-slug' );
+__( '<<>>123</<>', 'my-slug' );
 
 // phpcs:set WordPress.WP.I18n text_domain[]
 // phpcs:set WordPress.WP.I18n check_translator_comments true

--- a/WordPress/Tests/WP/I18nUnitTest.1.inc
+++ b/WordPress/Tests/WP/I18nUnitTest.1.inc
@@ -183,5 +183,13 @@ _n_noop($singular); // Bad x 3.
 // This test is needed to verify that the missing plural argument above does not cause an internal error, stopping the run.
 _n_noop( 'I have %d cat.', 'I have %d cats.' ); // Bad.
 
+// HTML wrapped strings.
+__( '<address>123 Fake Street</address>', 'my-slug' ); // Bad, string shouldn't be wrapped in HTML.
+__( 'I live at <address>123 Fake Street</address>', 'my-slug' ); // Okay, no consensus on HTML tags within strings.
+__( '<address>123 Fake Street</address> is my home', 'my-slug' ); // Okay, no consensus on HTML tags within strings.
+__( '<span>Text</span> More text <span>Text</span>', 'my-slug' ); // Good, we're not wrapping
+__( '<div class="my-class">Translatable content</div>', 'my-slug' ); // Bad
+__( '<option id="%1$s" value="%2$s">Translatable option name</option>', 'my-slug' ); // Wrapping is okay, since there are placeholders
+
 // phpcs:set WordPress.WP.I18n text_domain[]
 // phpcs:set WordPress.WP.I18n check_translator_comments true

--- a/WordPress/Tests/WP/I18nUnitTest.1.inc
+++ b/WordPress/Tests/WP/I18nUnitTest.1.inc
@@ -190,6 +190,8 @@ __( '<address>123 Fake Street</address> is my home', 'my-slug' ); // Okay, no co
 __( '<span>Text</span> More text <span>Text</span>', 'my-slug' ); // Good, we're not wrapping
 __( '<div class="my-class">Translatable content</div>', 'my-slug' ); // Bad
 __( '<option id="%1$s" value="%2$s">Translatable option name</option>', 'my-slug' ); // Wrapping is okay, since there are placeholders
+__( '<b><i>Foo</i></b>', 'my-slug' ); // Bad
+__( '<foo>Foo</foo>', 'my-slug' ); // Good
 
 // Strings containing malformed XML, to make sure we're able to parse them. No warnings should be thrown.
 __( '<div>text to translate', 'my-slug' );
@@ -203,6 +205,9 @@ __( '<>text to translate<>', 'my-slug' );
 __( '<div><div>', 'my-slug' );
 __( '<<>>text to translate<<>', 'my-slug' );
 __( '<<>>123</<>', 'my-slug' );
+__( '<b><i>Foo</b></i>', 'my-slug' );
+__( '<b><i>Foo</b></i></b>', 'my-slug' );
+__( '<foo>Foo</bar>', 'my-slug' );
 
 // Strings wrapped in '<a href="...">...</a>'. These get a different warning, as the link target might actually be localized.
 // phpcs:disable WordPress.WP.I18n.NoHtmlWrappedStrings

--- a/WordPress/Tests/WP/I18nUnitTest.1.inc
+++ b/WordPress/Tests/WP/I18nUnitTest.1.inc
@@ -193,6 +193,12 @@ __( '<option id="%1$s" value="%2$s">Translatable option name</option>', 'my-slug
 __( '<b><i>Foo</i></b>', 'my-slug' ); // Bad
 __( '<foo>Foo</foo>', 'my-slug' ); // Good
 
+// Strings wrapped in `<a href="...">...</a>` aren't flagged, since the link target might require localization.
+__( '<a href="http://wordpress.org">WordPress</a>', 'my-slug' ); // Good
+__( '<a id="anchor">translatable text</a>', 'my-slug' ) // Bad, since no href.
+__( '<a>translatable text</a>', 'my-slug' ) // Bad, since no href.
+__( '<a href="%s">translatable text</a>', 'my-slug' ) // Good, contains a placeholder in the href attribute.
+
 // Strings containing malformed XML, to make sure we're able to parse them. No warnings should be thrown.
 __( '<div>text to translate', 'my-slug' );
 __( 'text to <div>translate', 'my-slug' );
@@ -208,12 +214,6 @@ __( '<<>>123</<>', 'my-slug' );
 __( '<b><i>Foo</b></i>', 'my-slug' );
 __( '<b><i>Foo</b></i></b>', 'my-slug' );
 __( '<foo>Foo</bar>', 'my-slug' );
-
-// Strings wrapped in `<a href="...">...</a>` aren't flagged, since the link target might require localization.
-__( '<a href="http://wordpress.org">WordPress</a>', 'my-slug' ); // Good
-__( '<a id="anchor">translatable text</a>', 'my-slug' ) // Bad, since no href.
-__( '<a>translatable text</a>', 'my-slug' ) // Bad, since no href.
-__( '<a href="%s">translatable text</a>', 'my-slug' ) // Good, contains a placeholder in the href attribute.
 
 // phpcs:set WordPress.WP.I18n text_domain[]
 // phpcs:set WordPress.WP.I18n check_translator_comments true

--- a/WordPress/Tests/WP/I18nUnitTest.1.inc.fixed
+++ b/WordPress/Tests/WP/I18nUnitTest.1.inc.fixed
@@ -206,9 +206,10 @@ __( '<<>>123</<>', 'my-slug' );
 
 // Strings wrapped in '<a href="...">...</a>'. These get a different warning, as the link target might actually be localized.
 // phpcs:disable WordPress.WP.I18n.NoHtmlWrappedStrings
-__( '<a href="http://wordpress.org">WordPress</a>', 'my-slug' ); // Bad, strings shouldn't be wrapped in <a href="...">...</a>
-__( '<a id="anchor">translatable text</a>', 'my-slug' ) // Good, since we have disabled the NoHtmlWrappedStrings rule here
-__( '<a>translatable text</a>', 'my-slug' ) // Good, since we have disabled the NoHtmlWrappedStrings rule here
+__( '<a href="http://wordpress.org">WordPress</a>', 'my-slug' ); // Bad, strings shouldn't be wrapped in <a href="...">...</a>.
+__( '<a id="anchor">translatable text</a>', 'my-slug' ) // Good, since we have disabled the NoHtmlWrappedStrings rule here.
+__( '<a>translatable text</a>', 'my-slug' ) // Good, since we have disabled the NoHtmlWrappedStrings rule here.
+__( '<a href="%s">translatable text</a>', 'my-slug' ) // Good, contains a placeholder in the href attribute.
 // phpcs:enable WordPress.WP.I18n.NoHtmlWrappedStrings
 
 // phpcs:set WordPress.WP.I18n text_domain[]

--- a/WordPress/Tests/WP/I18nUnitTest.1.inc.fixed
+++ b/WordPress/Tests/WP/I18nUnitTest.1.inc.fixed
@@ -196,6 +196,7 @@ __( '<div>text to translate', 'my-slug' );
 __( 'text to <div>translate', 'my-slug' );
 __( 'text < to translate', 'my-slug' );
 __( 'text to > translate', 'my-slug' );
+__( '<div data-type=">foo">my address</div>', 'my-slug' );
 
 // phpcs:set WordPress.WP.I18n text_domain[]
 // phpcs:set WordPress.WP.I18n check_translator_comments true

--- a/WordPress/Tests/WP/I18nUnitTest.1.inc.fixed
+++ b/WordPress/Tests/WP/I18nUnitTest.1.inc.fixed
@@ -195,9 +195,9 @@ __( '<foo>Foo</foo>', 'my-slug' ); // Good
 
 // Strings wrapped in `<a href="...">...</a>` aren't flagged, since the link target might require localization.
 __( '<a href="http://wordpress.org">WordPress</a>', 'my-slug' ); // Good
-__( '<a id="anchor">translatable text</a>', 'my-slug' ) // Bad, since no href.
-__( '<a>translatable text</a>', 'my-slug' ) // Bad, since no href.
-__( '<a href="%s">translatable text</a>', 'my-slug' ) // Good, contains a placeholder in the href attribute.
+__( '<a id="anchor">translatable text</a>', 'my-slug' ) // Bad, since no href
+__( '<a>translatable text</a>', 'my-slug' ) // Bad, since no href
+__( '<a href="%s">translatable text</a>', 'my-slug' ) // Good
 
 // Strings containing malformed XML, to make sure we're able to parse them. No warnings should be thrown.
 __( '<div>text to translate', 'my-slug' );

--- a/WordPress/Tests/WP/I18nUnitTest.1.inc.fixed
+++ b/WordPress/Tests/WP/I18nUnitTest.1.inc.fixed
@@ -191,5 +191,11 @@ __( '<span>Text</span> More text <span>Text</span>', 'my-slug' ); // Good, we're
 __( '<div class="my-class">Translatable content</div>', 'my-slug' ); // Bad
 __( '<option id="%1$s" value="%2$s">Translatable option name</option>', 'my-slug' ); // Wrapping is okay, since there are placeholders
 
+// Strings containing malformed XML, to make sure we're able to parse them. No warnings should be thrown.
+__( '<div>text to translate', 'my-slug' );
+__( 'text to <div>translate', 'my-slug' );
+__( 'text < to translate', 'my-slug' );
+__( 'text to > translate', 'my-slug' );
+
 // phpcs:set WordPress.WP.I18n text_domain[]
 // phpcs:set WordPress.WP.I18n check_translator_comments true

--- a/WordPress/Tests/WP/I18nUnitTest.1.inc.fixed
+++ b/WordPress/Tests/WP/I18nUnitTest.1.inc.fixed
@@ -204,5 +204,12 @@ __( '<div><div>', 'my-slug' );
 __( '<<>>text to translate<<>', 'my-slug' );
 __( '<<>>123</<>', 'my-slug' );
 
+// Strings wrapped in '<a href="...">...</a>'. These get a different warning, as the link target might actually be localized.
+// phpcs:disable WordPress.WP.I18n.NoHtmlWrappedStrings
+__( '<a href="http://wordpress.org">WordPress</a>', 'my-slug' ); // Bad, strings shouldn't be wrapped in <a href="...">...</a>
+__( '<a id="anchor">translatable text</a>', 'my-slug' ) // Good, since we have disabled the NoHtmlWrappedStrings rule here
+__( '<a>translatable text</a>', 'my-slug' ) // Good, since we have disabled the NoHtmlWrappedStrings rule here
+// phpcs:enable WordPress.WP.I18n.NoHtmlWrappedStrings
+
 // phpcs:set WordPress.WP.I18n text_domain[]
 // phpcs:set WordPress.WP.I18n check_translator_comments true

--- a/WordPress/Tests/WP/I18nUnitTest.1.inc.fixed
+++ b/WordPress/Tests/WP/I18nUnitTest.1.inc.fixed
@@ -209,13 +209,11 @@ __( '<b><i>Foo</b></i>', 'my-slug' );
 __( '<b><i>Foo</b></i></b>', 'my-slug' );
 __( '<foo>Foo</bar>', 'my-slug' );
 
-// Strings wrapped in '<a href="...">...</a>'. These get a different warning, as the link target might actually be localized.
-// phpcs:disable WordPress.WP.I18n.NoHtmlWrappedStrings
-__( '<a href="http://wordpress.org">WordPress</a>', 'my-slug' ); // Bad, strings shouldn't be wrapped in <a href="...">...</a>.
-__( '<a id="anchor">translatable text</a>', 'my-slug' ) // Good, since we have disabled the NoHtmlWrappedStrings rule here.
-__( '<a>translatable text</a>', 'my-slug' ) // Good, since we have disabled the NoHtmlWrappedStrings rule here.
+// Strings wrapped in `<a href="...">...</a>` aren't flagged, since the link target might require localization.
+__( '<a href="http://wordpress.org">WordPress</a>', 'my-slug' ); // Good
+__( '<a id="anchor">translatable text</a>', 'my-slug' ) // Bad, since no href.
+__( '<a>translatable text</a>', 'my-slug' ) // Bad, since no href.
 __( '<a href="%s">translatable text</a>', 'my-slug' ) // Good, contains a placeholder in the href attribute.
-// phpcs:enable WordPress.WP.I18n.NoHtmlWrappedStrings
 
 // phpcs:set WordPress.WP.I18n text_domain[]
 // phpcs:set WordPress.WP.I18n check_translator_comments true

--- a/WordPress/Tests/WP/I18nUnitTest.1.inc.fixed
+++ b/WordPress/Tests/WP/I18nUnitTest.1.inc.fixed
@@ -197,6 +197,12 @@ __( 'text to <div>translate', 'my-slug' );
 __( 'text < to translate', 'my-slug' );
 __( 'text to > translate', 'my-slug' );
 __( '<div data-type=">foo">my address</div>', 'my-slug' );
+__( '<div>text to translate<div>', 'my-slug' );
+__( '<>text to translate</>', 'my-slug' );
+__( '<>text to translate<>', 'my-slug' );
+__( '<div><div>', 'my-slug' );
+__( '<<>>text to translate<<>', 'my-slug' );
+__( '<<>>123</<>', 'my-slug' );
 
 // phpcs:set WordPress.WP.I18n text_domain[]
 // phpcs:set WordPress.WP.I18n check_translator_comments true

--- a/WordPress/Tests/WP/I18nUnitTest.1.inc.fixed
+++ b/WordPress/Tests/WP/I18nUnitTest.1.inc.fixed
@@ -183,5 +183,13 @@ _n_noop($singular); // Bad x 3.
 // This test is needed to verify that the missing plural argument above does not cause an internal error, stopping the run.
 _n_noop( 'I have %d cat.', 'I have %d cats.' ); // Bad.
 
+// HTML wrapped strings.
+__( '<address>123 Fake Street</address>', 'my-slug' ); // Bad, string shouldn't be wrapped in HTML.
+__( 'I live at <address>123 Fake Street</address>', 'my-slug' ); // Okay, no consensus on HTML tags within strings.
+__( '<address>123 Fake Street</address> is my home', 'my-slug' ); // Okay, no consensus on HTML tags within strings.
+__( '<span>Text</span> More text <span>Text</span>', 'my-slug' ); // Good, we're not wrapping
+__( '<div class="my-class">Translatable content</div>', 'my-slug' ); // Bad
+__( '<option id="%1$s" value="%2$s">Translatable option name</option>', 'my-slug' ); // Wrapping is okay, since there are placeholders
+
 // phpcs:set WordPress.WP.I18n text_domain[]
 // phpcs:set WordPress.WP.I18n check_translator_comments true

--- a/WordPress/Tests/WP/I18nUnitTest.1.inc.fixed
+++ b/WordPress/Tests/WP/I18nUnitTest.1.inc.fixed
@@ -190,6 +190,8 @@ __( '<address>123 Fake Street</address> is my home', 'my-slug' ); // Okay, no co
 __( '<span>Text</span> More text <span>Text</span>', 'my-slug' ); // Good, we're not wrapping
 __( '<div class="my-class">Translatable content</div>', 'my-slug' ); // Bad
 __( '<option id="%1$s" value="%2$s">Translatable option name</option>', 'my-slug' ); // Wrapping is okay, since there are placeholders
+__( '<b><i>Foo</i></b>', 'my-slug' ); // Bad
+__( '<foo>Foo</foo>', 'my-slug' ); // Good
 
 // Strings containing malformed XML, to make sure we're able to parse them. No warnings should be thrown.
 __( '<div>text to translate', 'my-slug' );
@@ -203,6 +205,9 @@ __( '<>text to translate<>', 'my-slug' );
 __( '<div><div>', 'my-slug' );
 __( '<<>>text to translate<<>', 'my-slug' );
 __( '<<>>123</<>', 'my-slug' );
+__( '<b><i>Foo</b></i>', 'my-slug' );
+__( '<b><i>Foo</b></i></b>', 'my-slug' );
+__( '<foo>Foo</bar>', 'my-slug' );
 
 // Strings wrapped in '<a href="...">...</a>'. These get a different warning, as the link target might actually be localized.
 // phpcs:disable WordPress.WP.I18n.NoHtmlWrappedStrings

--- a/WordPress/Tests/WP/I18nUnitTest.1.inc.fixed
+++ b/WordPress/Tests/WP/I18nUnitTest.1.inc.fixed
@@ -193,6 +193,12 @@ __( '<option id="%1$s" value="%2$s">Translatable option name</option>', 'my-slug
 __( '<b><i>Foo</i></b>', 'my-slug' ); // Bad
 __( '<foo>Foo</foo>', 'my-slug' ); // Good
 
+// Strings wrapped in `<a href="...">...</a>` aren't flagged, since the link target might require localization.
+__( '<a href="http://wordpress.org">WordPress</a>', 'my-slug' ); // Good
+__( '<a id="anchor">translatable text</a>', 'my-slug' ) // Bad, since no href.
+__( '<a>translatable text</a>', 'my-slug' ) // Bad, since no href.
+__( '<a href="%s">translatable text</a>', 'my-slug' ) // Good, contains a placeholder in the href attribute.
+
 // Strings containing malformed XML, to make sure we're able to parse them. No warnings should be thrown.
 __( '<div>text to translate', 'my-slug' );
 __( 'text to <div>translate', 'my-slug' );
@@ -208,12 +214,6 @@ __( '<<>>123</<>', 'my-slug' );
 __( '<b><i>Foo</b></i>', 'my-slug' );
 __( '<b><i>Foo</b></i></b>', 'my-slug' );
 __( '<foo>Foo</bar>', 'my-slug' );
-
-// Strings wrapped in `<a href="...">...</a>` aren't flagged, since the link target might require localization.
-__( '<a href="http://wordpress.org">WordPress</a>', 'my-slug' ); // Good
-__( '<a id="anchor">translatable text</a>', 'my-slug' ) // Bad, since no href.
-__( '<a>translatable text</a>', 'my-slug' ) // Bad, since no href.
-__( '<a href="%s">translatable text</a>', 'my-slug' ) // Good, contains a placeholder in the href attribute.
 
 // phpcs:set WordPress.WP.I18n text_domain[]
 // phpcs:set WordPress.WP.I18n check_translator_comments true

--- a/WordPress/Tests/WP/I18nUnitTest.php
+++ b/WordPress/Tests/WP/I18nUnitTest.php
@@ -166,7 +166,9 @@ class I18nUnitTest extends AbstractSniffUnitTest {
 					159 => 1,
 					187 => 1,
 					191 => 1,
-					209 => 1,
+					193 => 1,
+					194 => 1,
+					214 => 1,
 				);
 
 			case 'I18nUnitTest.2.inc':

--- a/WordPress/Tests/WP/I18nUnitTest.php
+++ b/WordPress/Tests/WP/I18nUnitTest.php
@@ -168,8 +168,8 @@ class I18nUnitTest extends AbstractSniffUnitTest {
 					191 => 1,
 					193 => 1,
 					194 => 1,
-					214 => 1,
-					215 => 1,
+					198 => 1,
+					199 => 1,
 				);
 
 			case 'I18nUnitTest.2.inc':

--- a/WordPress/Tests/WP/I18nUnitTest.php
+++ b/WordPress/Tests/WP/I18nUnitTest.php
@@ -33,6 +33,9 @@ class I18nUnitTest extends AbstractSniffUnitTest {
 		// Test overruling the text domain from the command line for one test file.
 		if ( 'I18nUnitTest.3.inc' === $testFile ) {
 			$config->setConfigData( 'text_domain', 'something', true );
+		} else {
+			// Delete the text domain option so it doesn't persist for subsequent test files.
+			$config->setConfigData( 'text_domain', null, true );
 		}
 	}
 
@@ -161,6 +164,8 @@ class I18nUnitTest extends AbstractSniffUnitTest {
 					154 => 1,
 					158 => 1,
 					159 => 1,
+					187 => 1,
+					191 => 1,
 				);
 
 			case 'I18nUnitTest.2.inc':

--- a/WordPress/Tests/WP/I18nUnitTest.php
+++ b/WordPress/Tests/WP/I18nUnitTest.php
@@ -166,6 +166,7 @@ class I18nUnitTest extends AbstractSniffUnitTest {
 					159 => 1,
 					187 => 1,
 					191 => 1,
+					209 => 1,
 				);
 
 			case 'I18nUnitTest.2.inc':

--- a/WordPress/Tests/WP/I18nUnitTest.php
+++ b/WordPress/Tests/WP/I18nUnitTest.php
@@ -169,6 +169,7 @@ class I18nUnitTest extends AbstractSniffUnitTest {
 					193 => 1,
 					194 => 1,
 					214 => 1,
+					215 => 1,
 				);
 
 			case 'I18nUnitTest.2.inc':


### PR DESCRIPTION
Fixes the non-controversial part of #1419 by adding a sniff that detects translated strings wrapped in HTML tags, and a corresponding unit test. Quoting https://github.com/WordPress/WordPress-Coding-Standards/issues/1419#issuecomment-403797241:

> Examples where the markup _should_ be removed from inside of the string would be:
>
> ```
> <?php __( '<h1>Settings Page</h1>', 'text-domain ); ?>
> should be
> <h1><?php __( 'Settings Page', 'text-domain' ); ?></h1>
> because the markup only wraps the string.
> ```

Note that I had to add code to `I18nUnitTest.php` to reset the text domain as set via `setConfigData()` for one test file, as it would otherwise persist for every test file after that one.

Based on a WordPress.com-internal check. /cc @akirk