### PR TITLE
AbstractFunctionRestrictions: fix constants being recognized as functions

### DIFF
--- a/WordPress/Sniffs/WP/AlternativeFunctionsSniff.php
+++ b/WordPress/Sniffs/WP/AlternativeFunctionsSniff.php
@@ -89,6 +89,9 @@ class AlternativeFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 				'functions' => array(
 					'curl_*',
 				),
+				'whitelist' => array(
+					'curl_version' => true,
+				),
 			),
 
 			'parse_url' => array(
@@ -273,10 +276,6 @@ class AlternativeFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 				unset( $first_param );
 
 				break;
-
-			case 'curl_version':
-				// Curl version doesn't actually create a connection.
-				return;
 		}
 
 		if ( ! isset( $this->groups[ $group_name ]['since'] ) ) {

--- a/WordPress/Tests/WP/AlternativeFunctionsUnitTest.inc
+++ b/WordPress/Tests/WP/AlternativeFunctionsUnitTest.inc
@@ -71,3 +71,10 @@ curl_version(); // OK.
 
 // Safeguard that additional logic uses case-insensitive function name check.
 Strip_Tags( $something ); // Warning.
+
+if ( ! $curl['features'] && CURL_VERSION_SSL ) {} // OK.
+my_parse_url_function(); // OK.
+function curl_version_ssl() {} // OK.
+use function curl_version; // OK.
+use function something as curl_version; // OK.
+use function curl_init as curl_version; // Bad.

--- a/WordPress/Tests/WP/AlternativeFunctionsUnitTest.php
+++ b/WordPress/Tests/WP/AlternativeFunctionsUnitTest.php
@@ -64,6 +64,7 @@ class AlternativeFunctionsUnitTest extends AbstractSniffUnitTest {
 			67 => 1,
 			68 => 1,
 			73 => 1,
+			80 => 1,
 		);
 	}
 


### PR DESCRIPTION
This is a follow-up on #1658 which special cased the `curl_version()` function for the `WP.AlternativeFunctions` sniff.

The bug reported to me was that the sniff was throwing an error for the below code:
```php
		$curl = curl_version();

		$ssl_support = true;
		if ( ! $curl['features'] && CURL_VERSION_SSL ) {
			$ssl_support = false;
		}
```

Turned out, it wasn't throwing an error for the function call to `curl_version()`. Instead it was (incorrectly) throwing an error for the use of the `CURL_VERSION_SSL` constant, thinking that was a function call.

I've fixed this now and added a number of additional unit tests.

With an eye on modern PHP, the abstract sniff(s) needs more work, but as PHPCSUtils is expected to have a similar abstract sniff soon which will take all that into account and which we will be able to switch to, I think this will have to do for now.

## Commit Summary

### AlternativeFunctions: use `whitelist` instead of special case

The `AbstractFunctionRestrictions` sniff allows for a `whitelist` of functions which shouldn't be matched when a wildcard is used.
We may as well use it as it will bow out earlier than special casing the function in the `switch`.

### AbstractFunctionRestrictions: improve matching of function calls

The code as it was could inadvertently match a CONSTANT with the same name as a function.
This has been fixed by adding a check for an open parenthesis after the function name.

Adding that check, however, would break the check on `use function` import statements. So some additional code has been added to make sure those will still be matched too.

Includes tightening up the regex pattern.

Includes unit tests via the `WP.AlternativeFunctions` sniff.
