### PR TITLE
ArrayIndentation: bug fix - prevent fixer conflict

### DIFF
--- a/WordPress/Sniffs/Arrays/ArrayIndentationSniff.php
+++ b/WordPress/Sniffs/Arrays/ArrayIndentationSniff.php
@@ -208,11 +208,20 @@ class ArrayIndentationSniff extends Sniff {
 
 			// Bow out from reporting and fixing mixed multi-line/single-line arrays.
 			// That is handled by the ArrayDeclarationSpacingSniff.
-			if ( $this->tokens[ $first_content ]['line'] === $this->tokens[ $end_of_previous_item ]['line']
-				|| ( 1 !== $this->tokens[ $first_content ]['column']
-					&& \T_WHITESPACE !== $this->tokens[ ( $first_content - 1 ) ]['code'] )
-			) {
+			if ( $this->tokens[ $first_content ]['line'] === $this->tokens[ $end_of_previous_item ]['line'] ) {
 				return $closer;
+			}
+
+			// Ignore this item if there is anything but whitespace before the start of the next item.
+			if ( 1 !== $this->tokens[ $first_content ]['column'] ) {
+				// Go to the start of the line.
+				$i = $first_content;
+				while ( 1 !== $this->tokens[ --$i ]['column'] );
+
+				if ( \T_WHITESPACE !== $this->tokens[ $i ]['code'] ) {
+					$end_of_previous_item = $end_of_this_item;
+					continue;
+				}
 			}
 
 			$found_spaces = ( $this->tokens[ $first_content ]['column'] - 1 );

--- a/WordPress/Tests/Arrays/ArrayIndentationUnitTest.1.inc
+++ b/WordPress/Tests/Arrays/ArrayIndentationUnitTest.1.inc
@@ -436,3 +436,9 @@ $my_array = [
 'prop1' => $prop1,
 			'prop2' => $prop2,
 ] = $some_var;
+
+// Fixer conflict prevention.
+$bad = array(
+	'key1' => 'value1', /* comment
+	end */ 'key2' => 'value2',
+);

--- a/WordPress/Tests/Arrays/ArrayIndentationUnitTest.1.inc.fixed
+++ b/WordPress/Tests/Arrays/ArrayIndentationUnitTest.1.inc.fixed
@@ -436,3 +436,9 @@ $my_array = [
 'prop1' => $prop1,
 			'prop2' => $prop2,
 ] = $some_var;
+
+// Fixer conflict prevention.
+$bad = array(
+	'key1' => 'value1', /* comment
+	end */ 'key2' => 'value2',
+);

--- a/WordPress/Tests/Arrays/ArrayIndentationUnitTest.2.inc
+++ b/WordPress/Tests/Arrays/ArrayIndentationUnitTest.2.inc
@@ -434,7 +434,13 @@ $my_array = [
  */
 [
 'prop1' => $prop1,
-			'prop2' => $prop2,
+            'prop2' => $prop2,
 ] = $some_var;
+
+// Fixer conflict prevention.
+$bad = array(
+    'key1' => 'value1', /* comment
+    end */ 'key2' => 'value2',
+);
 
 // phpcs:set WordPress.Arrays.ArrayIndentation tabIndent true

--- a/WordPress/Tests/Arrays/ArrayIndentationUnitTest.2.inc.fixed
+++ b/WordPress/Tests/Arrays/ArrayIndentationUnitTest.2.inc.fixed
@@ -434,7 +434,13 @@ $my_array = [
  */
 [
 'prop1' => $prop1,
-			'prop2' => $prop2,
+            'prop2' => $prop2,
 ] = $some_var;
+
+// Fixer conflict prevention.
+$bad = array(
+    'key1' => 'value1', /* comment
+    end */ 'key2' => 'value2',
+);
 
 // phpcs:set WordPress.Arrays.ArrayIndentation tabIndent true


### PR DESCRIPTION
If an array item has something else on the same line before it, the indentation should be left alone.

This fixes a potential fixer conflict with the `DisallowInlineTabs` sniff which could occur when the sniffs are being run in a unconventional order.

Discovered when making a change to the Travis file and not reproducible locally, but consistently reproducible with the alternative running order of sniffs on select platforms, as per the [Travis build on Xenial](https://travis-ci.com/github/WordPress/WordPress-Coding-Standards/builds/176411794).