### PR TITLE
3.0: ValidFunctionName: implement PHPCSUtils and more

### DIFF
--- a/WordPress/Sniffs/NamingConventions/ValidFunctionNameSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidFunctionNameSniff.php
@@ -151,6 +151,11 @@ class ValidFunctionNameSniff extends PHPCS_PEAR_ValidFunctionNameSniff {
 			return;
 		}
 
+		// PHP magic methods are exempt from our rules.
+		if ( FunctionDeclarations::isMagicMethodName( $methodName ) === true ) {
+			return;
+		}
+
 		$extended   = ObjectDeclarations::findExtendedClassName( $phpcsFile, $currScope );
 		$interfaces = ObjectDeclarations::findImplementedInterfaceNames( $phpcsFile, $currScope );
 
@@ -159,13 +164,8 @@ class ValidFunctionNameSniff extends PHPCS_PEAR_ValidFunctionNameSniff {
 			return;
 		}
 
-		// Is this a magic method ? I.e. is it prefixed with "__" ?
+		// Is the method name prefixed with "__" ?
 		if ( 0 === strpos( $methodName, '__' ) ) {
-			$magicPart = substr( $methodNameLc, 2 );
-			if ( isset( $this->magicMethods[ $magicPart ] ) ) {
-				return;
-			}
-
 			$error     = 'Method name "%s" is invalid; only PHP magic methods should be prefixed with a double underscore';
 			$errorData = array( $className . '::' . $methodName );
 			$phpcsFile->addError( $error, $stackPtr, 'MethodDoubleUnderscore', $errorData );

--- a/WordPress/Sniffs/NamingConventions/ValidFunctionNameSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidFunctionNameSniff.php
@@ -68,22 +68,19 @@ class ValidFunctionNameSniff extends PHPCS_PEAR_ValidFunctionNameSniff {
 			return;
 		}
 
-		$functionNameLc = strtolower( $functionName );
+		// PHP magic functions are exempt from our rules.
+		if ( FunctionDeclarations::isMagicFunctionName( $functionName ) === true ) {
+			return;
+		}
 
-		// Is this a magic function ? I.e., it is prefixed with "__" ?
-		// Outside class scope this basically just means __autoload().
+		// Is the function name prefixed with "__" ?
 		if ( 0 === strpos( $functionName, '__' ) ) {
-			$magicPart = substr( $functionNameLc, 2 );
-			if ( isset( $this->magicFunctions[ $magicPart ] ) ) {
-				return;
-			}
-
 			$error     = 'Function name "%s" is invalid; only PHP magic methods should be prefixed with a double underscore';
 			$errorData = array( $functionName );
 			$phpcsFile->addError( $error, $stackPtr, 'FunctionDoubleUnderscore', $errorData );
 		}
 
-		if ( $functionNameLc !== $functionName ) {
+		if ( strtolower( $functionName ) !== $functionName ) {
 			$error     = 'Function name "%s" is not in snake case format, try "%s"';
 			$errorData = array(
 				$functionName,

--- a/WordPress/Sniffs/NamingConventions/ValidFunctionNameSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidFunctionNameSniff.php
@@ -136,9 +136,10 @@ class ValidFunctionNameSniff extends Sniff {
 	 */
 	protected function process_method_declaration( $stackPtr, $methodName, $currScope ) {
 
-		$className = ObjectDeclarations::getName( $this->phpcsFile, $currScope );
-		if ( isset( $className ) === false ) {
+		if ( \T_ANON_CLASS === $this->tokens[ $currScope ]['code'] ) {
 			$className = '[Anonymous Class]';
+		} else {
+			$className = ObjectDeclarations::getName( $this->phpcsFile, $currScope );
 		}
 
 		$methodNameLc = strtolower( $methodName );

--- a/WordPress/Sniffs/NamingConventions/ValidFunctionNameSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidFunctionNameSniff.php
@@ -12,6 +12,8 @@ namespace WordPressCS\WordPress\Sniffs\NamingConventions;
 use PHP_CodeSniffer\Standards\PEAR\Sniffs\NamingConventions\ValidFunctionNameSniff as PHPCS_PEAR_ValidFunctionNameSniff;
 use PHP_CodeSniffer\Files\File;
 use WordPressCS\WordPress\Sniff;
+use PHPCSUtils\Utils\FunctionDeclarations;
+use PHPCSUtils\Utils\ObjectDeclarations;
 
 /**
  * Enforces WordPress function name and method name format, based upon Squiz code.
@@ -54,7 +56,7 @@ class ValidFunctionNameSniff extends PHPCS_PEAR_ValidFunctionNameSniff {
 			return;
 		}
 
-		$functionName = $phpcsFile->getDeclarationName( $stackPtr );
+		$functionName = FunctionDeclarations::getName( $phpcsFile, $stackPtr );
 
 		if ( ! isset( $functionName ) ) {
 			// Ignore closures.
@@ -122,14 +124,14 @@ class ValidFunctionNameSniff extends PHPCS_PEAR_ValidFunctionNameSniff {
 			return;
 		}
 
-		$methodName = $phpcsFile->getDeclarationName( $stackPtr );
+		$methodName = FunctionDeclarations::getName( $phpcsFile, $stackPtr );
 
 		if ( ! isset( $methodName ) ) {
 			// Ignore closures.
 			return;
 		}
 
-		$className = $phpcsFile->getDeclarationName( $currScope );
+		$className = ObjectDeclarations::getName( $phpcsFile, $currScope );
 		if ( isset( $className ) === false ) {
 			$className = '[Anonymous Class]';
 		}
@@ -152,8 +154,8 @@ class ValidFunctionNameSniff extends PHPCS_PEAR_ValidFunctionNameSniff {
 			return;
 		}
 
-		$extended   = $phpcsFile->findExtendedClassName( $currScope );
-		$interfaces = $phpcsFile->findImplementedInterfaceNames( $currScope );
+		$extended   = ObjectDeclarations::findExtendedClassName( $phpcsFile, $currScope );
+		$interfaces = ObjectDeclarations::findImplementedInterfaceNames( $phpcsFile, $currScope );
 
 		// If this is a child class or interface implementation, it may have to use camelCase or double underscores.
 		if ( ! empty( $extended ) || ! empty( $interfaces ) ) {

--- a/WordPress/Sniffs/NamingConventions/ValidFunctionNameSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidFunctionNameSniff.php
@@ -104,7 +104,7 @@ class ValidFunctionNameSniff extends Sniff {
 		}
 
 		// Is the function name prefixed with "__" ?
-		if ( 0 === strpos( $functionName, '__' ) ) {
+		if ( preg_match( '`^__[^_]`', $functionName ) === 1 ) {
 			$error     = 'Function name "%s" is invalid; only PHP magic methods should be prefixed with a double underscore';
 			$errorData = array( $functionName );
 			$this->phpcsFile->addError( $error, $stackPtr, 'FunctionDoubleUnderscore', $errorData );
@@ -168,7 +168,7 @@ class ValidFunctionNameSniff extends Sniff {
 		}
 
 		// Is the method name prefixed with "__" ?
-		if ( 0 === strpos( $methodName, '__' ) ) {
+		if ( preg_match( '`^__[^_]`', $methodName ) === 1 ) {
 			$error     = 'Method name "%s" is invalid; only PHP magic methods should be prefixed with a double underscore';
 			$errorData = array( $className . '::' . $methodName );
 			$this->phpcsFile->addError( $error, $stackPtr, 'MethodDoubleUnderscore', $errorData );

--- a/WordPress/Tests/NamingConventions/ValidFunctionNameUnitTest.inc
+++ b/WordPress/Tests/NamingConventions/ValidFunctionNameUnitTest.inc
@@ -150,3 +150,10 @@ class PHP74Magic {
 	function __serialize() {} // OK.
 	function __unserialize() {} // OK.
 }
+
+class More_Nested {
+	public function method_name() {
+		function __autoload() {} // OK - magic function in global namespace.
+		function __CamelCase() {} // Bad x 2 for *function*, not method.
+	}
+}

--- a/WordPress/Tests/NamingConventions/ValidFunctionNameUnitTest.inc
+++ b/WordPress/Tests/NamingConventions/ValidFunctionNameUnitTest.inc
@@ -157,3 +157,9 @@ class More_Nested {
 		function __CamelCase() {} // Bad x 2 for *function*, not method.
 	}
 }
+
+function ___triple_underscore() {} // OK.
+
+class Triple {
+	function ___triple_underscore() {} // OK.
+}

--- a/WordPress/Tests/NamingConventions/ValidFunctionNameUnitTest.inc
+++ b/WordPress/Tests/NamingConventions/ValidFunctionNameUnitTest.inc
@@ -145,3 +145,8 @@ class Deprecated {
 	 */
 	public static function __deprecatedMethod() {}
 }
+
+class PHP74Magic {
+	function __serialize() {} // OK.
+	function __unserialize() {} // OK.
+}

--- a/WordPress/Tests/NamingConventions/ValidFunctionNameUnitTest.php
+++ b/WordPress/Tests/NamingConventions/ValidFunctionNameUnitTest.php
@@ -46,6 +46,7 @@ class ValidFunctionNameUnitTest extends AbstractSniffUnitTest {
 			106 => 2,
 			116 => 1,
 			117 => 1,
+			157 => 2,
 		);
 	}
 


### PR DESCRIPTION
This PR will be easiest to review by looking at the individual commits.

## Commit Details

### ValidFunctionName: implement PHPCSUtils

Use the improved PHPCSUtils versions of the PHPCS native methods.

### ValidFunctionName: use PHPCSUtils `isMagicFunctionName()`

Refs:
* [isMagicFunctionName()](https://phpcsutils.com/phpdoc/classes/PHPCSUtils-Utils-FunctionDeclarations.html#method_isMagicFunctionName)

### ValidFunctionName: use PHPCSUtils `isMagicMethodName()`

The magic method name list in PHPCSUtils is more complete than the one in the PEAR sniff.

Note: As this sniff bows out for methods declared in extended classes anyway, the PHP native double underscore methods from the SOAPClient class do not need to be taken into account, which is why the `isMagicMethodName()` method is used instead of the `isSpecialMethodName()` method.

Refs:
* [isMagicMethodName()](https://phpcsutils.com/phpdoc/classes/PHPCSUtils-Utils-FunctionDeclarations.html#method_isMagicMethodName)
* [isSpecialMethodName()](https://phpcsutils.com/phpdoc/classes/PHPCSUtils-Utils-FunctionDeclarations.html#method_isSpecialMethodName)

### ValidFunctionName: decouple from the PEAR sniff

This sniff extended the upstream `PEAR.NamingConventions.ValidFunctionName` sniff to allow using the properties related to magic functions/methods.

As handling of the magic functions/methods is now done via the PHPCSUtils `isMagicFunctionName()`/`isMagicMethodName()` methods, these properties are no longer used, so there is no need to extend the upstream PEAR sniff anymore.

In this commit:
* The parent sniff is changed from the upstream PEAR sniff to the WPCS base sniff.
* The `register()` and `process_token()` methods have been added.
* The `processTokenOutsideScope()` method has been renamed to `process_function_declaration()` to make the method name more descriptive.
* The `processTokenWithinScope()` method has been renamed to `process_method_declaration()` to make the method name more descriptive.
* The "method vs global function" determination is now done using the PHPCSUtils `Scopes::validDirectScope()` method which has higher accuracy.
    This fixes a bug where global functions declared nested within a method would not be examined at all.
* As the WPCS base sniff is now used, the `$this->phpcsFile` and `$this->tokens` properties are now available and use of them has been implemented.

Includes unit tests for the bug fix.

### ValidFunctionName: (re)move some code duplication

Move some code which was used in both the `process_function_declaration()` as well as the `process_method_declaration()` method to the `process_token()` method to remove some code duplication.

### ValidFunctionName: don't throw "DoubleUnderscore" error for triple underscore

This change was made in various upstream sniffs a while back as _triple_ underscore prefixed method names are not reserved by PHP.

Includes unit tests.

### ValidFunctionName: small efficiency fix

No need to call the `ObjectDeclarations::getName()` method for an anonymous class.

