### PR TITLE
3.0: Remove some utility methods from the Sniff class

### DIFF
--- a/WordPress/AbstractArrayAssignmentRestrictionsSniff.php
+++ b/WordPress/AbstractArrayAssignmentRestrictionsSniff.php
@@ -9,6 +9,7 @@
 
 namespace WordPressCS\WordPress;
 
+use PHPCSUtils\Utils\TextStrings;
 use WordPressCS\WordPress\Sniff;
 
 /**
@@ -164,16 +165,16 @@ abstract class AbstractArrayAssignmentRestrictionsSniff extends Sniff {
 
 			$keyIdx = $this->phpcsFile->findPrevious( array( \T_WHITESPACE, \T_CLOSE_SQUARE_BRACKET ), ( $operator - 1 ), null, true );
 			if ( ! is_numeric( $this->tokens[ $keyIdx ]['content'] ) ) {
-				$key            = $this->strip_quotes( $this->tokens[ $keyIdx ]['content'] );
+				$key            = TextStrings::stripQuotes( $this->tokens[ $keyIdx ]['content'] );
 				$valStart       = $this->phpcsFile->findNext( array( \T_WHITESPACE ), ( $operator + 1 ), null, true );
 				$valEnd         = $this->phpcsFile->findNext( array( \T_COMMA, \T_SEMICOLON ), ( $valStart + 1 ), null, false, null, true );
 				$val            = $this->phpcsFile->getTokensAsString( $valStart, ( $valEnd - $valStart ) );
-				$val            = $this->strip_quotes( $val );
+				$val            = TextStrings::stripQuotes( $val );
 				$inst[ $key ][] = array( $val, $token['line'] );
 			}
 		} elseif ( \in_array( $token['code'], array( \T_CONSTANT_ENCAPSED_STRING, \T_DOUBLE_QUOTED_STRING ), true ) ) {
 			// $foo = 'bar=taz&other=thing';
-			if ( preg_match_all( '#(?:^|&)([a-z_]+)=([^&]*)#i', $this->strip_quotes( $token['content'] ), $matches ) <= 0 ) {
+			if ( preg_match_all( '#(?:^|&)([a-z_]+)=([^&]*)#i', TextStrings::stripQuotes( $token['content'] ), $matches ) <= 0 ) {
 				return; // No assignments here, nothing to check.
 			}
 			foreach ( $matches[1] as $i => $_k ) {

--- a/WordPress/AbstractClassRestrictionsSniff.php
+++ b/WordPress/AbstractClassRestrictionsSniff.php
@@ -9,6 +9,7 @@
 
 namespace WordPressCS\WordPress;
 
+use PHPCSUtils\Utils\Namespaces;
 use WordPressCS\WordPress\AbstractFunctionRestrictionsSniff;
 
 /**
@@ -229,7 +230,7 @@ abstract class AbstractClassRestrictionsSniff extends AbstractFunctionRestrictio
 			// No namespace keyword found at all, so global namespace.
 			$classname = '\\' . $classname;
 		} else {
-			$namespace = $this->determine_namespace( $search_from );
+			$namespace = Namespaces::determineNamespace( $this->phpcsFile, $search_from );
 
 			if ( ! empty( $namespace ) ) {
 				$classname = '\\' . $namespace . '\\' . $classname;

--- a/WordPress/AbstractFunctionParameterSniff.php
+++ b/WordPress/AbstractFunctionParameterSniff.php
@@ -9,6 +9,7 @@
 
 namespace WordPressCS\WordPress;
 
+use PHPCSUtils\Utils\PassedParameters;
 use WordPressCS\WordPress\AbstractFunctionRestrictionsSniff;
 
 /**
@@ -68,7 +69,7 @@ abstract class AbstractFunctionParameterSniff extends AbstractFunctionRestrictio
 	 */
 	public function process_matched_token( $stackPtr, $group_name, $matched_content ) {
 
-		$parameters = $this->get_function_call_parameters( $stackPtr );
+		$parameters = PassedParameters::getParameters( $this->phpcsFile, $stackPtr );
 
 		if ( empty( $parameters ) ) {
 			return $this->process_no_parameters( $stackPtr, $group_name, $matched_content );

--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -2281,7 +2281,7 @@ abstract class Sniff implements PHPCS_Sniff {
 			return true;
 		}
 
-		if ( $this->get_function_call_parameter_count( $function_ptr ) >= $this->arrayCompareFunctions[ $function_name ] ) {
+		if ( PassedParameters::getParameterCount( $this->phpcsFile, $function_ptr ) >= $this->arrayCompareFunctions[ $function_name ] ) {
 			return true;
 		}
 

--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -1828,7 +1828,7 @@ abstract class Sniff implements PHPCS_Sniff {
 				);
 
 				if ( false !== $first_non_empty && \T_CONSTANT_ENCAPSED_STRING === $this->tokens[ $first_non_empty ]['code'] ) {
-					$functionName = $this->strip_quotes( $this->tokens[ $first_non_empty ]['content'] );
+					$functionName = TextStrings::stripQuotes( $this->tokens[ $first_non_empty ]['content'] );
 				}
 			}
 		}
@@ -2035,7 +2035,7 @@ abstract class Sniff implements PHPCS_Sniff {
 			$array_keys = (array) $array_keys;
 		}
 
-		$bare_array_keys = array_map( array( $this, 'strip_quotes' ), $array_keys );
+		$bare_array_keys = array_map( array( 'PHPCSUtils\Utils\TextStrings', 'stripQuotes' ), $array_keys );
 		$targets         = array(
 			\T_ISSET          => 'construct',
 			\T_EMPTY          => 'construct',
@@ -2077,7 +2077,7 @@ abstract class Sniff implements PHPCS_Sniff {
 						// $_POST['hello']), that must match too. Quote-style, however, doesn't matter.
 						if ( ! empty( $bare_array_keys ) ) {
 							$found_keys = $this->get_array_access_keys( $i );
-							$found_keys = array_map( array( $this, 'strip_quotes' ), $found_keys );
+							$found_keys = array_map( array( 'PHPCSUtils\Utils\TextStrings', 'stripQuotes' ), $found_keys );
 							$diff       = array_diff_assoc( $bare_array_keys, $found_keys );
 							if ( ! empty( $diff ) ) {
 								continue;
@@ -2138,7 +2138,7 @@ abstract class Sniff implements PHPCS_Sniff {
 						 */
 
 						$found_keys = $this->get_array_access_keys( $param2_first_token );
-						$found_keys = array_map( array( $this, 'strip_quotes' ), $found_keys );
+						$found_keys = array_map( array( 'PHPCSUtils\Utils\TextStrings', 'stripQuotes' ), $found_keys );
 
 						// First try matching the complete set against the second parameter.
 						$diff = array_diff_assoc( $bare_array_keys, $found_keys );
@@ -2148,7 +2148,7 @@ abstract class Sniff implements PHPCS_Sniff {
 
 						// If that failed, try getting an exact match for the subset against the
 						// second parameter and the last key against the first.
-						if ( $bare_keys === $found_keys && $this->strip_quotes( $params[1]['raw'] ) === $last_key ) {
+						if ( $bare_keys === $found_keys && TextStrings::stripQuotes( $params[1]['raw'] ) === $last_key ) {
 							return true;
 						}
 
@@ -2182,7 +2182,7 @@ abstract class Sniff implements PHPCS_Sniff {
 
 					if ( ! empty( $bare_array_keys ) ) {
 						$found_keys = $this->get_array_access_keys( $prev );
-						$found_keys = array_map( array( $this, 'strip_quotes' ), $found_keys );
+						$found_keys = array_map( array( 'PHPCSUtils\Utils\TextStrings', 'stripQuotes' ), $found_keys );
 						$diff       = array_diff_assoc( $bare_array_keys, $found_keys );
 						if ( ! empty( $diff ) ) {
 							continue 2;

--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -19,7 +19,6 @@ use PHPCSUtils\Utils\Namespaces;
 use PHPCSUtils\Utils\PassedParameters;
 use PHPCSUtils\Utils\Scopes;
 use PHPCSUtils\Utils\TextStrings;
-use PHPCSUtils\Utils\UseStatements;
 
 /**
  * Represents a PHP_CodeSniffer sniff for sniffing WordPress coding standards.
@@ -2287,35 +2286,6 @@ abstract class Sniff implements PHPCS_Sniff {
 		}
 
 		return false;
-	}
-
-	/**
-	 * Check what type of 'use' statement a token is part of.
-	 *
-	 * The T_USE token has multiple different uses:
-	 *
-	 * 1. In a closure: function () use ( $var ) {}
-	 * 2. In a class, to import a trait: use Trait_Name
-	 * 3. In a namespace, to import a class: use Some\Class;
-	 *
-	 * This function will check the token and return 'closure', 'trait', or 'class',
-	 * based on which of these uses the use is being used for.
-	 *
-	 * @since      0.7.0
-	 * @deprecated 3.0.0 Use {@see PHPCSUtils\Utils\UseStatements::getType()} instead.
-	 *
-	 * @param int $stackPtr The position of the token to check.
-	 *
-	 * @return string The type of use.
-	 */
-	protected function get_use_type( $stackPtr ) {
-
-		$type = UseStatements::getType( $this->phpcsFile, $stackPtr );
-		if ( 'import' === $type ) {
-			$type = 'class';
-		}
-
-		return $type;
 	}
 
 	/**

--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -2331,29 +2331,6 @@ abstract class Sniff implements PHPCS_Sniff {
 	}
 
 	/**
-	 * Checks if a function call has parameters.
-	 *
-	 * Expects to be passed the T_STRING stack pointer for the function call.
-	 * If passed a T_STRING which is *not* a function call, the behaviour is unreliable.
-	 *
-	 * Extra feature: If passed an T_ARRAY or T_OPEN_SHORT_ARRAY stack pointer, it
-	 * will detect whether the array has values or is empty.
-	 *
-	 * @link https://github.com/PHPCompatibility/PHPCompatibility/issues/120
-	 * @link https://github.com/PHPCompatibility/PHPCompatibility/issues/152
-	 *
-	 * @since      0.11.0
-	 * @deprecated 3.0.0  Use {@see PHPCSUtils\Utils\PassedParameters::hasParameters()} instead.
-	 *
-	 * @param int $stackPtr The position of the function call token.
-	 *
-	 * @return bool
-	 */
-	public function does_function_call_have_parameters( $stackPtr ) {
-		return PassedParameters::hasParameters( $this->phpcsFile, $stackPtr );
-	}
-
-	/**
 	 * Count the number of parameters a function call has been passed.
 	 *
 	 * Expects to be passed the T_STRING stack pointer for the function call.

--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -1216,7 +1216,7 @@ abstract class Sniff implements PHPCS_Sniff {
 		}
 
 		// Is the class/trait one of the whitelisted test classes ?
-		$namespace = $this->determine_namespace( $stackPtr );
+		$namespace = Namespaces::determineNamespace( $this->phpcsFile, $stackPtr );
 		$className = $this->phpcsFile->getDeclarationName( $stackPtr );
 		if ( '' !== $namespace ) {
 			if ( isset( $whitelist[ $namespace . '\\' . $className ] ) ) {

--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -2330,20 +2330,6 @@ abstract class Sniff implements PHPCS_Sniff {
 	}
 
 	/**
-	 * Check whether a T_VARIABLE token is a class property declaration.
-	 *
-	 * @since      0.14.0
-	 * @deprecated 3.0.0  Use {@see PHPCSUtils\Utils\Scopes::isOOProperty()} instead.
-	 *
-	 * @param int $stackPtr The position in the stack of the T_VARIABLE token to verify.
-	 *
-	 * @return bool
-	 */
-	public function is_class_property( $stackPtr ) {
-		return Scopes::isOOProperty( $this->phpcsFile, $stackPtr );
-	}
-
-	/**
 	 * Check whether the direct wrapping scope of a token is within a limited set of
 	 * acceptable tokens.
 	 *

--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -2331,33 +2331,6 @@ abstract class Sniff implements PHPCS_Sniff {
 	}
 
 	/**
-	 * Get information on all parameters passed to a function call.
-	 *
-	 * Expects to be passed the T_STRING stack pointer for the function call.
-	 * If passed a T_STRING which is *not* a function call, the behaviour is unreliable.
-	 *
-	 * Extra feature: If passed an T_ARRAY or T_OPEN_SHORT_ARRAY stack pointer,
-	 * it will tokenize the values / key/value pairs contained in the array call.
-	 *
-	 * @since      0.11.0
-	 * @deprecated 3.0.0  Use {@see PHPCSUtils\Utils\PassedParameters::getParameters()} instead.
-	 *
-	 * @param int $stackPtr The position of the function call token.
-	 *
-	 * @return array Multi-dimentional array with parameter details or
-	 *               empty array if no parameters are found.
-	 *
-	 *               @type int $position 1-based index position of the parameter. {
-	 *                   @type int $start Stack pointer for the start of the parameter.
-	 *                   @type int $end   Stack pointer for the end of parameter.
-	 *                   @type int $raw   Trimmed raw parameter content.
-	 *               }
-	 */
-	public function get_function_call_parameters( $stackPtr ) {
-		return PassedParameters::getParameters( $this->phpcsFile, $stackPtr );
-	}
-
-	/**
 	 * Get information on a specific parameter passed to a function call.
 	 *
 	 * Expects to be passed the T_STRING stack pointer for the function call.

--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -2330,22 +2330,6 @@ abstract class Sniff implements PHPCS_Sniff {
 	}
 
 	/**
-	 * Find the list opener & closer based on a T_LIST or T_OPEN_SHORT_ARRAY token.
-	 *
-	 * @since      2.2.0
-	 * @deprecated 3.0.0 Use {@see PHPCSUtils\Utils\Lists::getOpenClose()} instead.
-	 *
-	 * @param int $stackPtr The stack pointer to the array token.
-	 *
-	 * @return array|bool Array with two keys `opener`, `closer` or false if
-	 *                    not a (short) list token or if either or these
-	 *                    could not be determined.
-	 */
-	protected function find_list_open_close( $stackPtr ) {
-		return Lists::getOpenClose( $this->phpcsFile, $stackPtr );
-	}
-
-	/**
 	 * Determine the namespace name an arbitrary token lives in.
 	 *
 	 * @since      0.10.0

--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -2331,28 +2331,6 @@ abstract class Sniff implements PHPCS_Sniff {
 	}
 
 	/**
-	 * Get information on a specific parameter passed to a function call.
-	 *
-	 * Expects to be passed the T_STRING stack pointer for the function call.
-	 * If passed a T_STRING which is *not* a function call, the behaviour is unreliable.
-	 *
-	 * Will return a array with the start token pointer, end token pointer and the raw value
-	 * of the parameter at a specific offset.
-	 * If the specified parameter is not found, will return false.
-	 *
-	 * @since      0.11.0
-	 * @deprecated 3.0.0  Use {@see PHPCSUtils\Utils\PassedParameters::getParameter()} instead.
-	 *
-	 * @param int $stackPtr     The position of the function call token.
-	 * @param int $param_offset The 1-based index position of the parameter to retrieve.
-	 *
-	 * @return array|false
-	 */
-	public function get_function_call_parameter( $stackPtr, $param_offset ) {
-		return PassedParameters::getParameter( $this->phpcsFile, $stackPtr, $param_offset );
-	}
-
-	/**
 	 * Find the array opener & closer based on a T_ARRAY or T_OPEN_SHORT_ARRAY token.
 	 *
 	 * @since      0.12.0

--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -2330,21 +2330,6 @@ abstract class Sniff implements PHPCS_Sniff {
 	}
 
 	/**
-	 * Determine the namespace name an arbitrary token lives in.
-	 *
-	 * @since      0.10.0
-	 * @since      0.12.0 Moved from the `AbstractClassRestrictionsSniff` to this class.
-	 * @deprecated 3.0.0  Use {@see PHPCSUtils\Utils\Namespaces::determineNamespace()} instead.
-	 *
-	 * @param int $stackPtr The token position for which to determine the namespace.
-	 *
-	 * @return string Namespace name or empty string if it couldn't be determined or no namespace applies.
-	 */
-	public function determine_namespace( $stackPtr ) {
-		return Namespaces::determineNamespace( $this->phpcsFile, $stackPtr );
-	}
-
-	/**
 	 * Get the complete namespace name for a namespace declaration.
 	 *
 	 * For hierarchical namespaces, the name will be composed of several tokens,

--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -2097,7 +2097,7 @@ abstract class Sniff implements PHPCS_Sniff {
 						continue 2;
 					}
 
-					$params = $this->get_function_call_parameters( $i );
+					$params = PassedParameters::getParameters( $this->phpcsFile, $i );
 					if ( count( $params ) < 2 ) {
 						continue 2;
 					}

--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -2555,25 +2555,6 @@ abstract class Sniff implements PHPCS_Sniff {
 	}
 
 	/**
-	 * Determine whether a T_OPEN/CLOSE_SHORT_ARRAY token is a short list() construct.
-	 *
-	 * @internal This function will be introduced in PHPCS upstream in version 3.5.0
-	 * and can be removed from WPCS once WPCS raises the minimum version.
-	 *
-	 * @since      2.2.0
-	 * @deprecated 3.0.0  Use {@see PHPCSUtils\Utils\Lists::isShortList()} instead.
-	 *
-	 * @param int $stackPtr The position of the array bracket token.
-	 *
-	 * @return bool True if the token passed is the open/close bracket of a short list.
-	 *              False if the token is a short array bracket or not
-	 *              a T_OPEN/CLOSE_SHORT_ARRAY token.
-	 */
-	protected function is_short_list( $stackPtr ) {
-		return Lists::isShortList( $this->phpcsFile, $stackPtr );
-	}
-
-	/**
 	 * Get a list of the token pointers to the variables being assigned to in a list statement.
 	 *
 	 * @internal No need to take special measures for nested lists. Nested or not,

--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -2330,20 +2330,6 @@ abstract class Sniff implements PHPCS_Sniff {
 	}
 
 	/**
-	 * Check whether a T_CONST token is a class constant declaration.
-	 *
-	 * @since      0.14.0
-	 * @deprecated 3.0.0  Use {@see PHPCSUtils\Utils\Scopes::isOOConstant()} instead.
-	 *
-	 * @param int $stackPtr The position in the stack of the T_CONST token to verify.
-	 *
-	 * @return bool
-	 */
-	public function is_class_constant( $stackPtr ) {
-		return Scopes::isOOConstant( $this->phpcsFile, $stackPtr );
-	}
-
-	/**
 	 * Check whether a T_VARIABLE token is a class property declaration.
 	 *
 	 * @since      0.14.0

--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -2330,27 +2330,6 @@ abstract class Sniff implements PHPCS_Sniff {
 	}
 
 	/**
-	 * Check whether the direct wrapping scope of a token is within a limited set of
-	 * acceptable tokens.
-	 *
-	 * Used to check, for instance, if a T_CONST is a class constant.
-	 *
-	 * @since      0.14.0
-	 * @deprecated 3.0.0  Use {@see PHPCSUtils\Utils\Scopes::validDirectScope()} instead.
-	 *
-	 * @param int   $stackPtr     The position in the stack of the token to verify.
-	 * @param array $valid_scopes Array of token types.
-	 *                            Keys should be the token types in string format
-	 *                            to allow for newer token types.
-	 *                            Value is irrelevant.
-	 *
-	 * @return int|bool StackPtr to the scope if valid, false otherwise.
-	 */
-	protected function valid_direct_scope( $stackPtr, array $valid_scopes ) {
-		return Scopes::validDirectScope( $this->phpcsFile, $stackPtr, $valid_scopes );
-	}
-
-	/**
 	 * Checks whether this is a call to a $wpdb method that we want to sniff.
 	 *
 	 * If available in the child class, the $methodPtr, $i and $end properties are

--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -2330,25 +2330,6 @@ abstract class Sniff implements PHPCS_Sniff {
 	}
 
 	/**
-	 * Get the complete namespace name for a namespace declaration.
-	 *
-	 * For hierarchical namespaces, the name will be composed of several tokens,
-	 * i.e. MyProject\Sub\Level which will be returned together as one string.
-	 *
-	 * @since      0.12.0 A lesser variant of this method previously existed in the
-	 *                    `AbstractClassRestrictionsSniff` class.
-	 * @deprecated 3.0.0  Use {@see PHPCSUtils\Utils\Namespaces::getDeclaredName()} instead.
-	 *
-	 * @param int|bool $stackPtr The position of a T_NAMESPACE token.
-	 *
-	 * @return string|false Namespace name or false if not a namespace declaration.
-	 *                      Namespace name can be an empty string for global namespace declaration.
-	 */
-	public function get_declared_namespace_name( $stackPtr ) {
-		return Namespaces::getDeclaredName( $this->phpcsFile, $stackPtr );
-	}
-
-	/**
 	 * Check whether a T_CONST token is a class constant declaration.
 	 *
 	 * @since      0.14.0

--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -13,7 +13,6 @@ use PHP_CodeSniffer\Sniffs\Sniff as PHPCS_Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\BackCompat\Helper;
-use PHPCSUtils\Utils\Arrays;
 use PHPCSUtils\Utils\Lists;
 use PHPCSUtils\Utils\Namespaces;
 use PHPCSUtils\Utils\PassedParameters;
@@ -2328,21 +2327,6 @@ abstract class Sniff implements PHPCS_Sniff {
 		}
 
 		return preg_replace( self::REGEX_COMPLEX_VARS, '', $string );
-	}
-
-	/**
-	 * Find the array opener & closer based on a T_ARRAY or T_OPEN_SHORT_ARRAY token.
-	 *
-	 * @since      0.12.0
-	 * @deprecated 3.0.0 Use {@see PHPCSUtils\Utils\Arrays::getOpenClose()} instead.
-	 *
-	 * @param int $stackPtr The stack pointer to the array token.
-	 *
-	 * @return array|bool Array with two keys `opener`, `closer` or false if
-	 *                    either or these could not be determined.
-	 */
-	protected function find_array_open_close( $stackPtr ) {
-		return Arrays::getOpenClose( $this->phpcsFile, $stackPtr );
 	}
 
 	/**

--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -945,21 +945,6 @@ abstract class Sniff implements PHPCS_Sniff {
 	}
 
 	/**
-	 * Strip quotes surrounding an arbitrary string.
-	 *
-	 * Intended for use with the contents of a T_CONSTANT_ENCAPSED_STRING / T_DOUBLE_QUOTED_STRING.
-	 *
-	 * @since      0.11.0
-	 * @deprecated 3.0.0  Use {@see PHPCSUtils\Utils\TextStrings::stripQuotes()} instead.
-	 *
-	 * @param string $string The raw string.
-	 * @return string String without quotes around it.
-	 */
-	public function strip_quotes( $string ) {
-		return TextStrings::stripQuotes( $string );
-	}
-
-	/**
 	 * Add a PHPCS message to the output stack as either a warning or an error.
 	 *
 	 * @since 0.11.0

--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -2531,7 +2531,7 @@ abstract class Sniff implements PHPCS_Sniff {
 
 		if ( false !== $prev
 			&& \T_CONST === $this->tokens[ $prev ]['code']
-			&& $this->is_class_constant( $prev )
+			&& Scopes::isOOConstant( $this->phpcsFile, $prev )
 		) {
 			// Class constant declaration of the same name.
 			return false;

--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -2696,7 +2696,7 @@ abstract class Sniff implements PHPCS_Sniff {
 		}
 
 		if ( empty( $list_open_close ) ) {
-			$list_open_close = $this->find_list_open_close( $stackPtr );
+			$list_open_close = Lists::getOpenClose( $this->phpcsFile, $stackPtr );
 			if ( false === $list_open_close ) {
 				// Not a (short) list.
 				return array();

--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -1483,7 +1483,7 @@ abstract class Sniff implements PHPCS_Sniff {
 
 		$functionPtr = $this->is_in_function_call( $stackPtr, $valid_functions );
 		if ( false !== $functionPtr ) {
-			$second_param = $this->get_function_call_parameter( $functionPtr, 2 );
+			$second_param = PassedParameters::getParameter( $this->phpcsFile, $functionPtr, 2 );
 			if ( $stackPtr >= $second_param['start'] && $stackPtr <= $second_param['end'] ) {
 				return true;
 			}
@@ -1797,7 +1797,7 @@ abstract class Sniff implements PHPCS_Sniff {
 		if ( isset( $this->arrayWalkingFunctions[ $functionName ] ) ) {
 
 			// Get the callback parameter.
-			$callback = $this->get_function_call_parameter( $functionPtr, $this->arrayWalkingFunctions[ $functionName ] );
+			$callback = PassedParameters::getParameter( $this->phpcsFile, $functionPtr, $this->arrayWalkingFunctions[ $functionName ] );
 
 			if ( ! empty( $callback ) ) {
 				/*

--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -2331,30 +2331,6 @@ abstract class Sniff implements PHPCS_Sniff {
 	}
 
 	/**
-	 * Count the number of parameters a function call has been passed.
-	 *
-	 * Expects to be passed the T_STRING stack pointer for the function call.
-	 * If passed a T_STRING which is *not* a function call, the behaviour is unreliable.
-	 *
-	 * Extra feature: If passed an T_ARRAY or T_OPEN_SHORT_ARRAY stack pointer,
-	 * it will return the number of values in the array.
-	 *
-	 * @link https://github.com/PHPCompatibility/PHPCompatibility/issues/111
-	 * @link https://github.com/PHPCompatibility/PHPCompatibility/issues/114
-	 * @link https://github.com/PHPCompatibility/PHPCompatibility/issues/151
-	 *
-	 * @since      0.11.0
-	 * @deprecated 3.0.0  Use {@see PHPCSUtils\Utils\PassedParameters::getParameterCount()} instead.
-	 *
-	 * @param int $stackPtr The position of the function call token.
-	 *
-	 * @return int
-	 */
-	public function get_function_call_parameter_count( $stackPtr ) {
-		return PassedParameters::getParameterCount( $this->phpcsFile, $stackPtr );
-	}
-
-	/**
 	 * Get information on all parameters passed to a function call.
 	 *
 	 * Expects to be passed the T_STRING stack pointer for the function call.

--- a/WordPress/Sniffs/Arrays/ArrayDeclarationSpacingSniff.php
+++ b/WordPress/Sniffs/Arrays/ArrayDeclarationSpacingSniff.php
@@ -11,6 +11,7 @@ namespace WordPressCS\WordPress\Sniffs\Arrays;
 
 use WordPressCS\WordPress\Sniff;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Utils\Arrays;
 use PHPCSUtils\Utils\PassedParameters;
 
 /**
@@ -99,7 +100,7 @@ class ArrayDeclarationSpacingSniff extends Sniff {
 		/*
 		 * Determine the array opener & closer.
 		 */
-		$array_open_close = $this->find_array_open_close( $stackPtr );
+		$array_open_close = Arrays::getOpenClose( $this->phpcsFile, $stackPtr );
 		if ( false === $array_open_close ) {
 			// Array open/close could not be determined.
 			return;
@@ -214,7 +215,7 @@ class ArrayDeclarationSpacingSniff extends Sniff {
 
 						// Skip passed any nested arrays.
 						if ( isset( $this->targets[ $this->tokens[ $ptr ]['code'] ] ) ) {
-							$nested_array_open_close = $this->find_array_open_close( $ptr );
+							$nested_array_open_close = Arrays::getOpenClose( $this->phpcsFile, $ptr );
 							if ( false === $nested_array_open_close ) {
 								// Nested array open/close could not be determined.
 								continue;

--- a/WordPress/Sniffs/Arrays/ArrayDeclarationSpacingSniff.php
+++ b/WordPress/Sniffs/Arrays/ArrayDeclarationSpacingSniff.php
@@ -11,6 +11,7 @@ namespace WordPressCS\WordPress\Sniffs\Arrays;
 
 use WordPressCS\WordPress\Sniff;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Utils\PassedParameters;
 
 /**
  * Enforces WordPress array spacing format.
@@ -193,7 +194,7 @@ class ArrayDeclarationSpacingSniff extends Sniff {
 		$array_has_keys = $this->phpcsFile->findNext( \T_DOUBLE_ARROW, $opener, $closer );
 		if ( false !== $array_has_keys ) {
 
-			$array_items = $this->get_function_call_parameters( $stackPtr );
+			$array_items = PassedParameters::getParameters( $this->phpcsFile, $stackPtr );
 
 			if ( ( false === $this->allow_single_item_single_line_associative_arrays
 					&& ! empty( $array_items ) )
@@ -375,7 +376,7 @@ class ArrayDeclarationSpacingSniff extends Sniff {
 		/*
 		 * Check that each array item starts on a new line.
 		 */
-		$array_items      = $this->get_function_call_parameters( $stackPtr );
+		$array_items      = PassedParameters::getParameters( $this->phpcsFile, $stackPtr );
 		$end_of_last_item = $opener;
 
 		foreach ( $array_items as $item ) {

--- a/WordPress/Sniffs/Arrays/ArrayDeclarationSpacingSniff.php
+++ b/WordPress/Sniffs/Arrays/ArrayDeclarationSpacingSniff.php
@@ -91,7 +91,7 @@ class ArrayDeclarationSpacingSniff extends Sniff {
 	public function process_token( $stackPtr ) {
 
 		if ( \T_OPEN_SHORT_ARRAY === $this->tokens[ $stackPtr ]['code']
-			&& $this->is_short_list( $stackPtr )
+			&& Arrays::isShortArray( $this->phpcsFile, $stackPtr ) === false
 		) {
 			// Short list, not short array.
 			return;

--- a/WordPress/Sniffs/Arrays/ArrayIndentationSniff.php
+++ b/WordPress/Sniffs/Arrays/ArrayIndentationSniff.php
@@ -12,6 +12,7 @@ namespace WordPressCS\WordPress\Sniffs\Arrays;
 use WordPressCS\WordPress\Sniff;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\BackCompat\Helper;
+use PHPCSUtils\Utils\Arrays;
 use PHPCSUtils\Utils\PassedParameters;
 
 /**
@@ -104,7 +105,7 @@ class ArrayIndentationSniff extends Sniff {
 		/*
 		 * Determine the array opener & closer.
 		 */
-		$array_open_close = $this->find_array_open_close( $stackPtr );
+		$array_open_close = Arrays::getOpenClose( $this->phpcsFile, $stackPtr );
 		if ( false === $array_open_close ) {
 			// Array open/close could not be determined.
 			return;

--- a/WordPress/Sniffs/Arrays/ArrayIndentationSniff.php
+++ b/WordPress/Sniffs/Arrays/ArrayIndentationSniff.php
@@ -12,6 +12,7 @@ namespace WordPressCS\WordPress\Sniffs\Arrays;
 use WordPressCS\WordPress\Sniff;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\BackCompat\Helper;
+use PHPCSUtils\Utils\PassedParameters;
 
 /**
  * Enforces WordPress array indentation for multi-line arrays.
@@ -165,7 +166,7 @@ class ArrayIndentationSniff extends Sniff {
 		/*
 		 * Verify & correct the array item indentation.
 		 */
-		$array_items = $this->get_function_call_parameters( $stackPtr );
+		$array_items = PassedParameters::getParameters( $this->phpcsFile, $stackPtr );
 		if ( empty( $array_items ) ) {
 			// Strange, no array items found.
 			return;

--- a/WordPress/Sniffs/Arrays/ArrayIndentationSniff.php
+++ b/WordPress/Sniffs/Arrays/ArrayIndentationSniff.php
@@ -96,7 +96,7 @@ class ArrayIndentationSniff extends Sniff {
 		}
 
 		if ( \T_OPEN_SHORT_ARRAY === $this->tokens[ $stackPtr ]['code']
-			&& $this->is_short_list( $stackPtr )
+			&& Arrays::isShortArray( $this->phpcsFile, $stackPtr ) === false
 		) {
 			// Short list, not short array.
 			return;

--- a/WordPress/Sniffs/Arrays/CommaAfterArrayItemSniff.php
+++ b/WordPress/Sniffs/Arrays/CommaAfterArrayItemSniff.php
@@ -11,6 +11,7 @@ namespace WordPressCS\WordPress\Sniffs\Arrays;
 
 use WordPressCS\WordPress\Sniff;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Utils\Arrays;
 use PHPCSUtils\Utils\PassedParameters;
 
 /**
@@ -63,7 +64,7 @@ class CommaAfterArrayItemSniff extends Sniff {
 		/*
 		 * Determine the array opener & closer.
 		 */
-		$array_open_close = $this->find_array_open_close( $stackPtr );
+		$array_open_close = Arrays::getOpenClose( $this->phpcsFile, $stackPtr );
 		if ( false === $array_open_close ) {
 			// Array open/close could not be determined.
 			return;

--- a/WordPress/Sniffs/Arrays/CommaAfterArrayItemSniff.php
+++ b/WordPress/Sniffs/Arrays/CommaAfterArrayItemSniff.php
@@ -11,6 +11,7 @@ namespace WordPressCS\WordPress\Sniffs\Arrays;
 
 use WordPressCS\WordPress\Sniff;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Utils\PassedParameters;
 
 /**
  * Enforces a comma after each array item and the spacing around it.
@@ -82,7 +83,7 @@ class CommaAfterArrayItemSniff extends Sniff {
 			$single_line = false;
 		}
 
-		$array_items = $this->get_function_call_parameters( $stackPtr );
+		$array_items = PassedParameters::getParameters( $this->phpcsFile, $stackPtr );
 		if ( empty( $array_items ) ) {
 			// Strange, no array items found.
 			return;

--- a/WordPress/Sniffs/Arrays/CommaAfterArrayItemSniff.php
+++ b/WordPress/Sniffs/Arrays/CommaAfterArrayItemSniff.php
@@ -55,7 +55,7 @@ class CommaAfterArrayItemSniff extends Sniff {
 	public function process_token( $stackPtr ) {
 
 		if ( \T_OPEN_SHORT_ARRAY === $this->tokens[ $stackPtr ]['code']
-			&& $this->is_short_list( $stackPtr )
+			&& Arrays::isShortArray( $this->phpcsFile, $stackPtr ) === false
 		) {
 			// Short list, not short array.
 			return;

--- a/WordPress/Sniffs/Arrays/MultipleStatementAlignmentSniff.php
+++ b/WordPress/Sniffs/Arrays/MultipleStatementAlignmentSniff.php
@@ -9,6 +9,7 @@
 
 namespace WordPressCS\WordPress\Sniffs\Arrays;
 
+use PHPCSUtils\Utils\Arrays;
 use PHPCSUtils\Utils\PassedParameters;
 use WordPressCS\WordPress\Sniff;
 
@@ -176,7 +177,7 @@ class MultipleStatementAlignmentSniff extends Sniff {
 		/*
 		 * Determine the array opener & closer.
 		 */
-		$array_open_close = $this->find_array_open_close( $stackPtr );
+		$array_open_close = Arrays::getOpenClose( $this->phpcsFile, $stackPtr );
 		if ( false === $array_open_close ) {
 			// Array open/close could not be determined.
 			return;

--- a/WordPress/Sniffs/Arrays/MultipleStatementAlignmentSniff.php
+++ b/WordPress/Sniffs/Arrays/MultipleStatementAlignmentSniff.php
@@ -9,6 +9,7 @@
 
 namespace WordPressCS\WordPress\Sniffs\Arrays;
 
+use PHPCSUtils\Utils\PassedParameters;
 use WordPressCS\WordPress\Sniff;
 
 /**
@@ -184,7 +185,7 @@ class MultipleStatementAlignmentSniff extends Sniff {
 		$opener = $array_open_close['opener'];
 		$closer = $array_open_close['closer'];
 
-		$array_items = $this->get_function_call_parameters( $stackPtr );
+		$array_items = PassedParameters::getParameters( $this->phpcsFile, $stackPtr );
 		if ( empty( $array_items ) ) {
 			return;
 		}

--- a/WordPress/Sniffs/Arrays/MultipleStatementAlignmentSniff.php
+++ b/WordPress/Sniffs/Arrays/MultipleStatementAlignmentSniff.php
@@ -168,7 +168,7 @@ class MultipleStatementAlignmentSniff extends Sniff {
 	public function process_token( $stackPtr ) {
 
 		if ( \T_OPEN_SHORT_ARRAY === $this->tokens[ $stackPtr ]['code']
-			&& $this->is_short_list( $stackPtr )
+			&& Arrays::isShortArray( $this->phpcsFile, $stackPtr ) === false
 		) {
 			// Short list, not short array.
 			return;

--- a/WordPress/Sniffs/DB/PreparedSQLPlaceholdersSniff.php
+++ b/WordPress/Sniffs/DB/PreparedSQLPlaceholdersSniff.php
@@ -11,6 +11,7 @@ namespace WordPressCS\WordPress\Sniffs\DB;
 
 use WordPressCS\WordPress\Sniff;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Utils\TextStrings;
 
 /**
  * Check for incorrect use of the $wpdb->prepare method.
@@ -229,7 +230,7 @@ class PreparedSQLPlaceholdersSniff extends Sniff {
 							$query['start']
 						);
 
-						$prev_content = $this->strip_quotes( $this->tokens[ $prev ]['content'] );
+						$prev_content = TextStrings::stripQuotes( $this->tokens[ $prev ]['content'] );
 						$regex_quote  = $this->get_regex_quote_snippet( $prev_content, $this->tokens[ $prev ]['content'] );
 
 						// Only examine the implode if preceded by an ` IN (`.
@@ -268,7 +269,7 @@ class PreparedSQLPlaceholdersSniff extends Sniff {
 
 			$regex_quote = $this->regex_quote;
 			if ( isset( Tokens::$stringTokens[ $this->tokens[ $i ]['code'] ] ) ) {
-				$content     = $this->strip_quotes( $content );
+				$content     = TextStrings::stripQuotes( $content );
 				$regex_quote = $this->get_regex_quote_snippet( $content, $this->tokens[ $i ]['content'] );
 			}
 

--- a/WordPress/Sniffs/DB/PreparedSQLPlaceholdersSniff.php
+++ b/WordPress/Sniffs/DB/PreparedSQLPlaceholdersSniff.php
@@ -11,6 +11,7 @@ namespace WordPressCS\WordPress\Sniffs\DB;
 
 use WordPressCS\WordPress\Sniff;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Utils\PassedParameters;
 use PHPCSUtils\Utils\TextStrings;
 
 /**
@@ -175,7 +176,7 @@ class PreparedSQLPlaceholdersSniff extends Sniff {
 			return;
 		}
 
-		$parameters = $this->get_function_call_parameters( $this->methodPtr );
+		$parameters = PassedParameters::getParameters( $this->phpcsFile, $this->methodPtr );
 		if ( empty( $parameters ) ) {
 			return;
 		}
@@ -211,7 +212,7 @@ class PreparedSQLPlaceholdersSniff extends Sniff {
 				if ( \T_STRING === $this->tokens[ $i ]['code'] ) {
 
 					if ( 'sprintf' === strtolower( $this->tokens[ $i ]['content'] ) ) {
-						$sprintf_parameters = $this->get_function_call_parameters( $i );
+						$sprintf_parameters = PassedParameters::getParameters( $this->phpcsFile, $i );
 
 						if ( ! empty( $sprintf_parameters ) ) {
 							$skip_from  = ( $sprintf_parameters[1]['end'] + 1 );
@@ -498,7 +499,7 @@ class PreparedSQLPlaceholdersSniff extends Sniff {
 				&& ( \T_ARRAY === $this->tokens[ $next ]['code']
 					|| \T_OPEN_SHORT_ARRAY === $this->tokens[ $next ]['code'] )
 			) {
-				$replacements = $this->get_function_call_parameters( $next );
+				$replacements = PassedParameters::getParameters( $this->phpcsFile, $next );
 			}
 		}
 
@@ -614,7 +615,7 @@ class PreparedSQLPlaceholdersSniff extends Sniff {
 	 * @return bool True if the pattern is found, false otherwise.
 	 */
 	protected function analyse_implode( $implode_token ) {
-		$implode_params = $this->get_function_call_parameters( $implode_token );
+		$implode_params = PassedParameters::getParameters( $this->phpcsFile, $implode_token );
 
 		if ( empty( $implode_params ) || \count( $implode_params ) !== 2 ) {
 			return false;
@@ -641,7 +642,7 @@ class PreparedSQLPlaceholdersSniff extends Sniff {
 			return false;
 		}
 
-		$array_fill_params = $this->get_function_call_parameters( $array_fill );
+		$array_fill_params = PassedParameters::getParameters( $this->phpcsFile, $array_fill );
 
 		if ( empty( $array_fill_params ) || \count( $array_fill_params ) !== 3 ) {
 			return false;

--- a/WordPress/Sniffs/DateTime/CurrentTimeTimestampSniff.php
+++ b/WordPress/Sniffs/DateTime/CurrentTimeTimestampSniff.php
@@ -11,6 +11,7 @@ namespace WordPressCS\WordPress\Sniffs\DateTime;
 
 use WordPressCS\WordPress\AbstractFunctionParameterSniff;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Utils\TextStrings;
 
 /**
  * Don't use current_time() to get a (timezone corrected) "timestamp".
@@ -79,7 +80,7 @@ class CurrentTimeTimestampSniff extends AbstractFunctionParameterSniff {
 			}
 
 			if ( isset( Tokens::$textStringTokens[ $this->tokens[ $i ]['code'] ] ) ) {
-				$content_first = trim( $this->strip_quotes( $this->tokens[ $i ]['content'] ) );
+				$content_first = trim( TextStrings::stripQuotes( $this->tokens[ $i ]['content'] ) );
 				if ( 'U' !== $content_first && 'timestamp' !== $content_first ) {
 					// Most likely valid use of current_time().
 					return;

--- a/WordPress/Sniffs/Files/FileNameSniff.php
+++ b/WordPress/Sniffs/Files/FileNameSniff.php
@@ -9,6 +9,7 @@
 
 namespace WordPressCS\WordPress\Sniffs\Files;
 
+use PHPCSUtils\Utils\TextStrings;
 use WordPressCS\WordPress\Sniff;
 
 /**
@@ -138,8 +139,8 @@ class FileNameSniff extends Sniff {
 	 */
 	public function process_token( $stackPtr ) {
 
-		// Usage of `strip_quotes` is to ensure `stdin_path` passed by IDEs does not include quotes.
-		$file = $this->strip_quotes( $this->phpcsFile->getFileName() );
+		// Usage of `stripQuotes` is to ensure `stdin_path` passed by IDEs does not include quotes.
+		$file = TextStrings::stripQuotes( $this->phpcsFile->getFileName() );
 		if ( 'STDIN' === $file ) {
 			return;
 		}

--- a/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
+++ b/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
@@ -12,6 +12,7 @@ namespace WordPressCS\WordPress\Sniffs\NamingConventions;
 use WordPressCS\WordPress\AbstractFunctionParameterSniff;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\BackCompat\Helper;
+use PHPCSUtils\Utils\TextStrings;
 
 /**
  * Verify that everything defined in the global namespace is prefixed with a theme/plugin specific prefix.
@@ -641,7 +642,7 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 			}
 
 			$stackPtr      = $array_key;
-			$variable_name = $this->strip_quotes( $this->tokens[ $array_key ]['content'] );
+			$variable_name = TextStrings::stripQuotes( $this->tokens[ $array_key ]['content'] );
 
 			// Check whether a prefix is needed.
 			if ( isset( Tokens::$stringTokens[ $this->tokens[ $array_key ]['code'] ] )
@@ -792,7 +793,7 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 		}
 
 		$is_error    = true;
-		$raw_content = $this->strip_quotes( $parameters[1]['raw'] );
+		$raw_content = TextStrings::stripQuotes( $parameters[1]['raw'] );
 
 		if ( ( 'define' !== $matched_content
 			&& isset( $this->whitelisted_core_hooks[ $raw_content ] ) )
@@ -817,7 +818,7 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 				return;
 			}
 
-			$first_non_empty_content = $this->strip_quotes( $this->tokens[ $first_non_empty ]['content'] );
+			$first_non_empty_content = TextStrings::stripQuotes( $this->tokens[ $first_non_empty ]['content'] );
 
 			// Try again with just the first token if it's a text string.
 			if ( isset( Tokens::$stringTokens[ $this->tokens[ $first_non_empty ]['code'] ] )

--- a/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
+++ b/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
@@ -321,7 +321,7 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 			return $this->process_list_assignment( $stackPtr );
 
 		} elseif ( \T_NAMESPACE === $this->tokens[ $stackPtr ]['code'] ) {
-			$namespace_name = $this->get_declared_namespace_name( $stackPtr );
+			$namespace_name = Namespaces::getDeclaredName( $this->phpcsFile, $stackPtr );
 
 			if ( false === $namespace_name || '' === $namespace_name || '\\' === $namespace_name ) {
 				return;

--- a/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
+++ b/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
@@ -686,7 +686,7 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 			}
 
 			// Properties in a class do not need to be prefixed.
-			if ( false === $in_list && true === $this->is_class_property( $stackPtr ) ) {
+			if ( false === $in_list && true === Scopes::isOOProperty( $this->phpcsFile, $stackPtr ) ) {
 				return;
 			}
 

--- a/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
+++ b/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
@@ -12,6 +12,7 @@ namespace WordPressCS\WordPress\Sniffs\NamingConventions;
 use WordPressCS\WordPress\AbstractFunctionParameterSniff;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\BackCompat\Helper;
+use PHPCSUtils\Utils\Lists;
 use PHPCSUtils\Utils\TextStrings;
 
 /**
@@ -758,7 +759,7 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 	 *                  normal file processing.
 	 */
 	protected function process_list_assignment( $stackPtr ) {
-		$list_open_close = $this->find_list_open_close( $stackPtr );
+		$list_open_close = Lists::getOpenClose( $this->phpcsFile, $stackPtr );
 		if ( false === $list_open_close ) {
 			// Short array, not short list.
 			return;

--- a/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
+++ b/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
@@ -14,6 +14,7 @@ use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\BackCompat\Helper;
 use PHPCSUtils\Utils\Lists;
 use PHPCSUtils\Utils\Namespaces;
+use PHPCSUtils\Utils\Scopes;
 use PHPCSUtils\Utils\TextStrings;
 
 /**
@@ -443,7 +444,7 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 
 				case 'T_CONST':
 					// Constants in a class do not need to be prefixed.
-					if ( true === $this->is_class_constant( $stackPtr ) ) {
+					if ( true === Scopes::isOOConstant( $this->phpcsFile, $stackPtr ) ) {
 						return;
 					}
 

--- a/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
+++ b/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
@@ -13,6 +13,7 @@ use WordPressCS\WordPress\AbstractFunctionParameterSniff;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\BackCompat\Helper;
 use PHPCSUtils\Utils\Lists;
+use PHPCSUtils\Utils\Namespaces;
 use PHPCSUtils\Utils\TextStrings;
 
 /**
@@ -362,7 +363,7 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 		} else {
 
 			// Namespaced methods, classes and constants do not need to be prefixed.
-			$namespace = $this->determine_namespace( $stackPtr );
+			$namespace = Namespaces::determineNamespace( $this->phpcsFile, $stackPtr );
 			if ( '' !== $namespace && '\\' !== $namespace ) {
 				return;
 			}

--- a/WordPress/Sniffs/NamingConventions/ValidHookNameSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidHookNameSniff.php
@@ -11,6 +11,7 @@ namespace WordPressCS\WordPress\Sniffs\NamingConventions;
 
 use WordPressCS\WordPress\AbstractFunctionParameterSniff;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Utils\TextStrings;
 
 /**
  * Use lowercase letters in action and filter names. Separate words via underscores.
@@ -136,7 +137,7 @@ class ValidHookNameSniff extends AbstractFunctionParameterSniff {
 				continue;
 			}
 
-			$string = $this->strip_quotes( $this->tokens[ $i ]['content'] );
+			$string = TextStrings::stripQuotes( $this->tokens[ $i ]['content'] );
 
 			/*
 			 * Here be dragons - a double quoted string can contain extrapolated variables

--- a/WordPress/Sniffs/NamingConventions/ValidPostTypeSlugSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidPostTypeSlugSniff.php
@@ -11,6 +11,7 @@ namespace WordPressCS\WordPress\Sniffs\NamingConventions;
 
 use WordPressCS\WordPress\AbstractFunctionParameterSniff;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Utils\TextStrings;
 
 /**
  * Validates post type names.
@@ -136,7 +137,7 @@ class ValidPostTypeSlugSniff extends AbstractFunctionParameterSniff {
 			return;
 		}
 
-		$post_type = $this->strip_quotes( $this->tokens[ $string_pos ]['content'] );
+		$post_type = TextStrings::stripQuotes( $this->tokens[ $string_pos ]['content'] );
 
 		if ( strlen( $post_type ) === 0 ) {
 			// Error for using empty slug.

--- a/WordPress/Sniffs/PHP/IniSetSniff.php
+++ b/WordPress/Sniffs/PHP/IniSetSniff.php
@@ -9,6 +9,7 @@
 
 namespace WordPressCS\WordPress\Sniffs\PHP;
 
+use PHPCSUtils\Utils\TextStrings;
 use WordPressCS\WordPress\AbstractFunctionParameterSniff;
 
 /**
@@ -136,8 +137,8 @@ class IniSetSniff extends AbstractFunctionParameterSniff {
 	 * @return void
 	 */
 	public function process_parameters( $stackPtr, $group_name, $matched_content, $parameters ) {
-		$option_name  = $this->strip_quotes( $parameters[1]['raw'] );
-		$option_value = $this->strip_quotes( $parameters[2]['raw'] );
+		$option_name  = TextStrings::stripQuotes( $parameters[1]['raw'] );
+		$option_value = TextStrings::stripQuotes( $parameters[2]['raw'] );
 		if ( isset( $this->whitelisted_options[ $option_name ] ) ) {
 			$whitelisted_option = $this->whitelisted_options[ $option_name ];
 			if ( ! isset( $whitelisted_option['valid_values'] ) || in_array( strtolower( $option_value ), $whitelisted_option['valid_values'], true ) ) {

--- a/WordPress/Sniffs/Security/EscapeOutputSniff.php
+++ b/WordPress/Sniffs/Security/EscapeOutputSniff.php
@@ -11,6 +11,7 @@ namespace WordPressCS\WordPress\Sniffs\Security;
 
 use WordPressCS\WordPress\Sniff;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Utils\PassedParameters;
 use PHPCSUtils\Utils\TextStrings;
 
 /**
@@ -195,7 +196,7 @@ class EscapeOutputSniff extends Sniff {
 
 			// These functions only need to have the first argument escaped.
 			if ( \in_array( $function, array( 'trigger_error', 'user_error' ), true ) ) {
-				$first_param      = $this->get_function_call_parameter( $stackPtr, 1 );
+				$first_param      = PassedParameters::getParameter( $this->phpcsFile, $stackPtr, 1 );
 				$end_of_statement = ( $first_param['end'] + 1 );
 				unset( $first_param );
 			}
@@ -205,7 +206,7 @@ class EscapeOutputSniff extends Sniff {
 			 * pattern, it doesn't need to be escaped.
 			 */
 			if ( '_deprecated_file' === $function ) {
-				$first_param = $this->get_function_call_parameter( $stackPtr, 1 );
+				$first_param = PassedParameters::getParameter( $this->phpcsFile, $stackPtr, 1 );
 
 				// Quick check. This disregards comments.
 				if ( preg_match( '`^basename\s*\(\s*__FILE__\s*\)$`', $first_param['raw'] ) === 1 ) {
@@ -381,7 +382,8 @@ class EscapeOutputSniff extends Sniff {
 					if ( isset( $this->arrayWalkingFunctions[ $functionName ] ) ) {
 
 						// Get the callback parameter.
-						$callback = $this->get_function_call_parameter(
+						$callback = PassedParameters::getParameter(
+							$this->phpcsFile,
 							$ptr,
 							$this->arrayWalkingFunctions[ $functionName ]
 						);

--- a/WordPress/Sniffs/Security/EscapeOutputSniff.php
+++ b/WordPress/Sniffs/Security/EscapeOutputSniff.php
@@ -11,6 +11,7 @@ namespace WordPressCS\WordPress\Sniffs\Security;
 
 use WordPressCS\WordPress\Sniff;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Utils\TextStrings;
 
 /**
  * Verifies that all outputted strings are escaped.
@@ -400,7 +401,7 @@ class EscapeOutputSniff extends Sniff {
 							if ( false !== $mapped_function
 								&& \T_CONSTANT_ENCAPSED_STRING === $this->tokens[ $mapped_function ]['code']
 							) {
-								$functionName = $this->strip_quotes( $this->tokens[ $mapped_function ]['content'] );
+								$functionName = TextStrings::stripQuotes( $this->tokens[ $mapped_function ]['content'] );
 								$ptr          = $mapped_function;
 							}
 						}

--- a/WordPress/Sniffs/Utils/I18nTextDomainFixerSniff.php
+++ b/WordPress/Sniffs/Utils/I18nTextDomainFixerSniff.php
@@ -11,6 +11,7 @@ namespace WordPressCS\WordPress\Sniffs\Utils;
 
 use WordPressCS\WordPress\AbstractFunctionParameterSniff;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Utils\TextStrings;
 
 /**
  * Comprehensive I18n text domain fixer tool.
@@ -436,7 +437,7 @@ class I18nTextDomainFixerSniff extends AbstractFunctionParameterSniff {
 		}
 
 		// If we're still here, this means only one T_CONSTANT_ENCAPSED_STRING was found.
-		$old_domain = $this->strip_quotes( $this->tokens[ $domain_token ]['content'] );
+		$old_domain = TextStrings::stripQuotes( $this->tokens[ $domain_token ]['content'] );
 
 		if ( ! \in_array( $old_domain, $this->old_text_domain, true ) ) {
 			// Not a text domain targetted for replacement, ignore.
@@ -545,7 +546,7 @@ class I18nTextDomainFixerSniff extends AbstractFunctionParameterSniff {
 		$type    = 'plugin';
 		$skip_to = $stackPtr;
 
-		$file = $this->strip_quotes( $this->phpcsFile->getFileName() );
+		$file = TextStrings::stripQuotes( $this->phpcsFile->getFileName() );
 		if ( 'STDIN' === $file ) {
 			return;
 		}

--- a/WordPress/Sniffs/WP/AlternativeFunctionsSniff.php
+++ b/WordPress/Sniffs/WP/AlternativeFunctionsSniff.php
@@ -9,6 +9,7 @@
 
 namespace WordPressCS\WordPress\Sniffs\WP;
 
+use PHPCSUtils\Utils\PassedParameters;
 use PHPCSUtils\Utils\TextStrings;
 use WordPressCS\WordPress\AbstractFunctionRestrictionsSniff;
 
@@ -192,7 +193,7 @@ class AlternativeFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 				 * The function `wp_strip_all_tags()` is only a valid alternative when
 				 * only the first parameter is passed to `strip_tags()`.
 				 */
-				if ( $this->get_function_call_parameter_count( $stackPtr ) !== 1 ) {
+				if ( PassedParameters::getParameterCount( $this->phpcsFile, $stackPtr ) !== 1 ) {
 					return;
 				}
 
@@ -205,7 +206,7 @@ class AlternativeFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 				 *
 				 * @see https://developer.wordpress.org/reference/functions/wp_parse_url/#changelog
 				 */
-				if ( $this->get_function_call_parameter_count( $stackPtr ) !== 1
+				if ( PassedParameters::getParameterCount( $this->phpcsFile, $stackPtr ) !== 1
 					&& version_compare( $this->minimum_supported_version, '4.7.0', '<' )
 				) {
 					return;

--- a/WordPress/Sniffs/WP/AlternativeFunctionsSniff.php
+++ b/WordPress/Sniffs/WP/AlternativeFunctionsSniff.php
@@ -263,7 +263,7 @@ class AlternativeFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 				/*
 				 * Allow for handling raw data streams from the request body.
 				 */
-				$first_param = $this->get_function_call_parameter( $stackPtr, 1 );
+				$first_param = PassedParameters::getParameter( $this->phpcsFile, $stackPtr, 1 );
 
 				if ( false === $first_param ) {
 					// If the file to work with is not set, local data streams don't come into play.

--- a/WordPress/Sniffs/WP/AlternativeFunctionsSniff.php
+++ b/WordPress/Sniffs/WP/AlternativeFunctionsSniff.php
@@ -219,7 +219,7 @@ class AlternativeFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 				 * Using `wp_remote_get()` will only work for remote URLs.
 				 * See if we can determine is this function call is for a local file and if so, bow out.
 				 */
-				$params = $this->get_function_call_parameters( $stackPtr );
+				$params = PassedParameters::getParameters( $this->phpcsFile, $stackPtr );
 
 				if ( isset( $params[2] ) && 'true' === $params[2]['raw'] ) {
 					// Setting `$use_include_path` to `true` is only relevant for local files.

--- a/WordPress/Sniffs/WP/AlternativeFunctionsSniff.php
+++ b/WordPress/Sniffs/WP/AlternativeFunctionsSniff.php
@@ -9,6 +9,7 @@
 
 namespace WordPressCS\WordPress\Sniffs\WP;
 
+use PHPCSUtils\Utils\TextStrings;
 use WordPressCS\WordPress\AbstractFunctionRestrictionsSniff;
 
 /**
@@ -298,7 +299,7 @@ class AlternativeFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 	 */
 	protected function is_local_data_stream( $raw_param_value ) {
 
-		$raw_stripped = $this->strip_quotes( $raw_param_value );
+		$raw_stripped = TextStrings::stripQuotes( $raw_param_value );
 		if ( isset( $this->allowed_local_streams[ $raw_stripped ] )
 			|| isset( $this->allowed_local_stream_constants[ $raw_param_value ] )
 		) {

--- a/WordPress/Sniffs/WP/CronIntervalSniff.php
+++ b/WordPress/Sniffs/WP/CronIntervalSniff.php
@@ -11,6 +11,7 @@ namespace WordPressCS\WordPress\Sniffs\WP;
 
 use WordPressCS\WordPress\Sniff;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Utils\PassedParameters;
 use PHPCSUtils\Utils\TextStrings;
 
 /**
@@ -97,7 +98,7 @@ class CronIntervalSniff extends Sniff {
 			return;
 		}
 
-		$callback = $this->get_function_call_parameter( $functionPtr, 2 );
+		$callback = PassedParameters::getParameter( $this->phpcsFile, $functionPtr, 2 );
 		if ( false === $callback ) {
 			return;
 		}
@@ -115,7 +116,7 @@ class CronIntervalSniff extends Sniff {
 			&& ( \T_ARRAY === $this->tokens[ $callbackArrayPtr ]['code']
 				|| \T_OPEN_SHORT_ARRAY === $this->tokens[ $callbackArrayPtr ]['code'] )
 		) {
-			$callback = $this->get_function_call_parameter( $callbackArrayPtr, 2 );
+			$callback = PassedParameters::getParameter( $this->phpcsFile, $callbackArrayPtr, 2 );
 
 			if ( false === $callback ) {
 				$this->confused( $stackPtr );

--- a/WordPress/Sniffs/WP/CronIntervalSniff.php
+++ b/WordPress/Sniffs/WP/CronIntervalSniff.php
@@ -11,6 +11,7 @@ namespace WordPressCS\WordPress\Sniffs\WP;
 
 use WordPressCS\WordPress\Sniff;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Utils\TextStrings;
 
 /**
  * Flag cron schedules less than 15 minutes.
@@ -86,7 +87,7 @@ class CronIntervalSniff extends Sniff {
 	public function process_token( $stackPtr ) {
 		$token = $this->tokens[ $stackPtr ];
 
-		if ( 'cron_schedules' !== $this->strip_quotes( $token['content'] ) ) {
+		if ( 'cron_schedules' !== TextStrings::stripQuotes( $token['content'] ) ) {
 			return;
 		}
 
@@ -135,7 +136,7 @@ class CronIntervalSniff extends Sniff {
 		if ( \T_CLOSURE === $this->tokens[ $callbackFunctionPtr ]['code'] ) {
 			$functionPtr = $callbackFunctionPtr;
 		} else {
-			$functionName = $this->strip_quotes( $this->tokens[ $callbackFunctionPtr ]['content'] );
+			$functionName = TextStrings::stripQuotes( $this->tokens[ $callbackFunctionPtr ]['content'] );
 
 			for ( $ptr = 0; $ptr < $this->phpcsFile->numTokens; $ptr++ ) {
 				if ( \T_FUNCTION === $this->tokens[ $ptr ]['code'] ) {
@@ -165,7 +166,7 @@ class CronIntervalSniff extends Sniff {
 		for ( $i = $opening; $i <= $closing; $i++ ) {
 
 			if ( \in_array( $this->tokens[ $i ]['code'], array( \T_CONSTANT_ENCAPSED_STRING, \T_DOUBLE_QUOTED_STRING ), true ) ) {
-				if ( 'interval' === $this->strip_quotes( $this->tokens[ $i ]['content'] ) ) {
+				if ( 'interval' === TextStrings::stripQuotes( $this->tokens[ $i ]['content'] ) ) {
 					$operator = $this->phpcsFile->findNext( \T_DOUBLE_ARROW, $i, null, false, null, true );
 					if ( false === $operator ) {
 						$this->confused( $stackPtr );

--- a/WordPress/Sniffs/WP/DeprecatedParameterValuesSniff.php
+++ b/WordPress/Sniffs/WP/DeprecatedParameterValuesSniff.php
@@ -11,6 +11,7 @@ namespace WordPressCS\WordPress\Sniffs\WP;
 
 use WordPressCS\WordPress\AbstractFunctionParameterSniff;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Utils\TextStrings;
 
 /**
  * Check for usage of deprecated parameter values in WP functions and provide alternative based on the parameter passed.
@@ -187,7 +188,7 @@ class DeprecatedParameterValuesSniff extends AbstractFunctionParameterSniff {
 			return;
 		}
 
-		$matched_parameter = $this->strip_quotes( $this->tokens[ $parameter_position ]['content'] );
+		$matched_parameter = TextStrings::stripQuotes( $this->tokens[ $parameter_position ]['content'] );
 		if ( ! isset( $parameter_args[ $matched_parameter ] ) ) {
 			return;
 		}

--- a/WordPress/Sniffs/WP/DeprecatedParametersSniff.php
+++ b/WordPress/Sniffs/WP/DeprecatedParametersSniff.php
@@ -9,6 +9,7 @@
 
 namespace WordPressCS\WordPress\Sniffs\WP;
 
+use PHPCSUtils\Utils\TextStrings;
 use WordPressCS\WordPress\AbstractFunctionParameterSniff;
 
 /**
@@ -305,7 +306,7 @@ class DeprecatedParametersSniff extends AbstractFunctionParameterSniff {
 					$matched_parameter = array();
 					break;
 				default:
-					$matched_parameter = $this->strip_quotes( $parameters[ $position ]['raw'] );
+					$matched_parameter = TextStrings::stripQuotes( $parameters[ $position ]['raw'] );
 					break;
 			}
 

--- a/WordPress/Sniffs/WP/DiscouragedConstantsSniff.php
+++ b/WordPress/Sniffs/WP/DiscouragedConstantsSniff.php
@@ -11,6 +11,7 @@ namespace WordPressCS\WordPress\Sniffs\WP;
 
 use WordPressCS\WordPress\AbstractFunctionParameterSniff;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Utils\Scopes;
 use PHPCSUtils\Utils\TextStrings;
 
 /**
@@ -132,7 +133,7 @@ class DiscouragedConstantsSniff extends AbstractFunctionParameterSniff {
 
 		if ( false !== $prev
 			&& \T_CONST === $this->tokens[ $prev ]['code']
-			&& true === $this->is_class_constant( $prev )
+			&& true === Scopes::isOOConstant( $this->phpcsFile, $prev )
 		) {
 			// Class constant of the same name.
 			return;

--- a/WordPress/Sniffs/WP/DiscouragedConstantsSniff.php
+++ b/WordPress/Sniffs/WP/DiscouragedConstantsSniff.php
@@ -11,6 +11,7 @@ namespace WordPressCS\WordPress\Sniffs\WP;
 
 use WordPressCS\WordPress\AbstractFunctionParameterSniff;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Utils\TextStrings;
 
 /**
  * Warns against usage of discouraged WP CONSTANTS and recommends alternatives.
@@ -199,7 +200,7 @@ class DiscouragedConstantsSniff extends AbstractFunctionParameterSniff {
 			return;
 		}
 
-		$raw_content = $this->strip_quotes( $parameters[ $target_param ]['raw'] );
+		$raw_content = TextStrings::stripQuotes( $parameters[ $target_param ]['raw'] );
 
 		if ( isset( $this->discouraged_constants[ $raw_content ] ) ) {
 			$this->phpcsFile->addWarning(

--- a/WordPress/Sniffs/WP/GlobalVariablesOverrideSniff.php
+++ b/WordPress/Sniffs/WP/GlobalVariablesOverrideSniff.php
@@ -11,6 +11,7 @@ namespace WordPressCS\WordPress\Sniffs\WP;
 
 use WordPressCS\WordPress\Sniff;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Utils\TextStrings;
 
 /**
  * Warns about overwriting WordPress native global variables.
@@ -226,7 +227,7 @@ class GlobalVariablesOverrideSniff extends Sniff {
 				}
 
 				if ( \T_CONSTANT_ENCAPSED_STRING === $this->tokens[ $ptr ]['code'] ) {
-					$var_name .= $this->strip_quotes( $this->tokens[ $ptr ]['content'] );
+					$var_name .= TextStrings::stripQuotes( $this->tokens[ $ptr ]['content'] );
 				}
 			}
 
@@ -378,7 +379,7 @@ class GlobalVariablesOverrideSniff extends Sniff {
 				foreach ( $var_pointers as $ptr ) {
 					$var_name = $this->tokens[ $ptr ]['content'];
 					if ( '$GLOBALS' === $var_name ) {
-						$var_name = '$' . $this->strip_quotes( $this->get_array_access_key( $ptr ) );
+						$var_name = '$' . TextStrings::stripQuotes( $this->get_array_access_key( $ptr ) );
 					}
 
 					if ( \in_array( $var_name, $search, true ) ) {

--- a/WordPress/Sniffs/WP/GlobalVariablesOverrideSniff.php
+++ b/WordPress/Sniffs/WP/GlobalVariablesOverrideSniff.php
@@ -12,6 +12,7 @@ namespace WordPressCS\WordPress\Sniffs\WP;
 use WordPressCS\WordPress\Sniff;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\Utils\Lists;
+use PHPCSUtils\Utils\Scopes;
 use PHPCSUtils\Utils\TextStrings;
 
 /**
@@ -284,7 +285,7 @@ class GlobalVariablesOverrideSniff extends Sniff {
 		/*
 		 * Class property declarations with the same name as WP global variables are fine.
 		 */
-		if ( false === $in_list && true === $this->is_class_property( $stackPtr ) ) {
+		if ( false === $in_list && true === Scopes::isOOProperty( $this->phpcsFile, $stackPtr ) ) {
 			return;
 		}
 

--- a/WordPress/Sniffs/WP/GlobalVariablesOverrideSniff.php
+++ b/WordPress/Sniffs/WP/GlobalVariablesOverrideSniff.php
@@ -11,6 +11,7 @@ namespace WordPressCS\WordPress\Sniffs\WP;
 
 use WordPressCS\WordPress\Sniff;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Utils\Lists;
 use PHPCSUtils\Utils\TextStrings;
 
 /**
@@ -171,7 +172,7 @@ class GlobalVariablesOverrideSniff extends Sniff {
 	 *                  normal file processing.
 	 */
 	protected function process_list_assignment( $stackPtr ) {
-		$list_open_close = $this->find_list_open_close( $stackPtr );
+		$list_open_close = Lists::getOpenClose( $this->phpcsFile, $stackPtr );
 		if ( false === $list_open_close ) {
 			// Short array, not short list.
 			return;
@@ -368,7 +369,7 @@ class GlobalVariablesOverrideSniff extends Sniff {
 			if ( \T_LIST === $this->tokens[ $ptr ]['code']
 				|| \T_OPEN_SHORT_ARRAY === $this->tokens[ $ptr ]['code']
 			) {
-				$list_open_close = $this->find_list_open_close( $ptr );
+				$list_open_close = Lists::getOpenClose( $this->phpcsFile, $ptr );
 
 				if ( false === $list_open_close ) {
 					// Short array, not short list.

--- a/WordPress/Sniffs/WP/I18nSniff.php
+++ b/WordPress/Sniffs/WP/I18nSniff.php
@@ -12,6 +12,7 @@ namespace WordPressCS\WordPress\Sniffs\WP;
 use WordPressCS\WordPress\AbstractFunctionRestrictionsSniff;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\BackCompat\Helper;
+use PHPCSUtils\Utils\TextStrings;
 
 /**
  * Makes sure WP internationalization functions are used properly.
@@ -477,7 +478,7 @@ class I18nSniff extends AbstractFunctionRestrictionsSniff {
 
 		if ( isset( Tokens::$textStringTokens[ $tokens[0]['code'] ] ) ) {
 			if ( 'domain' === $arg_name && ! empty( $this->text_domain ) ) {
-				$stripped_content = $this->strip_quotes( $content );
+				$stripped_content = TextStrings::stripQuotes( $content );
 
 				if ( ! \in_array( $stripped_content, $this->text_domain, true ) ) {
 					$this->addMessage(
@@ -630,7 +631,7 @@ class I18nSniff extends AbstractFunctionRestrictionsSniff {
 		 *
 		 * Strip placeholders and surrounding quotes.
 		 */
-		$content_without_quotes  = trim( $this->strip_quotes( $content ) );
+		$content_without_quotes  = trim( TextStrings::stripQuotes( $content ) );
 		$non_placeholder_content = preg_replace( self::SPRINTF_PLACEHOLDER_REGEX, '', $content_without_quotes );
 
 		if ( '' === $non_placeholder_content ) {

--- a/WordPress/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
@@ -11,6 +11,7 @@ namespace WordPressCS\WordPress\Sniffs\WhiteSpace;
 
 use WordPressCS\WordPress\Sniff;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Utils\UseStatements;
 
 /**
  * Enforces spacing around logical operators and assignments, based upon Squiz code.
@@ -113,6 +114,12 @@ class ControlStructureSpacingSniff extends Sniff {
 	public function process_token( $stackPtr ) {
 		$this->spaces_before_closure_open_paren = (int) $this->spaces_before_closure_open_paren;
 
+		if ( \T_USE === $this->tokens[ $stackPtr ]['code']
+			&& UseStatements::isClosureUse( $this->phpcsFile, $stackPtr ) === false
+		) {
+			return;
+		}
+
 		if ( isset( $this->tokens[ ( $stackPtr + 1 ) ] ) && \T_WHITESPACE !== $this->tokens[ ( $stackPtr + 1 ) ]['code']
 			&& ! ( \T_ELSE === $this->tokens[ $stackPtr ]['code'] && \T_COLON === $this->tokens[ ( $stackPtr + 1 ) ]['code'] )
 			&& ! ( \T_CLOSURE === $this->tokens[ $stackPtr ]['code']
@@ -128,7 +135,7 @@ class ControlStructureSpacingSniff extends Sniff {
 
 		if ( ! isset( $this->tokens[ $stackPtr ]['scope_closer'] ) ) {
 
-			if ( \T_USE === $this->tokens[ $stackPtr ]['code'] && 'closure' === $this->get_use_type( $stackPtr ) ) {
+			if ( \T_USE === $this->tokens[ $stackPtr ]['code'] ) {
 				$scopeOpener = $this->phpcsFile->findNext( \T_OPEN_CURLY_BRACKET, ( $stackPtr + 1 ) );
 				$scopeCloser = $this->tokens[ $scopeOpener ]['scope_closer'];
 			} elseif ( \T_WHILE !== $this->tokens[ $stackPtr ]['code'] ) {


### PR DESCRIPTION
... in favour of the PHPCSUtils version of those methods.

This brings us:
* Improved functionality.
* Fewer bugs.
* Improved PHPCS cross-version compatibility.
* All PHPCSUtils are unit tested in depth.

**Note**: the current removals are based on [PHPCSUtils 1.0.0-alpha3](https://github.com/PHPCSStandards/PHPCSUtils/releases). There are a number of other methods which are still on the PHPCSUtils "To do" list, so I expect more utility methods to be removed/switched out in future PRs. 

For full details on the upstream classes and methods used, see the [PHPCSUtils documentation](https://phpcsutils.com/phpdoc/namespaces/phpcsutils-utils.html).

The removal is done in three steps, which correspond to the commits in this PR:
* Deprecate the old code
* Switch over any uses of the old code
* Remove the old code

Doing this removal in steps allowed for testing in between, making sure every use of the old methods was caught.

**Notes for review and merging this PR**:
* This PR will be easiest to review by going through the commits one-by-one.
* Merging this PR as is, is fine. Similar to #1922 it doesn't need to be squashed as the commits tell the story.

### Commit Details

* Sniff: deprecate everything which has moved to PHPCSUtils
* Sniff::strip_quotes(): switch over to the PHPCSUtils version
* Sniff::strip_quotes(): remove the function
* Sniff::get_use_type(): switch over to a PHPCSUtils alternative
* Sniff::get_use_type(): remove the function
* Sniff::does_function_call_have_parameters(): remove the function
    All uses of the method were already removed with the switching over of the deprecated utility methods themselves.
* Sniff::get_function_call_parameter_count(): switch over to the PHPCSUtils version
* Sniff::get_function_call_parameter_count(): remove the function
* Sniff::get_function_call_parameters(): switch over to the PHPCSUtils version
* Sniff::get_function_call_parameters(): remove the function
* Sniff::get_function_call_parameter(): switch over to the PHPCSUtils version
* Sniff::get_function_call_parameter(): remove the function
* Sniff::find_array_open_close(): switch over to the PHPCSUtils version
* Sniff::find_array_open_close(): remove the function
* Sniff::find_list_open_close(): switch over to the PHPCSUtils version
* Sniff::find_list_open_close(): remove the function
* Sniff::determine_namespace(): switch over to the PHPCSUtils version
* Sniff::determine_namespace(): remove the function
* Sniff::get_declared_namespace_name(): switch over to the PHPCSUtils version
* Sniff::get_declared_namespace_name(): remove the function
* Sniff::is_class_constant(): switch over to the PHPCSUtils version
* Sniff::is_class_constant(): remove the function
* Sniff::is_class_property(): switch over to the PHPCSUtils version
* Sniff::is_class_property(): remove the function
* Sniff::valid_direct_scope(): remove the function
    All uses of the method were already removed with the switching over of the deprecated utility methods themselves.
* Sniff::is_short_list(): switch over to a PHPCSUtils alternative
    PHPCSUtils contains both a `Lists::isShortList()` as well as an `Arrays::isShortArray()` method. These are not direct opposites as there are tokenizer problems across PHPCS version which sometimes affect one, sometimes the other, so instead of checking that something is "not a short list", in these cases, we should be checking that something **is** a short array.
* Sniff::is_short_list(): remove the function 