### PR TITLE
3.0: TypeCasts: remove sniffing for `T_STRING_CAST`

### DIFF
--- a/WordPress/Sniffs/PHP/TypeCastsSniff.php
+++ b/WordPress/Sniffs/PHP/TypeCastsSniff.php
@@ -38,7 +38,6 @@ class TypeCastsSniff extends Sniff {
 		return array(
 			\T_DOUBLE_CAST,
 			\T_UNSET_CAST,
-			\T_STRING_CAST,
 			\T_BINARY_CAST,
 		);
 	}
@@ -80,12 +79,7 @@ class TypeCastsSniff extends Sniff {
 				);
 				break;
 
-			case \T_STRING_CAST:
 			case \T_BINARY_CAST:
-				if ( \T_STRING_CAST === $token_code && '(binary)' !== $typecast_lc ) {
-					break;
-				}
-
 				$this->phpcsFile->addWarning(
 					'Using binary casting is strongly discouraged. Found: "%s"',
 					$stackPtr,


### PR DESCRIPTION
That token is no longer needed as the tokenization in PHPCS upstream was fixed in PHPCS 3.4.0.

Fixes #1600