### PR TITLE
EscapeOutput: defensive coding

### DIFF
--- a/WordPress/Sniffs/Security/EscapeOutputSniff.php
+++ b/WordPress/Sniffs/Security/EscapeOutputSniff.php
@@ -196,7 +196,12 @@ class EscapeOutputSniff extends Sniff {
 
 			// These functions only need to have the first argument escaped.
 			if ( \in_array( $function, array( 'trigger_error', 'user_error' ), true ) ) {
-				$first_param      = PassedParameters::getParameter( $this->phpcsFile, $stackPtr, 1 );
+				$first_param = PassedParameters::getParameter( $this->phpcsFile, $stackPtr, 1 );
+				if ( false === $first_param ) {
+					// First parameter doesn't exist. Nothing to do.
+					return;
+				}
+
 				$end_of_statement = ( $first_param['end'] + 1 );
 				unset( $first_param );
 			}
@@ -207,6 +212,10 @@ class EscapeOutputSniff extends Sniff {
 			 */
 			if ( '_deprecated_file' === $function ) {
 				$first_param = PassedParameters::getParameter( $this->phpcsFile, $stackPtr, 1 );
+				if ( false === $first_param ) {
+					// First parameter doesn't exist. Nothing to do.
+					return;
+				}
 
 				// Quick check. This disregards comments.
 				if ( preg_match( '`^basename\s*\(\s*__FILE__\s*\)$`', $first_param['raw'] ) === 1 ) {

--- a/WordPress/Tests/Security/EscapeOutputUnitTest.inc
+++ b/WordPress/Tests/Security/EscapeOutputUnitTest.inc
@@ -295,3 +295,6 @@ echo implode( '<br>', map_deep( $items, 'foo' ) ); // Bad.
 
 _deprecated_file( basename( __FILE__ ), '1.3.0' ); // Ok.
 _deprecated_file( $file, '1.3.0' ); // Error.
+
+trigger_error(); // Ignore.
+_deprecated_file(); // Ignore.


### PR DESCRIPTION
The `PassedParameters::getParameter()` method (and the `Sniff::get_function_call_parameter()` method before it), either returns an array with information on the parameter or `false` if the parameter does not exist.

A call to `trigger_error()` and the likes, without passing parameters is a little useless and will throw a warning in PHP 4/5/7 and a fatal `ArgumentCountError` in PHP 8.

However, those types of errors are not the concern of this sniff, so if a call to these functions is encountered without arguments, the sniff should conclude that there is nothing which needs escaping and bow out.

Fix now, including unit test to safeguard against it in the future.