### PR TITLE
3.0: Tests/RestrictedClasses: compatibility with PHPCS 4.x

### DIFF
--- a/WordPress/Tests/DB/RestrictedClassesUnitTest.php
+++ b/WordPress/Tests/DB/RestrictedClassesUnitTest.php
@@ -19,6 +19,7 @@ use WordPressCS\WordPress\AbstractFunctionRestrictionsSniff;
  *
  * @since   0.10.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
+ * @since   3.0.0  Renamed the fixtures to create compatibility with PHPCS 4.x/PHPUnit >=8.
  */
 class RestrictedClassesUnitTest extends AbstractSniffUnitTest {
 
@@ -28,8 +29,10 @@ class RestrictedClassesUnitTest extends AbstractSniffUnitTest {
 	 *
 	 * Note: as that class extends the abstract FunctionRestrictions class, that's
 	 * where we are passing the parameters to.
+	 *
+	 * @before
 	 */
-	protected function setUp() {
+	protected function enhanceGroups() {
 		parent::setUp();
 
 		AbstractFunctionRestrictionsSniff::$unittest_groups = array(
@@ -46,8 +49,10 @@ class RestrictedClassesUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Reset the $groups property.
+	 *
+	 * @after
 	 */
-	protected function tearDown() {
+	protected function resetGroups() {
 		AbstractFunctionRestrictionsSniff::$unittest_groups = array();
 		parent::tearDown();
 	}


### PR DESCRIPTION
PHPCS 4.x is set up to use PHPUnit 8+, including using the `void` return type for the `setUp[BeforeClass]()` and `tearDown[AfterClass]()` fixtures.

This commit makes our tests compatible with both PHPCS 3.x as well as 4.x and with PHPUnit < 8 and 8+.

This is done by:
* Renaming the fixtures in use in our test suite to use a different method name ( = only this class).
* And using the PHPUnit `@before` and `@after` annotations, which translate to `setUp()` and `tearDown()` to get round the `void` return type requirement.

Refs:
* https://phpunit.readthedocs.io/en/7.5/annotations.html#before
* https://phpunit.readthedocs.io/en/7.5/annotations.html#after