### PR TITLE
Clean up the I18n sniff

### DIFF
--- a/WordPress/Sniffs/WP/I18nSniff.php
+++ b/WordPress/Sniffs/WP/I18nSniff.php
@@ -653,10 +653,13 @@ class I18nSniff extends AbstractFunctionRestrictionsSniff {
 
 		// If the opening HTML element includes placeholders in its attributes, we don't warn.
 		// E.g. '<option id="%1$s" value="%2$s">Translatable option name</option>'.
-		for ( $i = 0; $attr = $reader->getAttributeNo( $i ); $i++ ) {
+		$i = 0;
+		while ( $attr = $reader->getAttributeNo( $i ) ) {
 			if ( preg_match( self::SPRINTF_PLACEHOLDER_REGEX, $attr ) === 1 ) {
 				return;
 			}
+
+			++$i;
 		}
 
 		// We don't flag strings wrapped in `<a href="...">...</a>`, as the link target might actually need localization.

--- a/WordPress/Sniffs/WP/I18nSniff.php
+++ b/WordPress/Sniffs/WP/I18nSniff.php
@@ -654,7 +654,7 @@ class I18nSniff extends AbstractFunctionRestrictionsSniff {
 		// If the opening HTML element includes placeholders in its attributes, we don't warn.
 		// E.g. '<option id="%1$s" value="%2$s">Translatable option name</option>'.
 		for ( $i = 0; $attr = $reader->getAttributeNo( $i ); $i++ ) {
-			if ( preg_match( self::SPRINTF_PLACEHOLDER_REGEX, $attr ) ) {
+			if ( preg_match( self::SPRINTF_PLACEHOLDER_REGEX, $attr ) === 1 ) {
 				return;
 			}
 		}

--- a/WordPress/Sniffs/WP/I18nSniff.php
+++ b/WordPress/Sniffs/WP/I18nSniff.php
@@ -630,8 +630,8 @@ class I18nSniff extends AbstractFunctionRestrictionsSniff {
 		 *
 		 * Strip placeholders and surrounding quotes.
 		 */
-		$content_without_surrounding_quotes = trim( $this->strip_quotes( $content ) );
-		$non_placeholder_content = preg_replace( self::SPRINTF_PLACEHOLDER_REGEX, '', $content_without_surrounding_quotes );
+		$content_without_quotes  = trim( $this->strip_quotes( $content ) );
+		$non_placeholder_content = preg_replace( self::SPRINTF_PLACEHOLDER_REGEX, '', $content_without_quotes );
 
 		if ( '' === $non_placeholder_content ) {
 			$this->phpcsFile->addError( 'Strings should have translatable content', $stack_ptr, 'NoEmptyStrings' );
@@ -644,7 +644,7 @@ class I18nSniff extends AbstractFunctionRestrictionsSniff {
 		 * Strip surrounding quotes.
 		 */
 		$reader = new \XMLReader();
-		$reader->XML( $content_without_surrounding_quotes, 'UTF-8', LIBXML_NOERROR | LIBXML_ERR_NONE | LIBXML_NOWARNING );
+		$reader->XML( $content_without_quotes, 'UTF-8', LIBXML_NOERROR | LIBXML_ERR_NONE | LIBXML_NOWARNING );
 
 		// Is the first node an HTML element?
 		if ( ! $reader->read() || \XMLReader::ELEMENT !== $reader->nodeType ) {
@@ -665,7 +665,7 @@ class I18nSniff extends AbstractFunctionRestrictionsSniff {
 		}
 
 		// Does the entire string only consist of this HTML node?
-		if ( $reader->readOuterXml() === $content_without_surrounding_quotes ) {
+		if ( $reader->readOuterXml() === $content_without_quotes ) {
 			$this->phpcsFile->addWarning( 'Strings should not be wrapped in HTML', $stack_ptr, 'NoHtmlWrappedStrings' );
 		}
 	}


### PR DESCRIPTION
While running some tests for something else, I noticed that the I18n sniff was throwing all sorts of CS warnings.

Fixed now.

#### I18n: rename variable

Rename a very long variable name and fix a CS warning for incorrect alignment.

#### I18n: use explicit comparison

#### I18n: assignment in condition is only allowed in a while loop

The code as was, was throwing two warnings for the assignment in the for loop. Let's not set a bad example.

