### PR TITLE
Travis/QA: always check that all sniffs are feature complete

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,6 +74,11 @@ jobs:
         # @link https://getcomposer.org/doc/03-cli.md#validate
         - composer validate --no-check-all --strict
 
+        # Check that the sniffs available are feature complete.
+        # For now, just check that all sniffs have unit tests.
+        # At a later stage the documentation check can be activated.
+        - composer check-complete
+
     #### RULESET STAGE ####
     # Make sure the rulesets don't throw unexpected errors or warnings.
     # This check needs to be run against a high PHP version to prevent triggering the syntax error check.

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
 	"require-dev": {
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.5 || ^0.6",
 		"phpcompatibility/php-compatibility": "^9.0",
-		"phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+		"phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0",
+		"phpcsstandards/phpcsdevtools": "^1.0"
 	},
 	"suggest": {
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.6 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
@@ -39,6 +40,12 @@
 		],
 		"run-tests": [
 			"@php ./vendor/phpunit/phpunit/phpunit --filter WordPress --bootstrap=\"./vendor/squizlabs/php_codesniffer/tests/bootstrap.php\" ./vendor/squizlabs/php_codesniffer/tests/AllTests.php"
+		],
+		"check-complete": [
+			"@php ./vendor/phpcsstandards/phpcsdevtools/bin/phpcs-check-feature-completeness -q ./WordPress"
+		],
+		"check-complete-strict": [
+			"@php ./vendor/phpcsstandards/phpcsdevtools/bin/phpcs-check-feature-completeness ./WordPress"
 		]
 	},
 	"support": {


### PR DESCRIPTION
The new `phpcsstandards/phpcsdevtools` package includes a script which can check whether sniffs are feature complete, i.e. whether all sniffs have unit tests and documentation.

By adding this check to the Travis script, we prevent untested and/or undocumented sniffs from entering the repo.

For now, the documentation check is silenced.

Ref: https://github.com/PHPCSStandards/PHPCSDevTools#checking-whether-all-sniffs-in-a-phpcs-standard-are-feature-complete

P.S.: the `PHPCSDevTools` package contains a few more goodies, have a look at the [readme](https://github.com/PHPCSStandards/PHPCSDevTools) for more information.