### PR TITLE
OperatorSpacing: defer to upstream for "instanceof"

### DIFF
--- a/WordPress/Sniffs/WhiteSpace/OperatorSpacingSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/OperatorSpacingSniff.php
@@ -13,7 +13,8 @@ use PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace\OperatorSpacingSniff as PH
 use PHP_CodeSniffer\Util\Tokens;
 
 /**
- * Verify operator spacing, uses the Squiz sniff, but additionally also sniffs for the `!` (boolean not) operator.
+ * Verify operator spacing, uses the Squiz sniff, but additionally also sniffs for the
+ * `!` (boolean not) and the boolean and logical and/or operators.
  *
  * "Always put spaces after commas, and on both sides of logical, comparison, string and assignment operators."
  *
@@ -31,7 +32,7 @@ use PHP_CodeSniffer\Util\Tokens;
  *                 $ignoreNewlines property.
  * @since   0.13.0 Class name changed: this class is now namespaced.
  *
- * Last synced with base class June 2017 at commit 41127aa4764536f38f504fb3f7b8831f05919c89.
+ * Last verified with base class July 2020 at commit a957a73e3533353451eb9fd62ee58bd0aba2773c.
  * @link    https://github.com/squizlabs/PHP_CodeSniffer/blob/master/CodeSniffer/Standards/Squiz/Sniffs/WhiteSpace/OperatorSpacingSniff.php
  */
 class OperatorSpacingSniff extends PHPCS_Squiz_OperatorSpacingSniff {
@@ -54,11 +55,9 @@ class OperatorSpacingSniff extends PHPCS_Squiz_OperatorSpacingSniff {
 	public function register() {
 		$tokens                   = parent::register();
 		$tokens[ \T_BOOLEAN_NOT ] = \T_BOOLEAN_NOT;
-		$tokens[ \T_INSTANCEOF ]  = \T_INSTANCEOF;
-		$logical_operators        = Tokens::$booleanOperators;
+		$tokens                  += Tokens::$booleanOperators;
 
-		// Using array union to auto-dedup.
-		return $tokens + $logical_operators;
+		return $tokens;
 	}
 
 }

--- a/WordPress/Tests/WhiteSpace/OperatorSpacingUnitTest.inc
+++ b/WordPress/Tests/WhiteSpace/OperatorSpacingUnitTest.inc
@@ -64,7 +64,3 @@ if ( $a === $b
 
 if ( $a === $b or
 	$b === $c ) {}
-
-// Instanceof
-if ( MyClass    instanceof    SomeOtherClass ) {}
-if ( MyClass instanceof SomeOtherClass ) {}

--- a/WordPress/Tests/WhiteSpace/OperatorSpacingUnitTest.inc.fixed
+++ b/WordPress/Tests/WhiteSpace/OperatorSpacingUnitTest.inc.fixed
@@ -64,7 +64,3 @@ if ( $a === $b
 
 if ( $a === $b or
 	$b === $c ) {}
-
-// Instanceof
-if ( MyClass instanceof SomeOtherClass ) {}
-if ( MyClass instanceof SomeOtherClass ) {}

--- a/WordPress/Tests/WhiteSpace/OperatorSpacingUnitTest.php
+++ b/WordPress/Tests/WhiteSpace/OperatorSpacingUnitTest.php
@@ -42,7 +42,6 @@ class OperatorSpacingUnitTest extends AbstractSniffUnitTest {
 			49 => 2,
 			50 => 2,
 			51 => 2,
-			69 => 2,
 		);
 	}
 


### PR DESCRIPTION
The `T_INSTANCEOF` token was added to the `OperatorSpacing` sniff targets in PR #1598.

In upstream PR squizlabs/PHP_CodeSniffer#2516, the same was done for the upstream sniff. This PR was merged & included in PHPCS 3.5.0.

As the minimum PHPCS version for WPCS has now been changed to PHPCS 3.5.0, the WPCS sniff no longer needs to register the `T_INSTANCEOF` token.

Includes _removing_ the unit tests related to this as the WPCS sniff should only test the differences between the upstream sniff and the WPCS version.

Includes minor code simplification for the remaining code.