### PR TITLE
3.0: Tests: add a bootstrap file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,6 +9,7 @@
 /phpunit.xml.dist export-ignore
 /.github export-ignore
 /bin export-ignore
+/Tests export-ignore
 /WordPress/Tests export-ignore
 
 #

--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * Bootstrap file for running the tests.
+ *
+ * - Load the PHPCS PHPUnit bootstrap file providing cross-version PHPUnit support.
+ *   {@link https://github.com/squizlabs/PHP_CodeSniffer/pull/1384}
+ * - Load the Composer autoload file.
+ * - Automatically limit the testing to the WordPressCS tests.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+if ( ! defined( 'PHP_CODESNIFFER_IN_TESTS' ) ) {
+	define( 'PHP_CODESNIFFER_IN_TESTS', true );
+}
+
+$ds = DIRECTORY_SEPARATOR;
+
+/*
+ * Load the necessary PHPCS files.
+ */
+// Get the PHPCS dir from an environment variable.
+$phpcsDir          = getenv( 'PHPCS_DIR' );
+$composerPHPCSPath = dirname( __DIR__ ) . $ds . 'vendor' . $ds . 'squizlabs' . $ds . 'php_codesniffer';
+
+if ( false === $phpcsDir && is_dir( $composerPHPCSPath ) ) {
+	// PHPCS installed via Composer.
+	$phpcsDir = $composerPHPCSPath;
+} elseif ( false !== $phpcsDir ) {
+	/*
+	 * PHPCS in a custom directory.
+	 * For this to work, the `PHPCS_DIR` needs to be set in a custom `phpunit.xml` file.
+	 */
+	$phpcsDir = realpath( $phpcsDir );
+}
+
+// Try and load the PHPCS autoloader.
+if ( false !== $phpcsDir
+	&& file_exists( $phpcsDir . $ds . 'autoload.php' )
+	&& file_exists( $phpcsDir . $ds . 'tests' . $ds . 'bootstrap.php' )
+) {
+	require_once $phpcsDir . $ds . 'autoload.php';
+	require_once $phpcsDir . $ds . 'tests' . $ds . 'bootstrap.php'; // PHPUnit 6.x+ support.
+} else {
+	echo 'Uh oh... can\'t find PHPCS.
+
+If you use Composer, please run `composer install`.
+Otherwise, make sure you set a `PHPCS_DIR` environment variable in your phpunit.xml file
+pointing to the PHPCS directory and that PHPCSUtils is included in the `installed_paths`
+for that PHPCS install.
+';
+
+	die( 1 );
+}
+
+/*
+ * Set the PHPCS_IGNORE_TEST environment variable to ignore tests from other standards.
+ */
+$wpcsStandards = array(
+	'WordPress' => true,
+);
+
+$allStandards   = PHP_CodeSniffer\Util\Standards::getInstalledStandards();
+$allStandards[] = 'Generic';
+
+$standardsToIgnore = array();
+foreach ( $allStandards as $standard ) {
+	if ( isset( $wpcsStandards[ $standard ] ) === true ) {
+		continue;
+	}
+
+	$standardsToIgnore[] = $standard;
+}
+
+$standardsToIgnoreString = implode( ',', $standardsToIgnore );
+
+// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.runtime_configuration_putenv -- This is not production, but test code.
+putenv( "PHPCS_IGNORE_TESTS={$standardsToIgnoreString}" );
+
+// Clean up.
+unset( $ds, $phpcsDir, $composerPHPCSPath, $allStandards, $standardsToIgnore, $standard, $standardsToIgnoreString );

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
 			"Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin::run"
 		],
 		"run-tests": [
-			"@php ./vendor/phpunit/phpunit/phpunit --filter WordPress --bootstrap=\"./vendor/squizlabs/php_codesniffer/tests/bootstrap.php\" ./vendor/squizlabs/php_codesniffer/tests/AllTests.php"
+			"@php ./vendor/phpunit/phpunit/phpunit --filter WordPress ./vendor/squizlabs/php_codesniffer/tests/AllTests.php"
 		],
 		"check-complete": [
 			"@php ./vendor/phpcsstandards/phpcsdevtools/bin/phpcs-check-feature-completeness -q ./WordPress"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,6 +3,7 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/6.3/phpunit.xsd"
 	backupGlobals="true"
+	bootstrap="./Tests/bootstrap.php"
 	beStrictAboutTestsThatDoNotTestAnything="false"
 	colors="true">
 
@@ -12,10 +13,4 @@
 		</testsuite>
 	</testsuites>
 
-	<php>
-		<!-- This line prevents issues with PHPCS trying to load sniff files for
-			 standards which we aren't testing.
-			 Ref: https://github.com/squizlabs/PHP_CodeSniffer/pull/1146 -->
-		<env name="PHPCS_IGNORE_TESTS" value="Generic,MySource,PEAR,PSR1,PSR2,PSR12,Squiz,Zend,PHPCompatibility"/>
-	</php>
 </phpunit>


### PR DESCRIPTION
While not strictly necessary, it makes life easier to have this bootstrap in place.

The bootstrap file will:
* Load the PHPCS autoloader (was previously done from the command-line);
* Load the Composer autoload file.
* Will automatically set the `PHPCS_IGNORE_TESTS` environment variable to the correct value to prevent running tests from other standards.

For locally running the tests after having run `composer install`, all should work fine.

For locally running the tests with a _git clone_ of PHPCS, a `phpunit.xml` overload file can be used with a `env` variable `PHPCS_DIR` to point the bootstrap to that install. Do make sure that PHPCSUtils is installed and registered in the `installed_paths` of that install if you do so.
