### PR TITLE
3.0: Core: replace `Generic.Arrays.DisallowShortArraySyntax` with `Universal` version

### DIFF
--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -106,7 +106,7 @@
 	#############################################################################
 	-->
 	<!-- Covers rule: Arrays must be declared using long array syntax. -->
-	<rule ref="Generic.Arrays.DisallowShortArraySyntax"/>
+	<rule ref="Universal.Arrays.DisallowShortArraySyntax"/>
 
 
 	<!--


### PR DESCRIPTION
The `Generic.Arrays.DisallowShortArraySyntax` sniff does not take short lists using square brackets `[]` into account, which leads to incorrect detection and fixing of more modern PHP code.

The `Universal.Arrays.DisallowShortArraySyntax` sniff in PHPCSExtra does take short lists into account and prevents these issues.

Fixes #1838

Ref: https://github.com/PHPCSStandards/PHPCSExtra/pull/40