### PR TITLE
PHPCS 4.x compatibility: allow for the JS/CSS tokenizer being dropped in PHPCS 4.x

### DIFF
--- a/WordPress/Sniffs/Classes/ClassInstantiationSniff.php
+++ b/WordPress/Sniffs/Classes/ClassInstantiationSniff.php
@@ -91,8 +91,9 @@ class ClassInstantiationSniff extends Sniff {
 	 */
 	public function process_token( $stackPtr ) {
 		// Make sure we have the right token, JS vs PHP.
-		if ( ( 'PHP' === $this->phpcsFile->tokenizerType && \T_NEW !== $this->tokens[ $stackPtr ]['code'] )
-			|| ( 'JS' === $this->phpcsFile->tokenizerType
+		if ( ( ( isset( $this->phpcsFile->tokenizerType ) === false || 'PHP' === $this->phpcsFile->tokenizerType )
+				&& \T_NEW !== $this->tokens[ $stackPtr ]['code'] )
+			|| ( ( isset( $this->phpcsFile->tokenizerType ) && 'JS' === $this->phpcsFile->tokenizerType )
 				&& ( \T_STRING !== $this->tokens[ $stackPtr ]['code']
 				|| 'new' !== strtolower( $this->tokens[ $stackPtr ]['content'] ) ) )
 		) {
@@ -102,7 +103,7 @@ class ClassInstantiationSniff extends Sniff {
 		/*
 		 * Check for new by reference used in PHP files.
 		 */
-		if ( 'PHP' === $this->phpcsFile->tokenizerType ) {
+		if ( isset( $this->phpcsFile->tokenizerType ) === false || 'PHP' === $this->phpcsFile->tokenizerType ) {
 			$prev_non_empty = $this->phpcsFile->findPrevious(
 				Tokens::$emptyTokens,
 				( $stackPtr - 1 ),

--- a/WordPress/Sniffs/Utils/I18nTextDomainFixerSniff.php
+++ b/WordPress/Sniffs/Utils/I18nTextDomainFixerSniff.php
@@ -341,7 +341,7 @@ class I18nTextDomainFixerSniff extends AbstractFunctionParameterSniff {
 			// Examine for plugin/theme file header.
 			return $this->process_comments( $stackPtr );
 
-		} elseif ( 'CSS' !== $this->phpcsFile->tokenizerType ) {
+		} elseif ( isset( $this->phpcsFile->tokenizerType ) === false || 'CSS' !== $this->phpcsFile->tokenizerType ) {
 			// Examine a T_STRING token in a PHP file as a function call.
 			return parent::process_token( $stackPtr );
 		}
@@ -551,7 +551,7 @@ class I18nTextDomainFixerSniff extends AbstractFunctionParameterSniff {
 		}
 
 		$file_name = basename( $file );
-		if ( 'CSS' === $this->phpcsFile->tokenizerType ) {
+		if ( isset( $this->phpcsFile->tokenizerType ) && 'CSS' === $this->phpcsFile->tokenizerType ) {
 			if ( 'style.css' !== $file_name && ! defined( 'PHP_CODESNIFFER_IN_TESTS' ) ) {
 				// CSS files only need to be examined for the file header.
 				return ( $this->phpcsFile->numTokens + 1 );

--- a/WordPress/Tests/Classes/ClassInstantiationUnitTest.php
+++ b/WordPress/Tests/Classes/ClassInstantiationUnitTest.php
@@ -10,6 +10,7 @@
 namespace WordPressCS\WordPress\Tests\Classes;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHPCSUtils\BackCompat\Helper;
 
 /**
  * Unit test class for the ClassInstantiation sniff.
@@ -28,6 +29,9 @@ class ClassInstantiationUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of errors>
 	 */
 	public function getErrorList( $testFile = '' ) {
+
+		$phpcs_version = Helper::getVersion();
+		$is_phpcs_4    = version_compare( $phpcs_version, '3.99.99', '>' );
 
 		switch ( $testFile ) {
 			case 'ClassInstantiationUnitTest.inc':
@@ -61,9 +65,9 @@ class ClassInstantiationUnitTest extends AbstractSniffUnitTest {
 
 			case 'ClassInstantiationUnitTest.js':
 				return array(
-					2 => 1,
-					3 => 1,
-					4 => 1,
+					2 => ( true === $is_phpcs_4 ? 0 : 1 ),
+					3 => ( true === $is_phpcs_4 ? 0 : 1 ),
+					4 => ( true === $is_phpcs_4 ? 0 : 1 ),
 				);
 
 			default:

--- a/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.php
+++ b/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.php
@@ -10,6 +10,7 @@
 namespace WordPressCS\WordPress\Tests\Utils;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHPCSUtils\BackCompat\Helper;
 
 /**
  * Unit test class for the I18nTextDomainFixer sniff.
@@ -52,15 +53,18 @@ class I18nTextDomainFixerUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getErrorList( $testFile = '' ) {
 
+		$phpcs_version = Helper::getVersion();
+		$is_phpcs_4    = version_compare( $phpcs_version, '3.99.99', '>' );
+
 		switch ( $testFile ) {
 			case 'I18nTextDomainFixerUnitTest.css':
 				return array(
-					29  => 1,
-					92  => 1,
-					107 => 1,
-					120 => 1,
-					133 => 1,
-					149 => 1,
+					29  => ( true === $is_phpcs_4 ? 0 : 1 ),
+					92  => ( true === $is_phpcs_4 ? 0 : 1 ),
+					107 => ( true === $is_phpcs_4 ? 0 : 1 ),
+					120 => ( true === $is_phpcs_4 ? 0 : 1 ),
+					133 => ( true === $is_phpcs_4 ? 0 : 1 ),
+					149 => ( true === $is_phpcs_4 ? 0 : 1 ),
 				);
 
 			case 'I18nTextDomainFixerUnitTest.3.inc':

--- a/WordPress/Tests/WhiteSpace/PrecisionAlignmentUnitTest.php
+++ b/WordPress/Tests/WhiteSpace/PrecisionAlignmentUnitTest.php
@@ -10,6 +10,7 @@
 namespace WordPressCS\WordPress\Tests\WhiteSpace;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHPCSUtils\BackCompat\Helper;
 
 /**
  * Unit test class for the PrecisionAlignment sniff.
@@ -61,6 +62,9 @@ class PrecisionAlignmentUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of warnings>
 	 */
 	public function getWarningList( $testFile = '' ) {
+		$phpcs_version = Helper::getVersion();
+		$is_phpcs_4    = version_compare( $phpcs_version, '3.99.99', '>' );
+
 		switch ( $testFile ) {
 			case 'PrecisionAlignmentUnitTest.1.inc':
 				return array(
@@ -105,14 +109,14 @@ class PrecisionAlignmentUnitTest extends AbstractSniffUnitTest {
 
 			case 'PrecisionAlignmentUnitTest.css':
 				return array(
-					4 => 1,
+					4 => ( true === $is_phpcs_4 ? 0 : 1 ),
 				);
 
 			case 'PrecisionAlignmentUnitTest.js':
 				return array(
-					4 => 1,
-					5 => 1,
-					6 => 1,
+					4 => ( true === $is_phpcs_4 ? 0 : 1 ),
+					5 => ( true === $is_phpcs_4 ? 0 : 1 ),
+					6 => ( true === $is_phpcs_4 ? 0 : 1 ),
 				);
 
 			case 'PrecisionAlignmentUnitTest.2.inc':


### PR DESCRIPTION
PHPCS 4.x will completely remove the JS/CSS tokenizers and all supporting features for JS/CSS support.

Until support for PHPCS 3.x will be dropped, WPCS will continue to support sniffing JS/CSS files.

This commit addresses the current PHPCS cross-version compatibility issues related to JS/CSS sniffing in WPCS:
* Prevent "Undefined property" notices in PHPCS 4.x for when WPCS tries to access the (removed) `File::$tokenizerType` property.
* Don't expect any errors/warnings in CSS/JS files being sniffed when on PHPCS 4.x.