### PR TITLE
Move "minimum WP version" related utilities to dedicated `MinimumWPVersionTrait`

### DIFF
--- a/WordPress/Helpers/MinimumWPVersionTrait.php
+++ b/WordPress/Helpers/MinimumWPVersionTrait.php
@@ -86,12 +86,12 @@ trait MinimumWPVersionTrait {
 	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
 	 */
 	protected function get_wp_version_from_cli( File $phpcsFile ) {
-		$cl_supported_version = trim( Helper::getCommandLineData( $phpcsFile, 'minimum_supported_wp_version' ) );
+		$cli_supported_version = trim( Helper::getCommandLineData( $phpcsFile, 'minimum_supported_wp_version' ) );
 
-		if ( ! empty( $cl_supported_version )
-			&& filter_var( $cl_supported_version, \FILTER_VALIDATE_FLOAT ) !== false
+		if ( ! empty( $cli_supported_version )
+			&& filter_var( $cli_supported_version, \FILTER_VALIDATE_FLOAT ) !== false
 		) {
-			$this->minimum_supported_version = $cl_supported_version;
+			$this->minimum_supported_version = $cli_supported_version;
 		}
 	}
 

--- a/WordPress/Helpers/MinimumWPVersionTrait.php
+++ b/WordPress/Helpers/MinimumWPVersionTrait.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPressCS\WordPress\Helpers;
+
+use PHP_CodeSniffer\Files\File;
+use PHPCSUtils\BackCompat\Helper;
+
+/**
+ * Helper utilities for sniffs which take the minimum supported WP version of the
+ * code under examination into account.
+ *
+ * Usage instructions:
+ * - Add appropriate `use` statement(s) to the file/class which intends to use this functionality.
+ * - Call the `MinimumWPVersionTrait::get_wp_version_from_cl()` method in the `process()`/`process_token()`
+ *   method.
+ * - After that, the `MinimumWPVersionTrait::$minimum_supported_version` property can be freely used
+ *   in the sniff.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @since   3.0.0 The property and method in this trait were previously contained in the
+ *                `WordPressCS\WordPress\Sniff` class and have been moved here.
+ */
+trait MinimumWPVersionTrait {
+
+	/**
+	 * Minimum supported WordPress version.
+	 *
+	 * Currently used by the `WordPress.WP.AlternativeFunctions`,
+	 * `WordPress.WP.DeprecatedClasses`, `WordPress.WP.DeprecatedFunctions`,
+	 * `WordPress.WP.DeprecatedParameter` and the `WordPress.WP.DeprecatedParameterValues` sniff.
+	 *
+	 * These sniffs will throw an error when usage of a deprecated class/function/parameter
+	 * is detected if the class/function/parameter was deprecated before the minimum
+	 * supported WP version; a warning otherwise.
+	 * By default, it is set to presume that a project will support the current
+	 * WP version and up to three releases before.
+	 *
+	 * This property allows changing the minimum supported WP version used by
+	 * these sniffs by setting a property in a custom phpcs.xml ruleset.
+	 * This property will need to be set for each sniff which uses it.
+	 *
+	 * Example usage:
+	 * <rule ref="WordPress.WP.DeprecatedClasses">
+	 *  <properties>
+	 *   <property name="minimum_supported_version" value="4.3"/>
+	 *  </properties>
+	 * </rule>
+	 *
+	 * Alternatively, the value can be passed in one go for all sniff using it via
+	 * the command line or by setting a `<config>` value in a custom phpcs.xml ruleset.
+	 * Note: the `_wp_` in the command line property name!
+	 *
+	 * CL: `phpcs --runtime-set minimum_supported_wp_version 4.5`
+	 * Ruleset: `<config name="minimum_supported_wp_version" value="4.5"/>`
+	 *
+	 * @since 0.14.0 Previously the individual sniffs each contained this property.
+	 * @since 3.0.0  Moved from the Sniff class to this dedicated Trait.
+	 *
+	 * @internal When the value of this property is changed, it will also need
+	 *           to be changed in the `WP/AlternativeFunctionsUnitTest.inc` file.
+	 *
+	 * @var string WordPress version.
+	 */
+	public $minimum_supported_version = '5.1';
+
+	/**
+	 * Overrule the minimum supported WordPress version with a command-line/config value.
+	 *
+	 * Handle setting the minimum supported WP version in one go for all sniffs which
+	 * expect it via the command line or via a `<config>` variable in a ruleset.
+	 * The config variable overrules the default `$minimum_supported_version` and/or a
+	 * `$minimum_supported_version` set for individual sniffs through the ruleset.
+	 *
+	 * @since 0.14.0
+	 * @since 3.0.0  Moved from the Sniff class to this dedicated Trait.
+	 *
+	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+	 */
+	protected function get_wp_version_from_cl() {
+		$cl_supported_version = trim( Helper::getConfigData( 'minimum_supported_wp_version' ) );
+		if ( ! empty( $cl_supported_version )
+			&& filter_var( $cl_supported_version, \FILTER_VALIDATE_FLOAT ) !== false
+		) {
+			$this->minimum_supported_version = $cl_supported_version;
+		}
+	}
+
+}

--- a/WordPress/Helpers/MinimumWPVersionTrait.php
+++ b/WordPress/Helpers/MinimumWPVersionTrait.php
@@ -18,7 +18,7 @@ use PHPCSUtils\BackCompat\Helper;
  *
  * Usage instructions:
  * - Add appropriate `use` statement(s) to the file/class which intends to use this functionality.
- * - Call the `MinimumWPVersionTrait::get_wp_version_from_cl()` method in the `process()`/`process_token()`
+ * - Call the `MinimumWPVersionTrait::get_wp_version_from_cli()` method in the `process()`/`process_token()`
  *   method.
  * - After that, the `MinimumWPVersionTrait::$minimum_supported_version` property can be freely used
  *   in the sniff.
@@ -79,12 +79,13 @@ trait MinimumWPVersionTrait {
 	 * `$minimum_supported_version` set for individual sniffs through the ruleset.
 	 *
 	 * @since 0.14.0
-	 * @since 3.0.0  Moved from the Sniff class to this dedicated Trait.
-	 *               Now requires the $phpcsFile object to be passed in.
+	 * @since 3.0.0  - Moved from the Sniff class to this dedicated Trait.
+	 *               - Renamed from `get_wp_version_from_cl()` to `get_wp_version_from_cli()`.
+	 *               - Now requires the $phpcsFile object to be passed in.
 	 *
 	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
 	 */
-	protected function get_wp_version_from_cl( File $phpcsFile ) {
+	protected function get_wp_version_from_cli( File $phpcsFile ) {
 		$cl_supported_version = trim( Helper::getCommandLineData( $phpcsFile, 'minimum_supported_wp_version' ) );
 
 		if ( ! empty( $cl_supported_version )

--- a/WordPress/Helpers/MinimumWPVersionTrait.php
+++ b/WordPress/Helpers/MinimumWPVersionTrait.php
@@ -80,11 +80,13 @@ trait MinimumWPVersionTrait {
 	 *
 	 * @since 0.14.0
 	 * @since 3.0.0  Moved from the Sniff class to this dedicated Trait.
+	 *               Now requires the $phpcsFile object to be passed in.
 	 *
 	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
 	 */
-	protected function get_wp_version_from_cl() {
-		$cl_supported_version = trim( Helper::getConfigData( 'minimum_supported_wp_version' ) );
+	protected function get_wp_version_from_cl( File $phpcsFile ) {
+		$cl_supported_version = trim( Helper::getCommandLineData( $phpcsFile, 'minimum_supported_wp_version' ) );
+
 		if ( ! empty( $cl_supported_version )
 			&& filter_var( $cl_supported_version, \FILTER_VALIDATE_FLOAT ) !== false
 		) {

--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -12,7 +12,6 @@ namespace WordPressCS\WordPress;
 use PHP_CodeSniffer\Sniffs\Sniff as PHPCS_Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
-use PHPCSUtils\BackCompat\Helper;
 use PHPCSUtils\Utils\Lists;
 use PHPCSUtils\Utils\Namespaces;
 use PHPCSUtils\Utils\PassedParameters;
@@ -48,46 +47,6 @@ abstract class Sniff implements PHPCS_Sniff {
 	 * @var string
 	 */
 	const REGEX_COMPLEX_VARS = '`(?:(\{)?(?<!\\\\)\$)?(\{)?(?<!\\\\)\$(\{)?(?P<varname>[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*)(?:->\$?(?P>varname)|\[[^\]]+\]|::\$?(?P>varname)|\([^\)]*\))*(?(3)\}|)(?(2)\}|)(?(1)\}|)`';
-
-	/**
-	 * Minimum supported WordPress version.
-	 *
-	 * Currently used by the `WordPress.WP.AlternativeFunctions`,
-	 * `WordPress.WP.DeprecatedClasses`, `WordPress.WP.DeprecatedFunctions`
-	 * and the `WordPress.WP.DeprecatedParameter` sniff.
-	 *
-	 * These sniffs will throw an error when usage of a deprecated class/function/parameter
-	 * is detected if the class/function/parameter was deprecated before the minimum
-	 * supported WP version; a warning otherwise.
-	 * By default, it is set to presume that a project will support the current
-	 * WP version and up to three releases before.
-	 *
-	 * This property allows changing the minimum supported WP version used by
-	 * these sniffs by setting a property in a custom phpcs.xml ruleset.
-	 * This property will need to be set for each sniff which uses it.
-	 *
-	 * Example usage:
-	 * <rule ref="WordPress.WP.DeprecatedClasses">
-	 *  <properties>
-	 *   <property name="minimum_supported_version" value="4.3"/>
-	 *  </properties>
-	 * </rule>
-	 *
-	 * Alternatively, the value can be passed in one go for all sniff using it via
-	 * the command line or by setting a `<config>` value in a custom phpcs.xml ruleset.
-	 * Note: the `_wp_` in the command line property name!
-	 *
-	 * CL: `phpcs --runtime-set minimum_supported_wp_version 4.5`
-	 * Ruleset: `<config name="minimum_supported_wp_version" value="4.5"/>`
-	 *
-	 * @since 0.14.0 Previously the individual sniffs each contained this property.
-	 *
-	 * @internal When the value of this property is changed, it will also need
-	 *           to be changed in the `WP/AlternativeFunctionsUnitTest.inc` file.
-	 *
-	 * @var string WordPress version.
-	 */
-	public $minimum_supported_version = '5.1';
 
 	/**
 	 * Custom list of classes which test classes can extend.
@@ -1119,25 +1078,6 @@ abstract class Sniff implements PHPCS_Sniff {
 		$lastPtr = ( $nextPtr - 1 );
 
 		return $lastPtr;
-	}
-
-	/**
-	 * Overrule the minimum supported WordPress version with a command-line/config value.
-	 *
-	 * Handle setting the minimum supported WP version in one go for all sniffs which
-	 * expect it via the command line or via a `<config>` variable in a ruleset.
-	 * The config variable overrules the default `$minimum_supported_version` and/or a
-	 * `$minimum_supported_version` set for individual sniffs through the ruleset.
-	 *
-	 * @since 0.14.0
-	 */
-	protected function get_wp_version_from_cl() {
-		$cl_supported_version = trim( Helper::getConfigData( 'minimum_supported_wp_version' ) );
-		if ( ! empty( $cl_supported_version )
-			&& filter_var( $cl_supported_version, \FILTER_VALIDATE_FLOAT ) !== false
-		) {
-			$this->minimum_supported_version = $cl_supported_version;
-		}
 	}
 
 	/**

--- a/WordPress/Sniffs/WP/AlternativeFunctionsSniff.php
+++ b/WordPress/Sniffs/WP/AlternativeFunctionsSniff.php
@@ -185,7 +185,7 @@ class AlternativeFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 	 */
 	public function process_matched_token( $stackPtr, $group_name, $matched_content ) {
 
-		$this->get_wp_version_from_cl();
+		$this->get_wp_version_from_cl( $this->phpcsFile );
 
 		/*
 		 * Deal with exceptions.

--- a/WordPress/Sniffs/WP/AlternativeFunctionsSniff.php
+++ b/WordPress/Sniffs/WP/AlternativeFunctionsSniff.php
@@ -12,6 +12,7 @@ namespace WordPressCS\WordPress\Sniffs\WP;
 use PHPCSUtils\Utils\PassedParameters;
 use PHPCSUtils\Utils\TextStrings;
 use WordPressCS\WordPress\AbstractFunctionRestrictionsSniff;
+use WordPressCS\WordPress\Helpers\MinimumWPVersionTrait;
 
 /**
  * Discourages the use of various functions and suggests (WordPress) alternatives.
@@ -23,9 +24,11 @@ use WordPressCS\WordPress\AbstractFunctionRestrictionsSniff;
  * @since   1.0.0  - Takes the minimum supported WP version into account.
  *                 - Takes exceptions based on passed parameters into account.
  *
- * @uses    \WordPressCS\WordPress\Sniff::$minimum_supported_version
+ * @uses    \WordPressCS\WordPress\Helpers\MinimumWPVersionTrait::$minimum_supported_version
  */
 class AlternativeFunctionsSniff extends AbstractFunctionRestrictionsSniff {
+
+	use MinimumWPVersionTrait;
 
 	/**
 	 * Local input streams which should not be flagged for the file system function checks.

--- a/WordPress/Sniffs/WP/AlternativeFunctionsSniff.php
+++ b/WordPress/Sniffs/WP/AlternativeFunctionsSniff.php
@@ -185,7 +185,7 @@ class AlternativeFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 	 */
 	public function process_matched_token( $stackPtr, $group_name, $matched_content ) {
 
-		$this->get_wp_version_from_cl( $this->phpcsFile );
+		$this->get_wp_version_from_cli( $this->phpcsFile );
 
 		/*
 		 * Deal with exceptions.

--- a/WordPress/Sniffs/WP/DeprecatedClassesSniff.php
+++ b/WordPress/Sniffs/WP/DeprecatedClassesSniff.php
@@ -96,7 +96,7 @@ class DeprecatedClassesSniff extends AbstractClassRestrictionsSniff {
 	 */
 	public function process_matched_token( $stackPtr, $group_name, $matched_content ) {
 
-		$this->get_wp_version_from_cl( $this->phpcsFile );
+		$this->get_wp_version_from_cli( $this->phpcsFile );
 
 		$class_name = ltrim( strtolower( $matched_content ), '\\' );
 

--- a/WordPress/Sniffs/WP/DeprecatedClassesSniff.php
+++ b/WordPress/Sniffs/WP/DeprecatedClassesSniff.php
@@ -96,7 +96,7 @@ class DeprecatedClassesSniff extends AbstractClassRestrictionsSniff {
 	 */
 	public function process_matched_token( $stackPtr, $group_name, $matched_content ) {
 
-		$this->get_wp_version_from_cl();
+		$this->get_wp_version_from_cl( $this->phpcsFile );
 
 		$class_name = ltrim( strtolower( $matched_content ), '\\' );
 

--- a/WordPress/Sniffs/WP/DeprecatedClassesSniff.php
+++ b/WordPress/Sniffs/WP/DeprecatedClassesSniff.php
@@ -10,6 +10,7 @@
 namespace WordPressCS\WordPress\Sniffs\WP;
 
 use WordPressCS\WordPress\AbstractClassRestrictionsSniff;
+use WordPressCS\WordPress\Helpers\MinimumWPVersionTrait;
 
 /**
  * Restricts the use of deprecated WordPress classes and suggests alternatives.
@@ -28,9 +29,11 @@ use WordPressCS\WordPress\AbstractClassRestrictionsSniff;
  *                 being provided via the command-line or as as <config> value
  *                 in a custom ruleset.
  *
- * @uses    \WordPressCS\WordPress\Sniff::$minimum_supported_version
+ * @uses    \WordPressCS\WordPress\Helpers\MinimumWPVersionTrait::$minimum_supported_version
  */
 class DeprecatedClassesSniff extends AbstractClassRestrictionsSniff {
+
+	use MinimumWPVersionTrait;
 
 	/**
 	 * List of deprecated classes with alternative when available.

--- a/WordPress/Sniffs/WP/DeprecatedFunctionsSniff.php
+++ b/WordPress/Sniffs/WP/DeprecatedFunctionsSniff.php
@@ -10,6 +10,7 @@
 namespace WordPressCS\WordPress\Sniffs\WP;
 
 use WordPressCS\WordPress\AbstractFunctionRestrictionsSniff;
+use WordPressCS\WordPress\Helpers\MinimumWPVersionTrait;
 
 /**
  * Restricts the use of various deprecated WordPress functions and suggests alternatives.
@@ -28,9 +29,11 @@ use WordPressCS\WordPress\AbstractFunctionRestrictionsSniff;
  *                 being provided via the command-line or as as <config> value
  *                 in a custom ruleset.
  *
- * @uses    \WordPressCS\WordPress\Sniff::$minimum_supported_version
+ * @uses    \WordPressCS\WordPress\Helpers\MinimumWPVersionTrait::$minimum_supported_version
  */
 class DeprecatedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
+
+	use MinimumWPVersionTrait;
 
 	/**
 	 * List of deprecated functions with alternative when available.

--- a/WordPress/Sniffs/WP/DeprecatedFunctionsSniff.php
+++ b/WordPress/Sniffs/WP/DeprecatedFunctionsSniff.php
@@ -1398,7 +1398,7 @@ class DeprecatedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 	 */
 	public function process_matched_token( $stackPtr, $group_name, $matched_content ) {
 
-		$this->get_wp_version_from_cl();
+		$this->get_wp_version_from_cl( $this->phpcsFile );
 
 		$function_name = strtolower( $matched_content );
 

--- a/WordPress/Sniffs/WP/DeprecatedFunctionsSniff.php
+++ b/WordPress/Sniffs/WP/DeprecatedFunctionsSniff.php
@@ -1398,7 +1398,7 @@ class DeprecatedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 	 */
 	public function process_matched_token( $stackPtr, $group_name, $matched_content ) {
 
-		$this->get_wp_version_from_cl( $this->phpcsFile );
+		$this->get_wp_version_from_cli( $this->phpcsFile );
 
 		$function_name = strtolower( $matched_content );
 

--- a/WordPress/Sniffs/WP/DeprecatedParameterValuesSniff.php
+++ b/WordPress/Sniffs/WP/DeprecatedParameterValuesSniff.php
@@ -154,7 +154,7 @@ class DeprecatedParameterValuesSniff extends AbstractFunctionParameterSniff {
 	 * @return void
 	 */
 	public function process_parameters( $stackPtr, $group_name, $matched_content, $parameters ) {
-		$this->get_wp_version_from_cl( $this->phpcsFile );
+		$this->get_wp_version_from_cli( $this->phpcsFile );
 		$param_count = \count( $parameters );
 		foreach ( $this->target_functions[ $matched_content ] as $position => $parameter_args ) {
 

--- a/WordPress/Sniffs/WP/DeprecatedParameterValuesSniff.php
+++ b/WordPress/Sniffs/WP/DeprecatedParameterValuesSniff.php
@@ -9,9 +9,10 @@
 
 namespace WordPressCS\WordPress\Sniffs\WP;
 
-use WordPressCS\WordPress\AbstractFunctionParameterSniff;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\Utils\TextStrings;
+use WordPressCS\WordPress\AbstractFunctionParameterSniff;
+use WordPressCS\WordPress\Helpers\MinimumWPVersionTrait;
 
 /**
  * Check for usage of deprecated parameter values in WP functions and provide alternative based on the parameter passed.
@@ -20,9 +21,11 @@ use PHPCSUtils\Utils\TextStrings;
  *
  * @since   1.0.0
  *
- * @uses    \WordPressCS\WordPress\Sniff::$minimum_supported_version
+ * @uses    \WordPressCS\WordPress\Helpers\MinimumWPVersionTrait::$minimum_supported_version
  */
 class DeprecatedParameterValuesSniff extends AbstractFunctionParameterSniff {
+
+	use MinimumWPVersionTrait;
 
 	/**
 	 * The group name for this group of functions.

--- a/WordPress/Sniffs/WP/DeprecatedParameterValuesSniff.php
+++ b/WordPress/Sniffs/WP/DeprecatedParameterValuesSniff.php
@@ -154,7 +154,7 @@ class DeprecatedParameterValuesSniff extends AbstractFunctionParameterSniff {
 	 * @return void
 	 */
 	public function process_parameters( $stackPtr, $group_name, $matched_content, $parameters ) {
-		$this->get_wp_version_from_cl();
+		$this->get_wp_version_from_cl( $this->phpcsFile );
 		$param_count = \count( $parameters );
 		foreach ( $this->target_functions[ $matched_content ] as $position => $parameter_args ) {
 

--- a/WordPress/Sniffs/WP/DeprecatedParametersSniff.php
+++ b/WordPress/Sniffs/WP/DeprecatedParametersSniff.php
@@ -283,7 +283,7 @@ class DeprecatedParametersSniff extends AbstractFunctionParameterSniff {
 	 */
 	public function process_parameters( $stackPtr, $group_name, $matched_content, $parameters ) {
 
-		$this->get_wp_version_from_cl( $this->phpcsFile );
+		$this->get_wp_version_from_cli( $this->phpcsFile );
 
 		$paramCount = \count( $parameters );
 		foreach ( $this->target_functions[ $matched_content ] as $position => $parameter_args ) {

--- a/WordPress/Sniffs/WP/DeprecatedParametersSniff.php
+++ b/WordPress/Sniffs/WP/DeprecatedParametersSniff.php
@@ -11,6 +11,7 @@ namespace WordPressCS\WordPress\Sniffs\WP;
 
 use PHPCSUtils\Utils\TextStrings;
 use WordPressCS\WordPress\AbstractFunctionParameterSniff;
+use WordPressCS\WordPress\Helpers\MinimumWPVersionTrait;
 
 /**
  * Check for usage of deprecated parameters in WP functions and suggest alternative based on the parameter passed.
@@ -29,9 +30,11 @@ use WordPressCS\WordPress\AbstractFunctionParameterSniff;
  *                 being provided via the command-line or as as <config> value
  *                 in a custom ruleset.
  *
- * @uses    \WordPressCS\WordPress\Sniff::$minimum_supported_version
+ * @uses    \WordPressCS\WordPress\Helpers\MinimumWPVersionTrait::$minimum_supported_version
  */
 class DeprecatedParametersSniff extends AbstractFunctionParameterSniff {
+
+	use MinimumWPVersionTrait;
 
 	/**
 	 * The group name for this group of functions.

--- a/WordPress/Sniffs/WP/DeprecatedParametersSniff.php
+++ b/WordPress/Sniffs/WP/DeprecatedParametersSniff.php
@@ -283,7 +283,7 @@ class DeprecatedParametersSniff extends AbstractFunctionParameterSniff {
 	 */
 	public function process_parameters( $stackPtr, $group_name, $matched_content, $parameters ) {
 
-		$this->get_wp_version_from_cl();
+		$this->get_wp_version_from_cl( $this->phpcsFile );
 
 		$paramCount = \count( $parameters );
 		foreach ( $this->target_functions[ $matched_content ] as $position => $parameter_args ) {


### PR DESCRIPTION
### Move "minimum WP version" related utilities to dedicated `MinimumWPVersionTrait`

The "minimum WP version" related utilities are only used by a small set of sniffs, so are better placed in a dedicated trait.

This moves the `$minimum_supported_version` property and the `get_wp_version_from_cl()` method to a new `WordPressCS\WordPress\Helpers\MinimumWPVersionTrait` and starts using that trait in the relevant sniffs.

Related to #1465

### MinimumWPVersionTrait: use PHPCSUtils Helper::getCommandLineData()

The `get_wp_version_from_cl()` method now uses the PHPCSUtils `Helper::getCommandLineData()` method instead of the `Helper::getConfigData()` for more reliable results.

Because of this change, the `$phpcsFile` object is now a required parameter for the `get_wp_version_from_cl()` method.
All calls to the method have been adjusted for this change.


--- [EDIT] New commit --- 

### MinimumWPVersionTrait: rename the `get_wp_version_from_cl()` method

... to `get_wp_version_from_cli()` as per the review suggestion.

Includes adjusting all relevant call to the method.
