### PR TITLE
PreparedSQL: quick fix for namespace separator

### DIFF
--- a/WordPress/Sniffs/DB/PreparedSQLSniff.php
+++ b/WordPress/Sniffs/DB/PreparedSQLSniff.php
@@ -69,6 +69,7 @@ class PreparedSQLSniff extends Sniff {
 		\T_INT_CAST                 => true,
 		\T_DOUBLE_CAST              => true,
 		\T_BOOL_CAST                => true,
+		\T_NS_SEPARATOR             => true,
 	);
 
 	/**

--- a/WordPress/Tests/DB/PreparedSQLUnitTest.inc
+++ b/WordPress/Tests/DB/PreparedSQLUnitTest.inc
@@ -39,7 +39,7 @@ $all_post_meta = $wpdb->get_results( $wpdb->prepare( sprintf(
 	WHERE `meta_key` = "sort_order"
 		AND `post_id` IN (%s)',
 	$wpdb->postmeta,
-	implode( ',', array_fill( 0, count( $post_ids ), '%d' ) )
+	\implode( ',', \array_fill( 0, \count( $post_ids ), '%d' ) )
 ), $post_ids ) ); // Ok.
 
 $wpdb->query( "


### PR DESCRIPTION
Reported in #1875: using a namespace separator with function calls in the `WordPress.DB.PreparedSQL` triggers a false positive on the namespace separator as "not being escaped".

While this really should be handled differently with proper FQN function name determination for function calls etc, for now, let's just ignore the namespace separator as that is not something which would need to be "prepared".

Fixes #1875