### PR TITLE
CI: use Parallel-Lint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -169,7 +169,7 @@ install:
 
 script:
   # Lint the PHP files against parse errors.
-  - if [[ "$LINT" == "1" ]]; then if find . -path ./vendor -prune -o -path ./bin -prune -o -name "*.php" -exec php -l {} \; | grep "^[Parse error|Fatal error]"; then exit 1; fi; fi
+  - if [[ "$LINT" == "1" ]]; then composer lint; fi
 
   # Run the unit tests.
   - composer run-tests

--- a/composer.json
+++ b/composer.json
@@ -23,11 +23,16 @@
 	"require-dev": {
 		"phpcompatibility/php-compatibility": "^9.0",
 		"phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0",
-		"phpcsstandards/phpcsdevtools": "^1.0"
+		"phpcsstandards/phpcsdevtools": "^1.0",
+		"php-parallel-lint/php-parallel-lint": "^1.0",
+		"php-parallel-lint/php-console-highlighter": "^0.5"
 	},
 	"minimum-stability": "dev",
 	"prefer-stable": true,
 	"scripts": {
+		"lint": [
+			"@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --exclude vendor --exclude .git"
+		],
 		"check-cs": [
 			"@php ./vendor/squizlabs/php_codesniffer/bin/phpcs"
 		],


### PR DESCRIPTION
Parallel-Lint, as the name implies, runs PHP lint in parallel, making it faster than native linting.
It also provides more helpful output with a syntax highlighter code snippet showing the context of syntax errors.
And lastly, it allows for easily running PHP linting over the files in a local dev environment.

So, as we're now doing a full `composer install` on every Travis build anyway, we may as well use this tool.