### PR TITLE
3.0: Composer: set the new requirements for WPCS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,10 +22,10 @@ php:
     - "nightly"
 
 env:
-  # `master` is now 3.x.
+  # PHPCS `master`.
   - PHPCS_BRANCH="dev-master" LINT=1
   # Lowest supported release in the 3.x series with which WPCS is compatible.
-  - PHPCS_BRANCH="3.3.1"
+  - PHPCS_BRANCH="3.5.0"
 
 # Define the stages used.
 # For non-PRs, only the sniff, ruleset and quicktest stages are run.
@@ -101,7 +101,7 @@ jobs:
 
     - stage: rulesets
       php: 7.4
-      env: PHPCS_BRANCH="3.3.1"
+      env: PHPCS_BRANCH="3.5.0"
       script:
         - $(pwd)/vendor/bin/phpcs -ps ./bin/class-ruleset-test.php --standard=WordPress-Core
         - $(pwd)/vendor/bin/phpcs -ps ./bin/class-ruleset-test.php --standard=WordPress-Docs
@@ -115,11 +115,11 @@ jobs:
       php: 7.4
       env: PHPCS_BRANCH="dev-master" LINT=1
     - php: 7.3
-      env: PHPCS_BRANCH="3.3.1"
+      env: PHPCS_BRANCH="3.5.0"
     - php: 5.4
       env: PHPCS_BRANCH="dev-master" LINT=1
     - php: 5.4
-      env: PHPCS_BRANCH="3.3.1"
+      env: PHPCS_BRANCH="3.5.0"
 
     #### TEST STAGE ####
     # Add extra build to test against PHPCS 4.

--- a/.travis.yml
+++ b/.travis.yml
@@ -125,12 +125,12 @@ jobs:
     # Add extra build to test against PHPCS 4.
     - stage: test
       php: 7.4
-      env: PHPCS_BRANCH="4.0.x-dev"
+      env: PHPCS_BRANCH="4.0.x-dev as 3.9.99"
 
   allow_failures:
     # Allow failures for unstable builds.
     - php: "nightly"
-    - env: PHPCS_BRANCH="4.0.x-dev"
+    - env: PHPCS_BRANCH="4.0.x-dev as 3.9.99"
 
 before_install:
     # Speed up build time by disabling Xdebug.
@@ -147,21 +147,23 @@ before_install:
 
     - export XMLLINT_INDENT="	"
     - export PHPUNIT_DIR=/tmp/phpunit
+
     - |
-      if [[ $TRAVIS_PHP_VERSION == "nightly" || $PHPCS_BRANCH == "4.0.x-dev" ]]; then
-          # Even though we're not doing a dev install, dev requirements are still checked.
-          # Neither the PHPCS Composer plugin nor PHPCompatibility allows yet for PHPCS 4.x.
-          # The Composer plugin also doesn't allow for installation on PHP 8.x/nightly.
-          composer remove --dev dealerdirect/phpcodesniffer-composer-installer phpcompatibility/php-compatibility --no-update --no-scripts
+      if [[ ${PHPCS_BRANCH:0:2} == "4." ]]; then
+        # Set Composer up to download only PHPCS from source for PHPCS 4.x.
+        # The source is needed to get the base testcase from PHPCS.
+        composer config preferred-install.squizlabs/php_codesniffer source
+      else
+        composer config preferred-install.squizlabs/php_codesniffer auto
       fi
-    - composer require squizlabs/php_codesniffer:${PHPCS_BRANCH} --update-no-dev --no-suggest --no-scripts
+    - composer require squizlabs/php_codesniffer:"${PHPCS_BRANCH}" --update-no-dev --no-suggest --no-scripts
     - |
       if [[ "${TRAVIS_BUILD_STAGE_NAME^}" == "Sniff" ]]; then
           composer install --dev --no-suggest
           # The `dev` required DealerDirect Composer plugin takes care of the installed_paths.
       else
           # The above require already does the install.
-          $(pwd)/vendor/bin/phpcs --config-set installed_paths $(pwd)
+          composer install-codestandards
       fi
     # Download PHPUnit 7.x for builds on PHP >= 7.2 as the PHPCS
     # test suite is currently not compatible with PHPUnit 8.x.

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
 	],
 	"require": {
 		"php": ">=5.4",
-		"squizlabs/php_codesniffer": "^3.3.1"
+		"squizlabs/php_codesniffer": "^3.5.0"
 	},
 	"require-dev": {
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.5 || ^0.6",

--- a/composer.json
+++ b/composer.json
@@ -16,18 +16,17 @@
 	],
 	"require": {
 		"php": ">=5.4",
-		"squizlabs/php_codesniffer": "^3.5.0"
+		"squizlabs/php_codesniffer": "^3.5.0",
+		"phpcsstandards/phpcsutils": "^1.0",
+		"phpcsstandards/phpcsextra": "^1.0"
 	},
 	"require-dev": {
-		"dealerdirect/phpcodesniffer-composer-installer": "^0.5 || ^0.6",
 		"phpcompatibility/php-compatibility": "^9.0",
 		"phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0",
 		"phpcsstandards/phpcsdevtools": "^1.0"
 	},
-	"suggest": {
-		"dealerdirect/phpcodesniffer-composer-installer": "^0.6 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
-	},
-	"minimum-stability": "RC",
+	"minimum-stability": "dev",
+	"prefer-stable": true,
 	"scripts": {
 		"check-cs": [
 			"@php ./vendor/squizlabs/php_codesniffer/bin/phpcs"


### PR DESCRIPTION
## Composer/Travis: change the minimum PHPCS version

Update the minimum required PHPCS version to `3.5.0`.

## Composer: add PHPCSUtils and PHPCSExtra as dependencies

Composer:
* Add PHPCSUtils and PHPCSExtra as dependencies.
* Remove the DealerDirect plugin from `require-dev` as well as from `suggests` as it comes with PHPCSUtils/PHPCSExtra automatically and not having it here may prevent conflicts with allowed versions in the future.

Travis:
* Alias PHPCS 4.x to `3.9.99` to allow testing with the dependencies before PHPCS 4.x is officially supported by them.
* When testing with PHPCS 4.x, we need `--prefer-source` as otherwise the test files we use from PHPCS itself won't be included.
    The way I've implemented this uses a [new feature](https://github.com/composer/composer/issues/6301) which is available since Composer 1.10.0 to selectively download from source.
    This prevents *all* packages being downloaded from source for the PHPCS `4.x` build, which would slow down the build and negate the Travis caching.


Note: the install/upgrade instructions in the Readme and other documentation will be addressed in a separate PR late in the 3.0 cycle, so as not to confuse people using the latest release, while 3.0.0 development is ongoing.

