### PR TITLE
EscapedNotTranslated: use PHPCSUtils `GetTokensAsString`

### DIFF
--- a/WordPress/Sniffs/CodeAnalysis/EscapedNotTranslatedSniff.php
+++ b/WordPress/Sniffs/CodeAnalysis/EscapedNotTranslatedSniff.php
@@ -11,6 +11,7 @@ namespace WordPressCS\WordPress\Sniffs\CodeAnalysis;
 
 use WordPressCS\WordPress\AbstractFunctionParameterSniff;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Utils\GetTokensAsString;
 
 /**
  * Flag calls to escaping functions which look like they may have been intended
@@ -76,7 +77,7 @@ class EscapedNotTranslatedSniff extends AbstractFunctionParameterSniff {
 		$data = array(
 			$matched_content,
 			$this->target_functions[ $matched_content ],
-			$this->phpcsFile->getTokensAsString( $stackPtr, ( $closer - $stackPtr + 1 ) ),
+			GetTokensAsString::compact( $this->phpcsFile, $stackPtr, $closer, true ),
 		);
 
 		$this->phpcsFile->addWarning(

--- a/WordPress/Tests/CodeAnalysis/EscapedNotTranslatedUnitTest.inc
+++ b/WordPress/Tests/CodeAnalysis/EscapedNotTranslatedUnitTest.inc
@@ -5,4 +5,7 @@ esc_html( $var );
 
 esc_html( 'text', 'domain' ); // Warning.
 esc_html( $foo, $bar ); // Warning.
-esc_attr( 'text', MY_DOMAIN ); // Warning.
+esc_attr(
+	'text', // Some comment.
+	MY_DOMAIN // More comment.
+); // Warning.


### PR DESCRIPTION
The PHPCS native `getTokensAsString()` method has two drawbacks:
1. It is fiddly to use as you always need to do some calculation to find the number of tokens you want to method to concatenate.
2. It will concatenate **everything**, i.e. including new lines, comments etc.

The `getTokensAsString()` method is often used to display a "found" string in an error message and the error message would benefit from that "found" string being clean of comments and having whitespace compacted.

In comes PHPCSUtils. PHPCSUtils has dedicated [`GetTokensAsString`](https://phpcsutils.com/phpdoc/classes/PHPCSUtils-Utils-GetTokensAsString.html) class which contains a variety of methods to retrieve a concatenated string of the content of a group of tokens.

So, for the `EscapedNotTranslated` sniff, replacing the function call to the PHPCS native method with one to one of the PHPCSUtils variations, ensures that the "found" string in the error message is clean and easy to read.

Tested by adjusting one of the existing unit tests.

The current unit test setup does not allow for testing the actual error message, but you can see the difference if you just run the sniff (with and without the change) over the adjusted unit test case file.