### PR TITLE
I18n: bug fix - trying to access array offset on null (PHP 7.4)

### DIFF
--- a/WordPress/Sniffs/WP/I18nSniff.php
+++ b/WordPress/Sniffs/WP/I18nSniff.php
@@ -390,8 +390,16 @@ class I18nSniff extends AbstractFunctionRestrictionsSniff {
 			$this->check_argument_tokens( $argument_assertion_context );
 		}
 
-		// For _n*() calls, compare the singular and plural strings.
-		if ( false !== strpos( $this->i18n_functions[ $matched_content ], 'number' ) ) {
+		/*
+		 * For _n*() calls, compare the singular and plural strings.
+		 * If either of the arguments is missing, empty or has more than 1 token, skip out.
+		 * An error for that will already have been reported via the `check_argument_tokens()` method.
+		 */
+		if ( false !== strpos( $this->i18n_functions[ $matched_content ], 'number' )
+			&& isset( $argument_assertions[0]['tokens'], $argument_assertions[1]['tokens'] )
+			&& count( $argument_assertions[0]['tokens'] ) === 1
+			&& count( $argument_assertions[1]['tokens'] ) === 1
+		) {
 			$single_context = $argument_assertions[0];
 			$plural_context = $argument_assertions[1];
 

--- a/WordPress/Tests/WP/I18nUnitTest.1.inc
+++ b/WordPress/Tests/WP/I18nUnitTest.1.inc
@@ -177,5 +177,11 @@ $offset_or_tz = _x( '0', 'default GMT offset or timezone string', 'my-slug' );
 $test = __( '%1$s %2$s', 'my-slug' ); // OK(ish), placeholder order may change depending on language.
 $test = __( '   %s    ', 'my-slug' ); // Bad, no translatable content.
 
+// Missing plural argument.
+_n_noop($singular); // Bad x 3.
+
+// This test is needed to verify that the missing plural argument above does not cause an internal error, stopping the run.
+_n_noop( 'I have %d cat.', 'I have %d cats.' ); // Bad.
+
 // phpcs:set WordPress.WP.I18n text_domain[]
 // phpcs:set WordPress.WP.I18n check_translator_comments true

--- a/WordPress/Tests/WP/I18nUnitTest.1.inc.fixed
+++ b/WordPress/Tests/WP/I18nUnitTest.1.inc.fixed
@@ -177,5 +177,11 @@ $offset_or_tz = _x( '0', 'default GMT offset or timezone string', 'my-slug' );
 $test = __( '%1$s %2$s', 'my-slug' ); // OK(ish), placeholder order may change depending on language.
 $test = __( '   %s    ', 'my-slug' ); // Bad, no translatable content.
 
+// Missing plural argument.
+_n_noop($singular); // Bad x 3.
+
+// This test is needed to verify that the missing plural argument above does not cause an internal error, stopping the run.
+_n_noop( 'I have %d cat.', 'I have %d cats.' ); // Bad.
+
 // phpcs:set WordPress.WP.I18n text_domain[]
 // phpcs:set WordPress.WP.I18n check_translator_comments true

--- a/WordPress/Tests/WP/I18nUnitTest.php
+++ b/WordPress/Tests/WP/I18nUnitTest.php
@@ -114,6 +114,8 @@ class I18nUnitTest extends AbstractSniffUnitTest {
 					153 => 1,
 					157 => 1,
 					178 => 1,
+					181 => 3,
+					184 => 1,
 				);
 
 			case 'I18nUnitTest.2.inc':


### PR DESCRIPTION
When a function call to one of the singular/plural text translation functions - like `_n_noop()` - is missing an argument, the sniff would still try an execute the `compare_single_and_plural_arguments()` check and on PHP 7.4 would generate a "_Trying to access array offset on value of type null_" error which would stop the PHPCS run dead with an `Internal.Exception` error code.

Fixed by skipping the check in that case. The missing argument should be reported by the preceding `check_argument_tokens()` check anyhow.

Includes unit test.

**Note: I've set this PR to priority high as this bug stops the PHPCS run dead on PHP 7.4, so this fix should be included in the upcoming WPCS 2.2.1 release.**