### PR TITLE
3.0: CapitalPDangit: implement PHPCSUtils and check namespace names

### DIFF
--- a/WordPress/Sniffs/WP/CapitalPDangitSniff.php
+++ b/WordPress/Sniffs/WP/CapitalPDangitSniff.php
@@ -113,9 +113,13 @@ class CapitalPDangitSniff extends Sniff {
 		 * The return values skip to the end of the array.
 		 * This prevents the sniff "hanging" on very long configuration arrays.
 		 */
-		if ( \T_OPEN_SHORT_ARRAY === $this->tokens[ $stackPtr ]['code'] && isset( $this->tokens[ $stackPtr ]['bracket_closer'] ) ) {
+		if ( \T_OPEN_SHORT_ARRAY === $this->tokens[ $stackPtr ]['code']
+			&& isset( $this->tokens[ $stackPtr ]['bracket_closer'] )
+		) {
 			return $this->tokens[ $stackPtr ]['bracket_closer'];
-		} elseif ( \T_ARRAY === $this->tokens[ $stackPtr ]['code'] && isset( $this->tokens[ $stackPtr ]['parenthesis_closer'] ) ) {
+		} elseif ( \T_ARRAY === $this->tokens[ $stackPtr ]['code']
+			&& isset( $this->tokens[ $stackPtr ]['parenthesis_closer'] )
+		) {
 			return $this->tokens[ $stackPtr ]['parenthesis_closer'];
 		}
 

--- a/WordPress/Sniffs/WP/CapitalPDangitSniff.php
+++ b/WordPress/Sniffs/WP/CapitalPDangitSniff.php
@@ -137,14 +137,14 @@ class CapitalPDangitSniff extends Sniff {
 			$levels = explode( '\\', $ns_name );
 			foreach ( $levels as $level ) {
 				if ( preg_match_all( self::WP_CLASSNAME_REGEX, $level, $matches, \PREG_PATTERN_ORDER ) > 0 ) {
-					$mispelled = $this->retrieve_misspellings( $matches[1] );
+					$misspelled = $this->retrieve_misspellings( $matches[1] );
 
-					if ( ! empty( $mispelled ) ) {
+					if ( ! empty( $misspelled ) ) {
 						$this->phpcsFile->addWarning(
 							'Please spell "WordPress" correctly. Found: "%s" as part of the namespace name.',
 							$stackPtr,
 							'MisspelledNamespaceName',
-							array( implode( ', ', $mispelled ) )
+							array( implode( ', ', $misspelled ) )
 						);
 					}
 				}
@@ -164,14 +164,14 @@ class CapitalPDangitSniff extends Sniff {
 			}
 
 			if ( preg_match_all( self::WP_CLASSNAME_REGEX, $classname, $matches, \PREG_PATTERN_ORDER ) > 0 ) {
-				$mispelled = $this->retrieve_misspellings( $matches[1] );
+				$misspelled = $this->retrieve_misspellings( $matches[1] );
 
-				if ( ! empty( $mispelled ) ) {
+				if ( ! empty( $misspelled ) ) {
 					$this->phpcsFile->addWarning(
 						'Please spell "WordPress" correctly. Found: "%s" as part of the class/interface/trait name.',
 						$stackPtr,
 						'MisspelledClassName',
-						array( implode( ', ', $mispelled ) )
+						array( implode( ', ', $misspelled ) )
 					);
 				}
 			}
@@ -263,9 +263,9 @@ class CapitalPDangitSniff extends Sniff {
 				}
 			}
 
-			$mispelled = $this->retrieve_misspellings( $matches[1] );
+			$misspelled = $this->retrieve_misspellings( $matches[1] );
 
-			if ( empty( $mispelled ) ) {
+			if ( empty( $misspelled ) ) {
 				return;
 			}
 
@@ -274,8 +274,8 @@ class CapitalPDangitSniff extends Sniff {
 				$stackPtr,
 				'Misspelled',
 				array(
-					\count( $mispelled ),
-					implode( ', ', $mispelled ),
+					\count( $misspelled ),
+					implode( ', ', $misspelled ),
 				)
 			);
 
@@ -298,7 +298,7 @@ class CapitalPDangitSniff extends Sniff {
 	 * @return array Array containing only the misspelled variants.
 	 */
 	protected function retrieve_misspellings( $match_stack ) {
-		$mispelled = array();
+		$misspelled = array();
 		foreach ( $match_stack as $match ) {
 			// Deal with multi-dimensional arrays when capturing offset.
 			if ( \is_array( $match ) ) {
@@ -306,11 +306,11 @@ class CapitalPDangitSniff extends Sniff {
 			}
 
 			if ( 'WordPress' !== $match ) {
-				$mispelled[] = $match;
+				$misspelled[] = $match;
 			}
 		}
 
-		return $mispelled;
+		return $misspelled;
 	}
 
 }

--- a/WordPress/Sniffs/WP/CapitalPDangitSniff.php
+++ b/WordPress/Sniffs/WP/CapitalPDangitSniff.php
@@ -184,13 +184,16 @@ class CapitalPDangitSniff extends Sniff {
 			|| \T_DOC_COMMENT === $this->tokens[ $stackPtr ]['code']
 		) {
 
-			$comment_start = $this->phpcsFile->findPrevious( \T_DOC_COMMENT_OPEN_TAG, ( $stackPtr - 1 ) );
-			if ( false !== $comment_start ) {
-				$comment_tag = $this->phpcsFile->findPrevious( \T_DOC_COMMENT_TAG, ( $stackPtr - 1 ), $comment_start );
-				if ( false !== $comment_tag && '@link' === $this->tokens[ $comment_tag ]['content'] ) {
-					// @link tag, so ignore.
-					return;
-				}
+			$comment_tag = $this->phpcsFile->findPrevious(
+				array( \T_DOC_COMMENT_TAG, \T_DOC_COMMENT_OPEN_TAG ),
+				( $stackPtr - 1 )
+			);
+			if ( false !== $comment_tag
+				&& \T_DOC_COMMENT_TAG === $this->tokens[ $comment_tag ]['code']
+				&& '@link' === $this->tokens[ $comment_tag ]['content']
+			) {
+				// @link tag, so ignore.
+				return;
 			}
 		}
 

--- a/WordPress/Sniffs/WP/CapitalPDangitSniff.php
+++ b/WordPress/Sniffs/WP/CapitalPDangitSniff.php
@@ -11,6 +11,7 @@ namespace WordPressCS\WordPress\Sniffs\WP;
 
 use WordPressCS\WordPress\Sniff;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Utils\ObjectDeclarations;
 
 /**
  * Capital P Dangit!
@@ -52,19 +53,6 @@ class CapitalPDangitSniff extends Sniff {
 	const WP_CLASSNAME_REGEX = '`(?:^|_)(Word[_]*Pres+)(?:_|$)`i';
 
 	/**
-	 * String tokens we want to listen for.
-	 *
-	 * @var array
-	 */
-	private $text_string_tokens = array(
-		\T_CONSTANT_ENCAPSED_STRING => \T_CONSTANT_ENCAPSED_STRING,
-		\T_DOUBLE_QUOTED_STRING     => \T_DOUBLE_QUOTED_STRING,
-		\T_HEREDOC                  => \T_HEREDOC,
-		\T_NOWDOC                   => \T_NOWDOC,
-		\T_INLINE_HTML              => \T_INLINE_HTML,
-	);
-
-	/**
 	 * Comment tokens we want to listen for as they contain text strings.
 	 *
 	 * @var array
@@ -93,7 +81,7 @@ class CapitalPDangitSniff extends Sniff {
 	 */
 	public function register() {
 		// Union the arrays - keeps the array keys.
-		$this->text_and_comment_tokens = ( $this->text_string_tokens + $this->comment_text_tokens );
+		$this->text_and_comment_tokens = ( Tokens::$textStringTokens + $this->comment_text_tokens );
 
 		$targets = ( $this->text_and_comment_tokens + Tokens::$ooScopeTokens );
 
@@ -132,7 +120,7 @@ class CapitalPDangitSniff extends Sniff {
 		 * These are not auto-fixable, but need the attention of a developer.
 		 */
 		if ( isset( Tokens::$ooScopeTokens[ $this->tokens[ $stackPtr ]['code'] ] ) ) {
-			$classname = $this->phpcsFile->getDeclarationName( $stackPtr );
+			$classname = ObjectDeclarations::getName( $this->phpcsFile, $stackPtr );
 			if ( empty( $classname ) ) {
 				return;
 			}

--- a/WordPress/Tests/WP/CapitalPDangitUnitTest.inc
+++ b/WordPress/Tests/WP/CapitalPDangitUnitTest.inc
@@ -191,3 +191,15 @@ class TestMe {
 
 // Allow "test" domain.
 $value = function_call( 'git.wordpress.test' );
+
+/*
+ * Test recognizing misspelling in namespace names.
+ */
+namespace {} // OK - no name.
+echo namespace\function_name(); // OK - operator.
+namespace Foo\WordPress\Bar; // OK.
+namespace My_WordPress_Plugin; // OK.
+
+namespace Foo\Bar\Wordpress\; // Bad.
+namespace Foo\word_presss\Bar; // Bad.
+namespace My_Wordpresss_Plugin\Foo\Bar; // Bad.

--- a/WordPress/Tests/WP/CapitalPDangitUnitTest.inc.fixed
+++ b/WordPress/Tests/WP/CapitalPDangitUnitTest.inc.fixed
@@ -191,3 +191,15 @@ class TestMe {
 
 // Allow "test" domain.
 $value = function_call( 'git.wordpress.test' );
+
+/*
+ * Test recognizing misspelling in namespace names.
+ */
+namespace {} // OK - no name.
+echo namespace\function_name(); // OK - operator.
+namespace Foo\WordPress\Bar; // OK.
+namespace My_WordPress_Plugin; // OK.
+
+namespace Foo\Bar\Wordpress\; // Bad.
+namespace Foo\word_presss\Bar; // Bad.
+namespace My_Wordpresss_Plugin\Foo\Bar; // Bad.

--- a/WordPress/Tests/WP/CapitalPDangitUnitTest.php
+++ b/WordPress/Tests/WP/CapitalPDangitUnitTest.php
@@ -62,6 +62,9 @@ class CapitalPDangitUnitTest extends AbstractSniffUnitTest {
 			167 => 1, // Old-style WPCS ignore comments are no longer supported.
 			173 => 1,
 			181 => 1,
+			203 => 1,
+			204 => 1,
+			205 => 1,
 		);
 	}
 


### PR DESCRIPTION
This PR will be easiest to review by looking at the individual commits.

## Commit Details

### CapitalPDangit: implement PHPCSUtils and other improvements

* The `Tokens::$textStringTokens` property was introduced in PHPCS 2.9.0 and is the same as the `$text_string_tokens` property in this sniff.
    Replacing this was missed in an earlier review round after the minimum PHPCS version changed.
* Use the PHPCSUtils [`ObjectDeclarations::getName()`](https://phpcsutils.com/phpdoc/classes/PHPCSUtils-Utils-ObjectDeclarations.html#method_getName) method instead of the PHPCS native `File::getDeclarationName()` method for a slightly more stable result.

### CapitalPDangit: check namespace names

Up to now, class names, trait names and interface names were already checked, but namespace names were not checked for the correct spelling of `WordPress`.

This new feature has now been added.

Includes unit tests.

### CapitalPDangit: minor efficiency tweak

No need to call `findPrevious()` twice.

### CapitalPDangit: minor code layout tweak

Minor code readability improvement.

