### PR TITLE
3.0: Core ruleset: add PHPCSUtils requirement

### DIFF
--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -7,6 +7,15 @@
 	<arg name="tab-width" value="4"/>
 
 	<!--
+		 Trigger error if PHPCSUtils cannot be found.
+		 PHPCSUtils does not contain any sniffs, so this rule isn't strictly necessary, but
+		 by having this here anyway, if PHPCSUtils is missing, the user will get a
+		 descriptive error message during the loading of the ruleset instead of
+		 a fatal "class not found" error once the sniffs start running.
+	-->
+	<rule ref="PHPCSUtils"/>
+
+	<!--
 	#############################################################################
 	Handbook: PHP - Single and Double Quotes.
 	Ref: https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#single-and-double-quotes


### PR DESCRIPTION
PHPCSUtils does not contain any sniffs, so adding this rule isn't strictly necessary, but by having the rule in the ruleset anyway, if PHPCSUtils is missing, the user will get a descriptive error message - `ERROR: Referenced sniff "PHPCSUtils" does not exist` - during the loading of the ruleset instead of a fatal "class not found" error once the sniffs start running.

Adding this only in the `Core` ruleset is sufficient.

Both `Extra` as well as `WordPress` include `Core` and `Docs` currently doesn't use any sniffs which use PHPCSUtils, so doesn't need it.

Inspired by https://github.com/sirbrillig/phpcs-variable-analysis/issues/160