### PR TITLE
First pass at sniff to confirm inline docs for filters are present

### DIFF
--- a/WordPress/Docs/Commenting/HooksInlineDocsStandard.xml
+++ b/WordPress/Docs/Commenting/HooksInlineDocsStandard.xml
@@ -8,7 +8,9 @@
         <code title="Valid: using a DocBlock to describe a hook.">
             <![CDATA[
 /**
- * Description of hook.
+ * Summary of hook.
+ *
+ * This is a longer description of a hook.
  *
  * @since 1.0.0
  */
@@ -18,7 +20,7 @@ do_action( 'hook' );
         <code title="Invalid: not using a DocBlock comment">
             <![CDATA[
 /*
- * This is not a docblock.
+ * This is not a DocBlock.
  */
 do_action( 'hook' );
         ]]>

--- a/WordPress/Docs/Commenting/HooksInlineDocsStandard.xml
+++ b/WordPress/Docs/Commenting/HooksInlineDocsStandard.xml
@@ -1,11 +1,11 @@
-<documentation title="Hooks Inline Docblock Standard">
+<documentation title="Hooks Inline DocBlock Standard">
     <standard>
         <![CDATA[
-    All WordPress hook execution functions should be preceded by a docblock explaining the hook.
+    All WordPress hook execution functions should be preceded by a DocBlock explaining the hook.
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: using a docblock to describe a hook.">
+        <code title="Valid: using a DocBlock to describe a hook.">
             <![CDATA[
 /**
  * Description of hook.
@@ -15,7 +15,7 @@
 do_action( 'hook' );
         ]]>
         </code>
-        <code title="Invalid: using a non-docblock comment">
+        <code title="Invalid: not using a DocBlock comment">
             <![CDATA[
 /*
  * This is not a docblock.
@@ -28,7 +28,7 @@ do_action( 'hook' );
         <code title="Valid: including a @since tag with a valid X.Y.Z version.">
             <![CDATA[
 /**
- * Description of hook.
+ * Summary of hook.
  *
  * <em>@since 1.0.0</em>
  */

--- a/WordPress/Docs/Commenting/HooksInlineDocsStandard.xml
+++ b/WordPress/Docs/Commenting/HooksInlineDocsStandard.xml
@@ -1,0 +1,49 @@
+<documentation title="Hooks Inline Docblock Standard">
+    <standard>
+        <![CDATA[
+    All WordPress hook execution functions should be preceded by a docblock explaining the hook.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: using a docblock to describe a hook.">
+            <![CDATA[
+/**
+ * Description of hook.
+ *
+ * @since 1.0.0
+ */
+do_action( 'hook' );
+        ]]>
+        </code>
+        <code title="Invalid: using a non-docblock comment">
+            <![CDATA[
+/*
+ * This is not a docblock.
+ */
+do_action( 'hook' );
+        ]]>
+        </code>
+    </code_comparison>
+    <code_comparison>
+        <code title="Valid: including a @since tag with a valid X.Y.Z version.">
+            <![CDATA[
+/**
+ * Description of hook.
+ *
+ * <em>@since 1.0.0</em>
+ */
+do_action( 'hook' );
+        ]]>
+        </code>
+        <code title="Invalid: including a @since tag with a different undeclared version.">
+            <![CDATA[
+/**
+ * Description of hook.
+ *
+ * <em>@since Initial release.</em>
+ */
+do_action( 'hook' );
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/WordPress/Sniffs/Commenting/HooksInlineDocsSniff.php
+++ b/WordPress/Sniffs/Commenting/HooksInlineDocsSniff.php
@@ -95,7 +95,6 @@ class HooksInlineDocsSniff extends AbstractFunctionRestrictionsSniff {
 					$stack_ptr,
 					'NoDocblockFound'
 				);
-				// return; Do we need to return here? Can we keep going?
 			}
 
 			/*
@@ -121,8 +120,8 @@ class HooksInlineDocsSniff extends AbstractFunctionRestrictionsSniff {
 					// If it is false, there is no text or if the text is on the another line, error.
 					if ( false === $string || $this->tokens[ $string ]['line'] !== $this->tokens[ $tag ]['line'] ) {
 						$this->phpcsFile->addError( 'Since tag must have a value.', $tag, 'EmptySince' );
-					} elseif ( ! preg_match( '\'/^\d+\.\d+\.\d+/\'', $string ) ) { // Requires X.Y.Z. Trailing 0 is needed for a major release.
-						$this->phpcsFile->addError( 'Since tag must have a X.Y.Z. version number.', $tag, 'InvalidSince' );
+					} elseif ( ! preg_match('/^\d+\.\d+\.\d+/', $this->tokens[ $string ]['content'] ) ) { // Requires X.Y.Z. Trailing 0 is needed for a major release.
+						$this->phpcsFile->addError( 'Since tag must have a X.Y.Z version number.' . $this->tokens[ $string ]['content'], $tag, 'InvalidSince' );
 					}
 				}
 			}
@@ -160,11 +159,19 @@ class HooksInlineDocsSniff extends AbstractFunctionRestrictionsSniff {
 	 *
 	 * @param int $start       The position of the starting token in the stack.
 	 * @param int $end       The position of the ending token in the stack.
+	 *
+	 * @return bool If docblock matches the previously documented convention.
 	 */
 	protected function is_previously_documented( $start, $end ) {
 		$string = $this->phpcsFile->findNext( T_DOC_COMMENT_STRING, $start, $end );
+
+		$content = $this->tokens[ $string ]['content'];
 		// If the call is documented elsewhere, stop here.
-		if ( 0 === strpos( $this->tokens[ $string ]['content'], 'This filter is documented in' ) ) {
+		if ( 0 === strpos( $content, 'This filter is documented' ) ) {
+			return true;
+		}
+
+		if ( 0 === strpos( $content, 'This action is documented' ) ) {
 			return true;
 		}
 

--- a/WordPress/Sniffs/Commenting/HooksInlineDocsSniff.php
+++ b/WordPress/Sniffs/Commenting/HooksInlineDocsSniff.php
@@ -40,13 +40,13 @@ class HooksInlineDocsSniff extends AbstractFunctionRestrictionsSniff {
 	 * they can be passed in the ruleset XML file via:
 	 * <rule ref="WordPress.Commenting.HooksInlineDocs">
 	 *  <properties>
-	 *   <property name="allowed_extra_versions" type="array">
-	 *    <element key="0.71" value="0.71"/>
-	 *    <element key="MU (3.0.0)" value="MU (3.0.0)"/>
-	 *   </property>
+	 *   <property name="allowed_extra_versions" type="array" value="0.71"/>
+	 *   <property name="allowed_extra_versions" type="array" value="MU (3.0.0)"/>
 	 * </rule>
 	 *
 	 * The key values are used to determine if a version is allowed outside of the X.Y.Z scheme. The value is not considered.
+	 *
+	 * @var array Array of allowed exceptional values.
 	 */
 	public $allowed_extra_versions = array();
 
@@ -137,7 +137,7 @@ class HooksInlineDocsSniff extends AbstractFunctionRestrictionsSniff {
 					// If it is false, there is no text or if the text is on the another line, error.
 					if ( false === $string || $this->tokens[ $string ]['line'] !== $this->tokens[ $tag ]['line'] ) {
 						$this->phpcsFile->addError( 'Since tag must have a value.', $tag, 'EmptySince' );
-					} elseif ( ! preg_match('/^\d+\.\d+\.\d+/', $this->tokens[ $string ]['content'], $matches ) ) { // Requires X.Y.Z. Trailing 0 is needed for a major release.
+					} elseif ( ! preg_match( '/^\d+\.\d+\.\d+/', $this->tokens[ $string ]['content'], $matches ) ) { // Requires X.Y.Z. Trailing 0 is needed for a major release.
 						if ( empty( $this->allowed_extra_versions ) || ! $this->array_begins_with( $this->tokens[ $string ]['content'], $this->allowed_extra_versions ) ) {
 							$this->phpcsFile->addError( 'Since tag must have a X.Y.Z version number.', $tag, 'InvalidSince' );
 						}
@@ -218,16 +218,16 @@ class HooksInlineDocsSniff extends AbstractFunctionRestrictionsSniff {
 	}
 
 	/**
-	 * Checks if an array key begins with a particular string.
+	 * Checks if an array value begins with a particular string.
 	 *
 	 * @param string $string Needle value.
-	 * @param array $array Haystack value.
+	 * @param array  $array Haystack value.
 	 *
 	 * @return bool If any array key begins within the given string.
 	 */
-	protected function array_begins_with( $string, $array ){
-		foreach ( $array as $key => $value ) {
-			if ( 0 === strpos( $string, $key ) ) {
+	protected function array_begins_with( $string, $array ) {
+		foreach ( $array as $value ) {
+			if ( 0 === strpos( $string, $value ) ) {
 				return true;
 			}
 		}

--- a/WordPress/Sniffs/Commenting/HooksInlineDocsSniff.php
+++ b/WordPress/Sniffs/Commenting/HooksInlineDocsSniff.php
@@ -217,6 +217,14 @@ class HooksInlineDocsSniff extends AbstractFunctionRestrictionsSniff {
 		return true;
 	}
 
+	/**
+	 * Checks if an array key begins with a particular string.
+	 *
+	 * @param string $string Needle value.
+	 * @param array $array Haystack value.
+	 *
+	 * @return bool If any array key begins within the given string.
+	 */
 	protected function array_begins_with( $string, $array ){
 		foreach ( $array as $key => $value ) {
 			if ( 0 === strpos( $string, $key ) ) {

--- a/WordPress/Sniffs/Commenting/HooksInlineDocsSniff.php
+++ b/WordPress/Sniffs/Commenting/HooksInlineDocsSniff.php
@@ -18,21 +18,6 @@ use PHP_CodeSniffer\Util\Tokens;
  * @package WPCS\WordPressCodingStandards
  */
 class HooksInlineDocsSniff extends AbstractFunctionRestrictionsSniff {
-
-	/**
-	 * Array of WordPress hook execution functions.
-	 *
-	 * @var array WordPress hook execution function name => filter or action.
-	 */
-	protected $hook_functions = array(
-		'apply_filters'            => 'filter',
-		'apply_filters_ref_array'  => 'filter',
-		'apply_filters_deprecated' => 'filter',
-		'do_action'                => 'action',
-		'do_action_ref_array'      => 'action',
-		'do_action_deprecated'     => 'action',
-	);
-
 	/**
 	 * Array of allowed exceptional version numbers.
 	 *
@@ -66,7 +51,7 @@ class HooksInlineDocsSniff extends AbstractFunctionRestrictionsSniff {
 	public function getGroups() {
 		return array(
 			'hooks' => array(
-				'functions' => array_keys( $this->hook_functions ),
+				'functions' => array_keys( $this->hookInvokeFunctions ),
 			),
 		);
 	}

--- a/WordPress/Sniffs/Commenting/HooksInlineDocsSniff.php
+++ b/WordPress/Sniffs/Commenting/HooksInlineDocsSniff.php
@@ -139,7 +139,7 @@ class HooksInlineDocsSniff extends AbstractFunctionRestrictionsSniff {
 						$this->phpcsFile->addError( 'Since tag must have a value.', $tag, 'EmptySince' );
 					} elseif ( ! preg_match('/^\d+\.\d+\.\d+/', $this->tokens[ $string ]['content'], $matches ) ) { // Requires X.Y.Z. Trailing 0 is needed for a major release.
 						if ( empty( $this->allowed_extra_versions ) || ! $this->array_begins_with( $this->tokens[ $string ]['content'], $this->allowed_extra_versions ) ) {
-							$this->phpcsFile->addError( 'Since tag must have a X.Y.Z version number.' . $this->tokens[ $string ]['content'], $tag, 'InvalidSince' );
+							$this->phpcsFile->addError( 'Since tag must have a X.Y.Z version number.', $tag, 'InvalidSince' );
 						}
 					}
 				}

--- a/WordPress/Sniffs/Commenting/HooksInlineDocsSniff.php
+++ b/WordPress/Sniffs/Commenting/HooksInlineDocsSniff.php
@@ -7,7 +7,7 @@
  * @license https://opensource.org/licenses/MIT MIT
  */
 
-namespace WordPressCS\WordPress\Sniffs\WP;
+namespace WordPressCS\WordPress\Sniffs\Commenting;
 
 use WordPressCS\WordPress\AbstractFunctionRestrictionsSniff;
 use PHP_CodeSniffer\Util\Tokens;

--- a/WordPress/Sniffs/WP/HooksInlineDocsSniff.php
+++ b/WordPress/Sniffs/WP/HooksInlineDocsSniff.php
@@ -181,8 +181,8 @@ class HooksInlineDocsSniff extends AbstractFunctionRestrictionsSniff {
 	protected function verify_valid_match( $stack_ptr ) {
 		$func_open_paren_token = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $stack_ptr + 1 ), null, true );
 		if ( false === $func_open_paren_token
-		     || \T_OPEN_PARENTHESIS !== $this->tokens[ $func_open_paren_token ]['code']
-		     || ! isset( $this->tokens[ $func_open_paren_token ]['parenthesis_closer'] )
+			|| \T_OPEN_PARENTHESIS !== $this->tokens[ $func_open_paren_token ]['code']
+			|| ! isset( $this->tokens[ $func_open_paren_token ]['parenthesis_closer'] )
 		) {
 			// Live coding, parse error or not a function call.
 			return false;

--- a/WordPress/Sniffs/WP/HooksInlineDocsSniff.php
+++ b/WordPress/Sniffs/WP/HooksInlineDocsSniff.php
@@ -17,7 +17,7 @@ use PHP_CodeSniffer\Util\Tokens;
  *
  * @package WPCS\WordPressCodingStandards
  */
-class HooksMustHaveDocblockSniff extends AbstractFunctionRestrictionsSniff {
+class HooksInlineDocsSniff extends AbstractFunctionRestrictionsSniff {
 
 	/**
 	 * Array of WordPress hook execution functions.

--- a/WordPress/Sniffs/WP/HooksInlineDocsSniff.php
+++ b/WordPress/Sniffs/WP/HooksInlineDocsSniff.php
@@ -1,0 +1,193 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPressCS\WordPress\Sniffs\WP;
+
+use WordPressCS\WordPress\AbstractFunctionRestrictionsSniff;
+use PHP_CodeSniffer\Util\Tokens;
+
+/**
+ * Class HooksMustHaveDocblockSniff
+ *
+ * @package WPCS\WordPressCodingStandards
+ */
+class HooksMustHaveDocblockSniff extends AbstractFunctionRestrictionsSniff {
+
+	/**
+	 * Array of WordPress hook execution functions.
+	 *
+	 * @var array WordPress hook execution function name => filter or action.
+	 */
+	protected $hook_functions = array(
+		'apply_filters'            => 'filter',
+		'apply_filters_ref_array'  => 'filter',
+		'apply_filters_deprecated' => 'filter',
+		'do_action'                => 'action',
+		'do_action_ref_array'      => 'action',
+		'do_action_deprecated'     => 'action',
+	);
+
+	/**
+	 * Groups of functions to restrict.
+	 *
+	 * Example: groups => array(
+	 *  'lambda' => array(
+	 *      'type'      => 'error' | 'warning',
+	 *      'message'   => 'Use anonymous functions instead please!',
+	 *      'functions' => array( 'file_get_contents', 'create_function' ),
+	 *  )
+	 * )
+	 *
+	 * @return array
+	 */
+	public function getGroups() {
+		return array(
+			'hooks' => array(
+				'functions' => array_keys( $this->hook_functions ),
+			),
+		);
+	}
+
+	/**
+	 * Process a matched token.
+	 *
+	 * @since 1.0.0 Logic split off from the `process_token()` method.
+	 *
+	 * @param int    $stack_ptr       The position of the current token in the stack.
+	 * @param string $group_name      The name of the group which was matched.
+	 * @param string $matched_content The token content (function name) which was matched.
+	 *
+	 * @return int|void Integer stack pointer to skip forward or void to continue
+	 *                  normal file processing.
+	 */
+	public function process_matched_token( $stack_ptr, $group_name, $matched_content ) {
+
+		if ( ! $this->verify_valid_match( $stack_ptr ) ) {
+			return;
+		}
+
+		$previous_comment = $this->return_previous_comment( $stack_ptr );
+
+		if ( false !== $previous_comment ) {
+			/*
+			 * Check to determine if there is a comment immediately preceding the function call.
+			 */
+			if ( ( $this->tokens[ $previous_comment ]['line'] + 1 ) !== $this->tokens[ $stack_ptr ]['line'] ) {
+				$this->phpcsFile->addError(
+					'The inline documentation for a hook must be on the line immediately before the function call.',
+					$stack_ptr,
+					'DocMustBePreceding'
+				);
+			}
+
+			/*
+			 * Check that the comment starts is a docblock.
+			 */
+			if ( \T_DOC_COMMENT_CLOSE_TAG !== $this->tokens[ $previous_comment ]['code'] ) {
+				$this->phpcsFile->addError(
+					'Hooks must include a docblock with /** formatting */',
+					$stack_ptr,
+					'NoDocblockFound'
+				);
+				// return; Do we need to return here? Can we keep going?
+			}
+
+			/*
+			 * Process docblock tags.
+			 */
+			$comment_end   = $previous_comment;
+			$comment_start = $this->return_comment_start( $comment_end );
+			$has           = array(
+				'since' => false,
+			);
+
+			// The comment isn't a docblock or is documented elsewhere, so we're going to stop here.
+			if ( ! $comment_start || $this->is_previously_documented( $comment_start, $comment_end ) ) {
+				return;
+			}
+
+			foreach ( $this->tokens[ $comment_start ]['comment_tags'] as $tag ) {
+				// Is the next tag of the docblock the "@since" tag?
+				if ( '@since' === $this->tokens[ $tag ]['content'] ) {
+					$has['since'] = true;
+					// Find the next string, which will be the text after the @since.
+					$string = $this->phpcsFile->findNext( T_DOC_COMMENT_STRING, $tag, $comment_end );
+					// If it is false, there is no text or if the text is on the another line, error.
+					if ( false === $string || $this->tokens[ $string ]['line'] !== $this->tokens[ $tag ]['line'] ) {
+						$this->phpcsFile->addError( 'Since tag must have a value.', $tag, 'EmptySince' );
+					} elseif ( ! preg_match( '\'/^\d+\.\d+\.\d+/\'', $string ) ) { // Requires X.Y.Z. Trailing 0 is needed for a major release.
+						$this->phpcsFile->addError( 'Since tag must have a X.Y.Z. version number.', $tag, 'InvalidSince' );
+					}
+				}
+			}
+
+			foreach ( $has as $name => $present ) {
+				if ( ! $present ) {
+					$this->phpcsFile->addError( 'Hook documentation is missing a tag: ' . $name, $comment_start, 'No' . ucfirst( $name ) );
+				}
+			}
+		}
+	}
+
+	/**
+	 * Helper function to identify the comment previous to a pointer reference.
+	 *
+	 * @param int $stack_ptr       The position of the token in the stack.
+	 */
+	protected function return_previous_comment( $stack_ptr ) {
+		return $this->phpcsFile->findPrevious( Tokens::$commentTokens, ( $stack_ptr - 1 ) );
+	}
+
+	/**
+	 * Returns the starting comment reference when passed an end reference.
+	 *
+	 * Used to help set bounds for searching through a docblock.
+	 *
+	 * @param int $end       The position of the ending token in the stack.
+	 */
+	protected function return_comment_start( $end ) {
+		return ( isset( $this->tokens[ $end ]['comment_opener'] ) ) ? $this->tokens[ $end ]['comment_opener'] : false;
+	}
+
+	/**
+	 * Determines if a filter docblock is referencing a complete docblock elsewhere.
+	 *
+	 * @param int $start       The position of the starting token in the stack.
+	 * @param int $end       The position of the ending token in the stack.
+	 */
+	protected function is_previously_documented( $start, $end ) {
+		$string = $this->phpcsFile->findNext( T_DOC_COMMENT_STRING, $start, $end );
+		// If the call is documented elsewhere, stop here.
+		if ( 0 === strpos( $this->tokens[ $string ]['content'], 'This filter is documented in' ) ) {
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Verifies the match is valid and worthy of continued processing.
+	 *
+	 * @param int $stack_ptr       The position of the token in the stack.
+	 *
+	 * @return bool True for valid.
+	 */
+	protected function verify_valid_match( $stack_ptr ) {
+		$func_open_paren_token = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $stack_ptr + 1 ), null, true );
+		if ( false === $func_open_paren_token
+		     || \T_OPEN_PARENTHESIS !== $this->tokens[ $func_open_paren_token ]['code']
+		     || ! isset( $this->tokens[ $func_open_paren_token ]['parenthesis_closer'] )
+		) {
+			// Live coding, parse error or not a function call.
+			return false;
+		}
+
+		return true;
+	}
+}

--- a/WordPress/Tests/Commenting/HooksInlineDocsUnitTest.inc
+++ b/WordPress/Tests/Commenting/HooksInlineDocsUnitTest.inc
@@ -1,5 +1,7 @@
 <?php
-// phpcs:set WordPress.Commenting.HooksInlineDocs allowed_extra_versions[] MU
+/**
+ * Test file for the hooks DocBlocks.
+ */
 
 /*
  * Set 1
@@ -72,20 +74,21 @@ apply_filters( 'hook', 'function' );
  */
 apply_filters( 'hook', 'function' );
 
-// Complete docblock with a "exceptional" version number declared in the XML.
-/**
- * This is a description.
- *
- * @since MU
- */
-apply_filters( 'hook', 'function' );
-
 // Complete docblock with a "normal" version number and extra text.
 /**
  * This is a description.
  *
  * @since 1.0.0
  * @since 1.2.0 Added something.
+ */
+apply_filters( 'hook', 'function' );
+
+// phpcs:set WordPress.Commenting.HooksInlineDocs allowed_extra_versions[] MU
+// Complete docblock with a "exceptional" version number declared in the XML or via phpcs:set.
+/**
+ * This is a description.
+ *
+ * @since MU
  */
 apply_filters( 'hook', 'function' );
 
@@ -97,6 +100,8 @@ apply_filters( 'hook', 'function' );
  */
 apply_filters( 'hook', 'function' );
 
+// phpcs:set WordPress.Commenting.HooksLineDocs allowed_extra_versions[]
+
 // "Already documented" example of an action.
 /** This action is documented in file.php */
 do_action( 'hook ' );
@@ -104,5 +109,3 @@ do_action( 'hook ' );
 // "Already documented" example of a filter.
 /** This filter is documented in file.php */
 apply_filters(' hook', 'function' );
-
-// phpcs:set WordPress.Commenting.HooksLineDocs allowed_extra_versions[]

--- a/WordPress/Tests/Commenting/HooksInlineDocsUnitTest.inc
+++ b/WordPress/Tests/Commenting/HooksInlineDocsUnitTest.inc
@@ -61,7 +61,42 @@ apply_filters( 'hook', 'function' );
 apply_filters( 'hook', 'function' );
 
 /*
- * Set 4
+ * Set 6
+ *
+ * "Real World Cases"
+ */
+
+// This should fail since the hook does not have a DocBlock.
+/**
+ * This is my function DocBlock.
+ *
+ * @since 0000.00000.0000000000
+ */
+function my_function_has_a_hook() {
+	do_action( 'foo' );
+}
+
+// This should fail since the hook does not have a DocBlock.
+/**
+ * This is my function DocBlock.
+ *
+ * @since 0000.00000.0000000000
+ */
+function my_function_has_a_hook() {
+	echo 'foo';
+}
+do_action( 'foo' );
+
+// This should fail since the hook does not have a DocBlock.
+/**
+ * This is my function DocBlock.
+ *
+ * @since 0000.00000.0000000000
+ */
+function my_function_has_a_hook() { do_action( 'foo' ); }
+
+/*
+ * Set 5
  *
  * Valid comments. These should pass.
  */

--- a/WordPress/Tests/Commenting/HooksInlineDocsUnitTest.inc
+++ b/WordPress/Tests/Commenting/HooksInlineDocsUnitTest.inc
@@ -1,5 +1,5 @@
 <?php
-// phpcs:set WordPress.Commenting.HooksLineDocs allowed_extra_versions ['MU'=>'MU']
+// phpcs:set WordPress.Commenting.HooksInlineDocs allowed_extra_versions[] MU
 
 /*
  * Set 1
@@ -96,3 +96,5 @@ apply_filters( 'hook', 'function' );
  * @since MU Additional text.
  */
 apply_filters( 'hook', 'function' );
+
+// phpcs:set WordPress.Commenting.HooksLineDocs allowed_extra_versions[]

--- a/WordPress/Tests/Commenting/HooksInlineDocsUnitTest.inc
+++ b/WordPress/Tests/Commenting/HooksInlineDocsUnitTest.inc
@@ -97,4 +97,12 @@ apply_filters( 'hook', 'function' );
  */
 apply_filters( 'hook', 'function' );
 
+// "Already documented" example of an action.
+/** This action is documented in file.php */
+do_action( 'hook ' );
+
+// "Already documented" example of a filter.
+/** This filter is documented in file.php */
+apply_filters(' hook', 'function' );
+
 // phpcs:set WordPress.Commenting.HooksLineDocs allowed_extra_versions[]

--- a/WordPress/Tests/Commenting/HooksInlineDocsUnitTest.inc
+++ b/WordPress/Tests/Commenting/HooksInlineDocsUnitTest.inc
@@ -1,0 +1,98 @@
+<?php
+// phpcs:set WordPress.Commenting.HooksLineDocs allowed_extra_versions ['MU'=>'MU']
+
+/*
+ * Set 1
+ *
+ * Make sure we check each function. These should all fail as there are no inline docs.
+ */
+
+apply_filters( 'hook', 'function' );
+apply_filters_ref_array( 'hook', 'function' );
+apply_filters_deprecated( 'hook', 'function' );
+do_action( 'hook', 'function' );
+do_action_ref_array( 'hook', 'function' );
+do_action_deprecated( 'hook', 'function' );
+
+/*
+ * Set 2
+ *
+ * Invalid comment styles. These should fail.
+ */
+
+// Wrong format.
+apply_filters( 'hook', 'function' );
+
+/*
+ * Docblocks need the /** format
+ */
+apply_filters( 'hook', 'function' );
+
+/*
+ * Set 3
+ *
+ * Docblocks missing required values. These should fail.
+ */
+
+// Has a since tag with no value.
+/**
+ * This is a description.
+ *
+ * @since
+ */
+apply_filters( 'hook', 'function' );
+
+// Has a since tag with an incomplete value.
+/**
+ * This is a description.
+ *
+ * @since 8.5
+ */
+apply_filters( 'hook', 'function' );
+
+// Has a since tag with an wrong value.
+/**
+ * This is a description.
+ *
+ * @since Test
+ */
+apply_filters( 'hook', 'function' );
+
+/*
+ * Set 4
+ *
+ * Valid comments. These should pass.
+ */
+
+// Complete docblock with a "normal" version number.
+/**
+ * This is a description.
+ *
+ * @since 1.0.0
+ */
+apply_filters( 'hook', 'function' );
+
+// Complete docblock with a "exceptional" version number declared in the XML.
+/**
+ * This is a description.
+ *
+ * @since MU
+ */
+apply_filters( 'hook', 'function' );
+
+// Complete docblock with a "normal" version number and extra text.
+/**
+ * This is a description.
+ *
+ * @since 1.0.0
+ * @since 1.2.0 Added something.
+ */
+apply_filters( 'hook', 'function' );
+
+// Complete docblock with a "exceptional" version number declared in the XML with extra text.
+/**
+ * This is a description.
+ *
+ * @since MU Additional text.
+ */
+apply_filters( 'hook', 'function' );

--- a/WordPress/Tests/Commenting/HooksInlineDocsUnitTest.inc
+++ b/WordPress/Tests/Commenting/HooksInlineDocsUnitTest.inc
@@ -50,7 +50,7 @@ apply_filters( 'hook', 'function' );
  */
 apply_filters( 'hook', 'function' );
 
-// Has a since tag with an wrong value.
+// Has a since tag with a wrong value.
 /**
  * This is a description.
  *

--- a/WordPress/Tests/Commenting/HooksInlineDocsUnitTest.php
+++ b/WordPress/Tests/Commenting/HooksInlineDocsUnitTest.php
@@ -26,17 +26,20 @@ class HooksInlineDocsUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getErrorList() {
 		return array(
-			10 => 2,
-			11 => 2,
 			12 => 2,
 			13 => 2,
 			14 => 2,
 			15 => 2,
-			24 => 1,
-			29 => 1,
-			41 => 1,
-			49 => 1,
-			57 => 1,
+			16 => 2,
+			17 => 2,
+			26 => 1,
+			31 => 1,
+			43 => 1,
+			51 => 1,
+			59 => 1,
+			76 => 1,
+			88 => 1,
+			96 => 1,
 		);
 	}
 

--- a/WordPress/Tests/Commenting/HooksInlineDocsUnitTest.php
+++ b/WordPress/Tests/Commenting/HooksInlineDocsUnitTest.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Unit test class for WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPressCS\WordPress\Tests\Commenting;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+/**
+ * Unit test class for the HooksInlineDOcs sniff.
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since 3.0.0
+ */
+class HooksInlineDocsUnitTest extends AbstractSniffUnitTest {
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * @return array <int line number> => <int number of errors>
+	 */
+	public function getErrorList() {
+		return array(
+			10 => 2,
+			11 => 2,
+			12 => 2,
+			13 => 2,
+			14 => 2,
+			15 => 2,
+			24 => 1,
+			29 => 1,
+			41 => 1,
+			49 => 1,
+			57 => 1,
+		);
+	}
+
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * @return array <int line number> => <int number of warnings>
+	 */
+	public function getWarningList() {
+		return array();
+	}
+}


### PR DESCRIPTION
Fixes #424

First pass at sniff to confirm inline docs for hooks are present.

I'm adding this into Jetpack via https://github.com/Automattic/jetpack/pull/15693 since I wanted to check for some Jetpack-specific things. Per suggestion, wanted to offer the "base" to core WPCS for everyone's benefit.

In the initial commit, it finds a matching the various hook function (L27) using WPCS' `AbstractFunctionRestrictionsSniff` and checks for a preceding comment. The preceding comment need to be on the previous line (noting this is an open question from the Jetpack PR https://github.com/Automattic/jetpack/pull/15693#pullrequestreview-406406725) and confirm it is using the docblock format.

For the initial commit, it is verifying it has a `@since` tag within the docblock and that the value starts with a X.Y.Z version number. I'm not sure about WP itself, but Jetpack requires three levels to both confirm the exact version (e.g. 8.5 vs 8.5.0) and ensure that all hooks in the same major release (X.Y) will have the same value to avoid our docs parser tagging it as two separate versions.

If Core WPCS doesn't need that, I can remove that to just verify a `@since` tag is present and move the version check itself to Jetpack as I did with our `@module` tag in https://github.com/Automattic/jetpack/pull/15693/files#diff-eb7bc4afcdf23e6f99ae1f793afd119bR57 

