### PR TITLE
 Travis: retry composer install on failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -171,15 +171,15 @@ install:
       else
         composer config preferred-install.squizlabs/php_codesniffer auto
       fi
-    - composer require squizlabs/php_codesniffer:"${PHPCS_BRANCH}" --no-update --no-suggest --no-scripts
+    - travis_retry composer require squizlabs/php_codesniffer:"${PHPCS_BRANCH}" --no-update --no-suggest --no-scripts
     - |
       if [[ $TRAVIS_PHP_VERSION == "nightly" ]]; then
         # PHPUnit 7.x does not allow for installation on PHP 8, so ignore platform
         # requirements to get PHPUnit 7.x to install on nightly.
-        composer install --ignore-platform-reqs --no-suggest
+        travis_retry composer install --ignore-platform-reqs --no-suggest
       else
         # Do a normal dev install in all other cases.
-        composer install --no-suggest
+        travis_retry composer install --no-suggest
       fi
 
 script:


### PR DESCRIPTION
Initially I was only going to pull the first commit, but Composer `1.10.11` has just come out and is breaking builds, so the second commit is a temporary fix for that.

Once this PR has been merged, I will rebase @NielsdeBlaauw's two Docs PRs so we can have a passing build for those.


### Travis: retry composer install on failure

The builds are failing a little too often for my taste on the below error.
```
[Composer\Downloader\TransportException]
Peer fingerprint did not match
```

I'm prefixing the `composer install` commands now with `travis_retry` in an attempt to get round this problem.

Ref:
* https://docs.travis-ci.com/user/common-build-problems/#timeouts-installing-dependencies

### ~~Travis: roll-back Composer to v 1.10.10~~

~~... as there is an issue with Composer 1.10.11, which prevents the `install` from working.~~

~~For more information: composer/composer#9191~~

