### PR TITLE
Move the `include`/`require` parenthesis rules

### DIFF
--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -98,6 +98,16 @@
 	<!-- Covers rule: Braces should always be used, even when they are not required. -->
 	<rule ref="Generic.ControlStructures.InlineControlStructure"/>
 
+	<!-- Covers rule: parenthesis should not be used when using include, include_once, require, require_once. -->
+	<rule ref="PEAR.Files.IncludingFile.BracketsNotRequired">
+		<type>warning</type>
+	</rule>
+	<rule ref="PEAR.Files.IncludingFile.UseRequire">
+		<type>warning</type>
+	</rule>
+	<rule ref="PEAR.Files.IncludingFile.UseRequireOnce">
+		<type>warning</type>
+	</rule>
 
 	<!--
 	#############################################################################
@@ -235,6 +245,10 @@
 		<severity>0</severity>
 	</rule>
 
+	<!-- Check correct spacing of language constructs. This also ensures that the
+	     above rule for not using brackets with require is fixed correctly.
+		 https://github.com/WordPress/WordPress-Coding-Standards/issues/1153 -->
+	<rule ref="Squiz.WhiteSpace.LanguageConstructSpacing"/>
 
 	<!-- Covers rule: Call a function, like so: my_function( $param1, func_param( $param2 ) ); -->
 	<rule ref="PEAR.Functions.FunctionCallSignature">

--- a/WordPress-Extra/ruleset.xml
+++ b/WordPress-Extra/ruleset.xml
@@ -35,23 +35,6 @@
 		 https://github.com/WordPress/WordPress-Coding-Standards/pull/809 -->
 	<rule ref="Squiz.PHP.DisallowSizeFunctionsInLoops"/>
 
-	<!-- And yet more best practices.
-		 https://github.com/WordPress/WordPress-Coding-Standards/issues/1143 -->
-	<rule ref="PEAR.Files.IncludingFile.BracketsNotRequired">
-		<type>warning</type>
-	</rule>
-	<rule ref="PEAR.Files.IncludingFile.UseRequire">
-		<type>warning</type>
-	</rule>
-	<rule ref="PEAR.Files.IncludingFile.UseRequireOnce">
-		<type>warning</type>
-	</rule>
-
-	<!-- Check correct spacing of language constructs. This also ensures that the
-	     above rule for not using brackets with require is fixed correctly.
-		 https://github.com/WordPress/WordPress-Coding-Standards/issues/1153 -->
-	<rule ref="Squiz.WhiteSpace.LanguageConstructSpacing"/>
-
 	<!-- Hook callbacks may not use all params -->
 	<!-- https://github.com/WordPress/WordPress-Coding-Standards/pull/382#discussion_r29981655 -->
 	<!--<rule ref="Generic.CodeAnalysis.UnusedFunctionParameter"/>-->


### PR DESCRIPTION
This is a follow-up to [WP-Core 48082](https://core.trac.wordpress.org/ticket/48082) and [WP-Core 49376](https://core.trac.wordpress.org/ticket/49376).

This PR moves the rules that check and enforce the following from `WordPress-Extra` to `WordPressCore`
- No parenthesis when using the `include`/`require` language constructs.
- One and only one space immediately following the use of a language construct.

[Related Slack conversation](https://wordpress.slack.com/archives/C5VCTJGH3/p1580999225029300).