### PR TITLE
TypeCasts: change `(unset)` cast from warning to error

### DIFF
--- a/WordPress/Sniffs/PHP/TypeCastsSniff.php
+++ b/WordPress/Sniffs/PHP/TypeCastsSniff.php
@@ -72,8 +72,8 @@ class TypeCastsSniff extends Sniff {
 				break;
 
 			case \T_UNSET_CAST:
-				$this->phpcsFile->addWarning(
-					'Using the "(unset)" cast is strongly discouraged. Use the "unset()" language construct or assign "null" as the value to the variable instead.',
+				$this->phpcsFile->addError(
+					'Using the "(unset)" cast is forbidden as the type cast is removed in PHP 8. Use the "unset()" language construct or assign "null" as the value to the variable instead.',
 					$stackPtr,
 					'UnsetFound'
 				);

--- a/WordPress/Tests/PHP/TypeCastsUnitTest.inc
+++ b/WordPress/Tests/PHP/TypeCastsUnitTest.inc
@@ -10,8 +10,8 @@ $a = (object) $b;
 $a = (double) $b;
 $a = (real) $b;
 
+$a = (unset) $b; // Error.
 // Warning: Discouraged casts.
-$a = (unset) $b; // Warning.
 $a = (binary) $b; // Warning.
 $a = b"binary string"; // Warning.
 $a = b"binary $string"; // Warning.
@@ -25,5 +25,5 @@ $a = (object      ) $b;
 
 $a = (double ) $b; // Error.
 $a = ( real ) $b; // Error.
-$a = (  unset ) $b; // Warning.
+$a = (  unset ) $b; // Error.
 $a = ( binary ) $b; // Warning.

--- a/WordPress/Tests/PHP/TypeCastsUnitTest.inc.fixed
+++ b/WordPress/Tests/PHP/TypeCastsUnitTest.inc.fixed
@@ -10,8 +10,8 @@ $a = (object) $b;
 $a = (float) $b;
 $a = (float) $b;
 
+$a = (unset) $b; // Error.
 // Warning: Discouraged casts.
-$a = (unset) $b; // Warning.
 $a = (binary) $b; // Warning.
 $a = b"binary string"; // Warning.
 $a = b"binary $string"; // Warning.
@@ -25,5 +25,5 @@ $a = (object      ) $b;
 
 $a = (float) $b; // Error.
 $a = (float) $b; // Error.
-$a = (  unset ) $b; // Warning.
+$a = (  unset ) $b; // Error.
 $a = ( binary ) $b; // Warning.

--- a/WordPress/Tests/PHP/TypeCastsUnitTest.php
+++ b/WordPress/Tests/PHP/TypeCastsUnitTest.php
@@ -29,8 +29,10 @@ class TypeCastsUnitTest extends AbstractSniffUnitTest {
 		return array(
 			10 => 1,
 			11 => 1,
+			13 => 1,
 			26 => 1,
 			27 => 1,
+			28 => 1,
 		);
 	}
 
@@ -41,11 +43,9 @@ class TypeCastsUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getWarningList() {
 		return array(
-			14 => 1,
 			15 => 1,
 			16 => 1,
 			17 => 1,
-			28 => 1,
 			29 => 1,
 		);
 	}


### PR DESCRIPTION
The `(unset)` cast has been removed in PHP 8 and should never be used.

Includes updated unit tests.