### PR TITLE
Update default minimum_supported_version to WP 5.1

### DIFF
--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -82,7 +82,7 @@ abstract class Sniff implements PHPCS_Sniff {
 	 *
 	 * @var string WordPress version.
 	 */
-	public $minimum_supported_version = '5.0';
+	public $minimum_supported_version = '5.1';
 
 	/**
 	 * Custom list of classes which test classes can extend.

--- a/WordPress/Sniffs/WP/DeprecatedFunctionsSniff.php
+++ b/WordPress/Sniffs/WP/DeprecatedFunctionsSniff.php
@@ -1359,6 +1359,12 @@ class DeprecatedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 			'alt'     => 'wp_update_user()',
 			'version' => '5.3.0',
 		),
+
+		// WP 5.4.0.
+		'wp_get_user_request_data' => array(
+			'alt'     => 'wp_get_user_request()',
+			'version' => '5.4.0',
+		),
 	);
 
 	/**

--- a/WordPress/Tests/WP/DeprecatedFunctionsUnitTest.inc
+++ b/WordPress/Tests/WP/DeprecatedFunctionsUnitTest.inc
@@ -345,3 +345,5 @@ install_blog();
 _wp_json_prepare_data();
 _wp_privacy_requests_screen_options();
 update_user_status();
+/* ============ WP 5.4 ============ */
+wp_get_user_request_data();

--- a/WordPress/Tests/WP/DeprecatedFunctionsUnitTest.php
+++ b/WordPress/Tests/WP/DeprecatedFunctionsUnitTest.php
@@ -76,10 +76,13 @@ class DeprecatedFunctionsUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getWarningList() {
 
-		$warnings = array_fill( 342, 6, 1 );
+		$warnings = array_fill( 342, 8, 1 );
 
 		// Unset the lines related to version comments.
-		unset( $warnings[344] );
+		unset(
+			$warnings[344],
+			$warnings[348]
+		);
 
 		return $warnings;
 	}


### PR DESCRIPTION
The minimum version should be three versions behind the latest WP release, so what with 5.4 being out, it should now be 5.1.

Includes updating the list of deprecated functions. Input for this based on @JDGrimes's WP deprecated code scanner & WP Core `trunk`.