### PR TITLE
3.0: EnqueuedResources: PHPCSUtils implementation

### DIFF
--- a/WordPress/Sniffs/WP/EnqueuedResourcesSniff.php
+++ b/WordPress/Sniffs/WP/EnqueuedResourcesSniff.php
@@ -9,8 +9,11 @@
 
 namespace WordPressCS\WordPress\Sniffs\WP;
 
-use WordPressCS\WordPress\Sniff;
+use PHP_CodeSniffer\Exceptions\RuntimeException;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Tokens\Collections;
+use PHPCSUtils\Utils\TextStrings;
+use WordPressCS\WordPress\Sniff;
 
 /**
  * Makes sure scripts and styles are enqueued and not explicitly echo'd.
@@ -22,6 +25,8 @@ use PHP_CodeSniffer\Util\Tokens;
  * @since   0.3.0
  * @since   0.12.0 This class now extends the WordPressCS native `Sniff` class.
  * @since   0.13.0 Class name changed: this class is now namespaced.
+ * @since   3.0.0  Added a check for a complete text string in the case where it
+ *                 spans two lines.
  */
 class EnqueuedResourcesSniff extends Sniff {
 
@@ -31,7 +36,10 @@ class EnqueuedResourcesSniff extends Sniff {
 	 * @return array
 	 */
 	public function register() {
-		return Tokens::$textStringTokens;
+		$targets   = Collections::$textStingStartTokens;
+		$targets[] = \T_INLINE_HTML;
+
+		return $targets;
 	}
 
 	/**
@@ -42,23 +50,59 @@ class EnqueuedResourcesSniff extends Sniff {
 	 * @return void
 	 */
 	public function process_token( $stackPtr ) {
-		$token = $this->tokens[ $stackPtr ];
 
-		if ( preg_match( '# rel=\\\\?[\'"]?stylesheet\\\\?[\'"]?#', $token['content'] ) > 0 ) {
-			$this->phpcsFile->addError(
-				'Stylesheets must be registered/enqueued via wp_enqueue_style',
-				$stackPtr,
-				'NonEnqueuedStylesheet'
-			);
+		$content = $this->tokens[ $stackPtr ]['content'];
+		if ( \T_INLINE_HTML !== $this->tokens[ $stackPtr ]['code'] ) {
+			try {
+				$content = TextStrings::getCompleteTextString( $this->phpcsFile, $stackPtr );
+			} catch ( RuntimeException $e ) {
+				// Not the first token in a multi-line text string. Any issues will already have been reported.
+				return;
+			}
 		}
 
-		if ( preg_match( '#<script[^>]*(?<=src=)#', $token['content'] ) > 0 ) {
-			$this->phpcsFile->addError(
-				'Scripts must be registered/enqueued via wp_enqueue_script',
-				$stackPtr,
-				'NonEnqueuedScript'
-			);
+		if ( preg_match_all( '# rel=\\\\?[\'"]?stylesheet\\\\?[\'"]?#', $content, $matches, PREG_OFFSET_CAPTURE ) > 0 ) {
+			foreach ( $matches[0] as $match ) {
+				$this->phpcsFile->addError(
+					'Stylesheets must be registered/enqueued via wp_enqueue_style',
+					$this->find_token_in_multiline_string( $stackPtr, $content, $match[1] ),
+					'NonEnqueuedStylesheet'
+				);
+			}
 		}
+
+		if ( preg_match_all( '#<script[^>]*(?<=src=)#', $content, $matches, PREG_OFFSET_CAPTURE ) > 0 ) {
+			foreach ( $matches[0] as $match ) {
+				$this->phpcsFile->addError(
+					'Scripts must be registered/enqueued via wp_enqueue_script',
+					$this->find_token_in_multiline_string( $stackPtr, $content, $match[1] ),
+					'NonEnqueuedScript'
+				);
+			}
+		}
+	}
+
+	/**
+	 * Find the exact token on which the error should be reported for multi-line strings.
+	 *
+	 * @param int    $stackPtr     The position of the current token in the stack.
+	 * @param string $content      The complete, potentially multi-line, text string.
+	 * @param int    $match_offset The offset within the content at which the match was found.
+	 *
+	 * @return int The stack pointer to the token containing the start of the match.
+	 */
+	private function find_token_in_multiline_string( $stackPtr, $content, $match_offset ) {
+		$newline_count = 0;
+		if ( $match_offset > 0 ) {
+			$newline_count = substr_count( $content, "\n", 0, $match_offset );
+		}
+
+		// Account for heredoc/nowdoc text starting at the token *after* the opener.
+		if ( isset( Tokens::$heredocTokens[ $this->tokens[ $stackPtr ]['code'] ] ) === true ) {
+			++$newline_count;
+		}
+
+		return ( $stackPtr + $newline_count );
 	}
 
 }

--- a/WordPress/Tests/WP/EnqueuedResourcesUnitTest.inc
+++ b/WordPress/Tests/WP/EnqueuedResourcesUnitTest.inc
@@ -36,3 +36,20 @@ EOD;
 jQuery( document ).ready( function() {
 	$('link[rel="stylesheet"]:not([data-inprogress])').forEach(StyleFix.link);
 });
+
+<?php
+// Test multi-line text string.
+echo '<script type="text/javascript"
+	src="' . $script . '"/>';
+
+// Test multi-line text string with multiple issues.
+echo '<script type="text/javascript"
+	src="http://someurl/somefile1.js"/>
+	<script src="http://someurl/somefile2.js"></script>
+	<script type="text/javascript"
+	src="http://someurl/somefile3.js"/>
+	';
+
+// Test multi-line text string with multiple issues.
+echo '<link rel="stylesheet" href="http://someurl/somefile1.css"/>
+	<link rel="stylesheet" href="http://someurl/somefile2.css"/>';

--- a/WordPress/Tests/WP/EnqueuedResourcesUnitTest.php
+++ b/WordPress/Tests/WP/EnqueuedResourcesUnitTest.php
@@ -44,6 +44,12 @@ class EnqueuedResourcesUnitTest extends AbstractSniffUnitTest {
 			26 => 1,
 			30 => 1,
 			31 => 1,
+			42 => 1,
+			46 => 1,
+			48 => 1,
+			49 => 1,
+			54 => 1,
+			55 => 1,
 		);
 	}
 


### PR DESCRIPTION
This PR is a part of the next milestone where we are adding [PHPCSUtils](https://phpcsutils.com/) into existing sniffs.

### Changes

- Added extra tokens to the check, to account for multiline text strings and inline HTML as well
- Fixed the handling of multi-line text strings:
  - As it was, if the text the sniff is looking for was split over multiple lines, the sniff would incorrectly not throw an error (false negative).
  By using the PHPCSUtils [`TextStrings::getCompleteTextString()`](https://phpcsutils.com/phpdoc/classes/PHPCSUtils-Utils-TextStrings.html#method_getCompleteTextString) method, we can get access to the complete content of a multi-line text string and prevent the false negative.
  This does create two minor complications though:
    1. The complete text string may contain multiple link/script tags, so we need to use `preg_match_all()` instead of `preg_match()` to be able to report on each of the matches.
    2. We need to figure out on which line of the multi-line text string the matched content occurred so we can throw the error on the correct line.
    Luckily, as multi-line text strings have only one token per line, that's easy enough to work out, especially if we let `preg_match_all()` remember the offsets at which a match was found, so we also won't confuse one match for another.

Thanks to @jrfnl for doing the majority of the job and walking me through the changes needed to happen and explaining why 😊 .