### PR TITLE
3.0: Move "is unit test" utility functions to dedicated trait

### DIFF
--- a/WordPress/Helpers/IsUnitTestTrait.php
+++ b/WordPress/Helpers/IsUnitTestTrait.php
@@ -19,6 +19,13 @@ use WordPressCS\WordPress\Sniff as WPCS_Sniff;
  * Helper utilities for sniffs which need to take into account whether the
  * code under examination is unit test code or not.
  *
+ * Usage instructions:
+ * - Add appropriate `use` statement(s) to the file/class which intends to use this functionality.
+ * - Now the sniff will automatically support the public `custom_test_classes` property which
+ *   users can set in their custom ruleset. Do not add the property to the sniff!
+ * - The sniff can call the methods in this trait to verify if certain code was found within
+ *   a test method or is a test class and will take the custom property into account.
+ *
  * @package WPCS\WordPressCodingStandards
  * @since   3.0.0 The properties and method in this trait were previously contained in the
  *                `WordPressCS\WordPress\Sniff` class and have been moved here.
@@ -28,13 +35,15 @@ trait IsUnitTestTrait {
 	/**
 	 * Custom list of classes which test classes can extend.
 	 *
-	 * This property allows end-users to add to the $known_test_classes via their ruleset.
-	 * This property will need to be set for each sniff which uses the
-	 * `is_test_class()` method.
-	 * Currently the method is used by the `WordPress.WP.GlobalVariablesOverride`,
+	 * This property allows end-users to add to the build-in `$known_test_classes`
+	 * via their custom PHPCS ruleset.
+	 * This property will need to be set for each sniff which uses this trait.
+	 *
+	 * Currently this property is used by the `WordPress.WP.GlobalVariablesOverride`,
 	 * `WordPress.NamingConventions.PrefixAllGlobals` and the `WordPress.Files.Filename` sniffs.
 	 *
 	 * Example usage:
+	 * ```xml
 	 * <rule ref="WordPress.[Subset].[Sniffname]">
 	 *  <properties>
 	 *   <property name="custom_test_classes" type="array">
@@ -43,6 +52,11 @@ trait IsUnitTestTrait {
 	 *   </property>
 	 *  </properties>
 	 * </rule>
+	 * ```
+	 *
+	 * Note: it is strongly _recommended_ to exclude your test directories for
+	 * select error codes of those particular sniffs instead of relying on this
+	 * property/trait.
 	 *
 	 * @since 0.11.0
 	 * @since 3.0.0  Moved from the Sniff class to this dedicated Trait.
@@ -85,8 +99,9 @@ trait IsUnitTestTrait {
 	 * Check if a class token is part of a unit test suite.
 	 *
 	 * Unit test classes are identified as such:
-	 * - Class which either extends WP_UnitTestCase or PHPUnit_Framework_TestCase
-	 *   or a custom whitelisted unit test class.
+	 * - Class which either extends one of the known test cases, such as `WP_UnitTestCase`
+	 *   or `PHPUnit_Framework_TestCase` or extends a custom unit test class as listed in the
+	 *   `custom_test_classes` property.
 	 *
 	 * @since 0.12.0 Split off from the `is_token_in_test_method()` method.
 	 * @since 1.0.0  Improved recognition of namespaced class names.

--- a/WordPress/Helpers/IsUnitTestTrait.php
+++ b/WordPress/Helpers/IsUnitTestTrait.php
@@ -28,7 +28,7 @@ trait IsUnitTestTrait {
 	/**
 	 * Custom list of classes which test classes can extend.
 	 *
-	 * This property allows end-users to add to the $test_class_whitelist via their ruleset.
+	 * This property allows end-users to add to the $known_test_classes via their ruleset.
 	 * This property will need to be set for each sniff which uses the
 	 * `is_test_class()` method.
 	 * Currently the method is used by the `WordPress.WP.GlobalVariablesOverride`,
@@ -52,14 +52,15 @@ trait IsUnitTestTrait {
 	public $custom_test_class_whitelist = array();
 
 	/**
-	 * Whitelist of classes which test classes can extend.
+	 * List of PHPUnit and WP native classes which test classes can extend.
 	 *
 	 * @since 0.11.0
 	 * @since 3.0.0  Moved from the Sniff class to this dedicated Trait.
+	 *               Renamed from `$test_class_whitelist` to `$known_test_classes`.
 	 *
 	 * @var string[]
 	 */
-	protected $test_class_whitelist = array(
+	protected $known_test_classes = array(
 		'WP_UnitTestCase_Base'                       => true,
 		'WP_UnitTestCase'                            => true,
 		'WP_Ajax_UnitTestCase'                       => true,
@@ -99,10 +100,10 @@ trait IsUnitTestTrait {
 			return false;
 		}
 
-		// Add any potentially whitelisted custom test classes to the whitelist.
+		// Add any potentially extra custom test classes to the known test classes list.
 		$whitelist = WPCS_Sniff::merge_custom_array(
 			$this->custom_test_class_whitelist,
-			$this->test_class_whitelist
+			$this->known_test_classes
 		);
 
 		/*

--- a/WordPress/Helpers/IsUnitTestTrait.php
+++ b/WordPress/Helpers/IsUnitTestTrait.php
@@ -102,7 +102,7 @@ trait IsUnitTestTrait {
 		}
 
 		// Add any potentially extra custom test classes to the known test classes list.
-		$whitelist = WPCS_Sniff::merge_custom_array(
+		$known_test_classes = WPCS_Sniff::merge_custom_array(
 			$this->custom_test_classes,
 			$this->known_test_classes
 		);
@@ -111,18 +111,18 @@ trait IsUnitTestTrait {
 		 * Show some tolerance for user input.
 		 * The custom test class names should be passed as FQN without a prefixing `\`.
 		 */
-		foreach ( $whitelist as $k => $v ) {
-			$whitelist[ $k ] = ltrim( $v, '\\' );
+		foreach ( $known_test_classes as $k => $v ) {
+			$known_test_classes[ $k ] = ltrim( $v, '\\' );
 		}
 
 		// Is the class/trait one of the whitelisted test classes ?
 		$namespace = Namespaces::determineNamespace( $phpcsFile, $stackPtr );
 		$className = ObjectDeclarations::getName( $phpcsFile, $stackPtr );
 		if ( '' !== $namespace ) {
-			if ( isset( $whitelist[ $namespace . '\\' . $className ] ) ) {
+			if ( isset( $known_test_classes[ $namespace . '\\' . $className ] ) ) {
 				return true;
 			}
-		} elseif ( isset( $whitelist[ $className ] ) ) {
+		} elseif ( isset( $known_test_classes[ $className ] ) ) {
 			return true;
 		}
 
@@ -133,14 +133,14 @@ trait IsUnitTestTrait {
 		}
 
 		if ( '\\' === $extendedClassName[0] ) {
-			if ( isset( $whitelist[ substr( $extendedClassName, 1 ) ] ) ) {
+			if ( isset( $known_test_classes[ substr( $extendedClassName, 1 ) ] ) ) {
 				return true;
 			}
 		} elseif ( '' !== $namespace ) {
-			if ( isset( $whitelist[ $namespace . '\\' . $extendedClassName ] ) ) {
+			if ( isset( $known_test_classes[ $namespace . '\\' . $extendedClassName ] ) ) {
 				return true;
 			}
-		} elseif ( isset( $whitelist[ $extendedClassName ] ) ) {
+		} elseif ( isset( $known_test_classes[ $extendedClassName ] ) ) {
 			return true;
 		}
 

--- a/WordPress/Helpers/IsUnitTestTrait.php
+++ b/WordPress/Helpers/IsUnitTestTrait.php
@@ -55,6 +55,9 @@ trait IsUnitTestTrait {
 	/**
 	 * List of PHPUnit and WP native classes which test classes can extend.
 	 *
+	 * {internal These are the test cases provided in the `/tests/phpunit/includes/`
+	 *           directory of WP Core.}
+	 *
 	 * @since 0.11.0
 	 * @since 3.0.0  Moved from the Sniff class to this dedicated Trait.
 	 *               Renamed from `$test_class_whitelist` to `$known_test_classes`.
@@ -65,10 +68,12 @@ trait IsUnitTestTrait {
 		'WP_UnitTestCase_Base'                       => true,
 		'WP_UnitTestCase'                            => true,
 		'WP_Ajax_UnitTestCase'                       => true,
+		'Block_Supported_Styles_Test'                => true,
 		'WP_Canonical_UnitTestCase'                  => true,
 		'WP_Test_REST_TestCase'                      => true,
 		'WP_Test_REST_Controller_Testcase'           => true,
 		'WP_Test_REST_Post_Type_Controller_Testcase' => true,
+		'WP_Test_XML_TestCase'                       => true,
 		'WP_XMLRPC_UnitTestCase'                     => true,
 		'PHPUnit_Framework_TestCase'                 => true,
 		'PHPUnit\Framework\TestCase'                 => true,

--- a/WordPress/Helpers/IsUnitTestTrait.php
+++ b/WordPress/Helpers/IsUnitTestTrait.php
@@ -1,0 +1,154 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPressCS\WordPress\Helpers;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Utils\Namespaces;
+use WordPressCS\WordPress\Sniff as WPCS_Sniff;
+
+/**
+ * Helper utilities for sniffs which need to take into account whether the
+ * code under examination is unit test code or not.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @since   3.0.0 The properties and method in this trait were previously contained in the
+ *                `WordPressCS\WordPress\Sniff` class and have been moved here.
+ */
+trait IsUnitTestTrait {
+
+	/**
+	 * Custom list of classes which test classes can extend.
+	 *
+	 * This property allows end-users to add to the $test_class_whitelist via their ruleset.
+	 * This property will need to be set for each sniff which uses the
+	 * `is_test_class()` method.
+	 * Currently the method is used by the `WordPress.WP.GlobalVariablesOverride`,
+	 * `WordPress.NamingConventions.PrefixAllGlobals` and the `WordPress.Files.Filename` sniffs.
+	 *
+	 * Example usage:
+	 * <rule ref="WordPress.[Subset].[Sniffname]">
+	 *  <properties>
+	 *   <property name="custom_test_class_whitelist" type="array">
+	 *     <element value="My_Plugin_First_Test_Class"/>
+	 *     <element value="My_Plugin_Second_Test_Class"/>
+	 *   </property>
+	 *  </properties>
+	 * </rule>
+	 *
+	 * @since 0.11.0
+	 * @since 3.0.0  Moved from the Sniff class to this dedicated Trait.
+	 *
+	 * @var string|string[]
+	 */
+	public $custom_test_class_whitelist = array();
+
+	/**
+	 * Whitelist of classes which test classes can extend.
+	 *
+	 * @since 0.11.0
+	 * @since 3.0.0  Moved from the Sniff class to this dedicated Trait.
+	 *
+	 * @var string[]
+	 */
+	protected $test_class_whitelist = array(
+		'WP_UnitTestCase_Base'                       => true,
+		'WP_UnitTestCase'                            => true,
+		'WP_Ajax_UnitTestCase'                       => true,
+		'WP_Canonical_UnitTestCase'                  => true,
+		'WP_Test_REST_TestCase'                      => true,
+		'WP_Test_REST_Controller_Testcase'           => true,
+		'WP_Test_REST_Post_Type_Controller_Testcase' => true,
+		'WP_XMLRPC_UnitTestCase'                     => true,
+		'PHPUnit_Framework_TestCase'                 => true,
+		'PHPUnit\Framework\TestCase'                 => true,
+		// PHPUnit native TestCase class when imported via use statement.
+		'TestCase'                                   => true,
+	);
+
+	/**
+	 * Check if a class token is part of a unit test suite.
+	 *
+	 * Unit test classes are identified as such:
+	 * - Class which either extends WP_UnitTestCase or PHPUnit_Framework_TestCase
+	 *   or a custom whitelisted unit test class.
+	 *
+	 * @since 0.12.0 Split off from the `is_token_in_test_method()` method.
+	 * @since 1.0.0  Improved recognition of namespaced class names.
+	 * @since 3.0.0  Moved from the Sniff class to this dedicated Trait.
+	 *
+	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+	 * @param int                         $stackPtr  The position of the token to be examined.
+	 *                                               This should be a class, anonymous class or trait token.
+	 *
+	 * @return bool True if the class is a unit test class, false otherwise.
+	 */
+	protected function is_test_class( File $phpcsFile, $stackPtr ) {
+
+		$tokens = $phpcsFile->getTokens();
+
+		if ( isset( $tokens[ $stackPtr ], Tokens::$ooScopeTokens[ $tokens[ $stackPtr ]['code'] ] ) === false ) {
+			return false;
+		}
+
+		// Add any potentially whitelisted custom test classes to the whitelist.
+		$whitelist = WPCS_Sniff::merge_custom_array(
+			$this->custom_test_class_whitelist,
+			$this->test_class_whitelist
+		);
+
+		/*
+		 * Show some tolerance for user input.
+		 * The custom test class names should be passed as FQN without a prefixing `\`.
+		 */
+		foreach ( $whitelist as $k => $v ) {
+			$whitelist[ $k ] = ltrim( $v, '\\' );
+		}
+
+		// Is the class/trait one of the whitelisted test classes ?
+		$namespace = Namespaces::determineNamespace( $phpcsFile, $stackPtr );
+		$className = $phpcsFile->getDeclarationName( $stackPtr );
+		if ( '' !== $namespace ) {
+			if ( isset( $whitelist[ $namespace . '\\' . $className ] ) ) {
+				return true;
+			}
+		} elseif ( isset( $whitelist[ $className ] ) ) {
+			return true;
+		}
+
+		// Does the class/trait extend one of the whitelisted test classes ?
+		$extendedClassName = $phpcsFile->findExtendedClassName( $stackPtr );
+		if ( false === $extendedClassName ) {
+			return false;
+		}
+
+		if ( '\\' === $extendedClassName[0] ) {
+			if ( isset( $whitelist[ substr( $extendedClassName, 1 ) ] ) ) {
+				return true;
+			}
+		} elseif ( '' !== $namespace ) {
+			if ( isset( $whitelist[ $namespace . '\\' . $extendedClassName ] ) ) {
+				return true;
+			}
+		} elseif ( isset( $whitelist[ $extendedClassName ] ) ) {
+			return true;
+		}
+
+		/*
+		 * Not examining imported classes via `use` statements as with the variety of syntaxes,
+		 * this would get very complicated.
+		 * After all, users can add an `<exclude-pattern>` for a particular sniff to their
+		 * custom ruleset to selectively exclude the test directory.
+		 */
+
+		return false;
+	}
+
+}

--- a/WordPress/Helpers/IsUnitTestTrait.php
+++ b/WordPress/Helpers/IsUnitTestTrait.php
@@ -37,7 +37,7 @@ trait IsUnitTestTrait {
 	 * Example usage:
 	 * <rule ref="WordPress.[Subset].[Sniffname]">
 	 *  <properties>
-	 *   <property name="custom_test_class_whitelist" type="array">
+	 *   <property name="custom_test_classes" type="array">
 	 *     <element value="My_Plugin_First_Test_Class"/>
 	 *     <element value="My_Plugin_Second_Test_Class"/>
 	 *   </property>
@@ -46,10 +46,11 @@ trait IsUnitTestTrait {
 	 *
 	 * @since 0.11.0
 	 * @since 3.0.0  Moved from the Sniff class to this dedicated Trait.
+	 *               Renamed from `$custom_test_class_whitelist` to `$custom_test_classes`.
 	 *
 	 * @var string|string[]
 	 */
-	public $custom_test_class_whitelist = array();
+	public $custom_test_classes = array();
 
 	/**
 	 * List of PHPUnit and WP native classes which test classes can extend.
@@ -102,7 +103,7 @@ trait IsUnitTestTrait {
 
 		// Add any potentially extra custom test classes to the known test classes list.
 		$whitelist = WPCS_Sniff::merge_custom_array(
-			$this->custom_test_class_whitelist,
+			$this->custom_test_classes,
 			$this->known_test_classes
 		);
 

--- a/WordPress/Helpers/IsUnitTestTrait.php
+++ b/WordPress/Helpers/IsUnitTestTrait.php
@@ -12,6 +12,7 @@ namespace WordPressCS\WordPress\Helpers;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\Utils\Namespaces;
+use PHPCSUtils\Utils\ObjectDeclarations;
 use WordPressCS\WordPress\Sniff as WPCS_Sniff;
 
 /**
@@ -114,7 +115,7 @@ trait IsUnitTestTrait {
 
 		// Is the class/trait one of the whitelisted test classes ?
 		$namespace = Namespaces::determineNamespace( $phpcsFile, $stackPtr );
-		$className = $phpcsFile->getDeclarationName( $stackPtr );
+		$className = ObjectDeclarations::getName( $phpcsFile, $stackPtr );
 		if ( '' !== $namespace ) {
 			if ( isset( $whitelist[ $namespace . '\\' . $className ] ) ) {
 				return true;
@@ -124,7 +125,7 @@ trait IsUnitTestTrait {
 		}
 
 		// Does the class/trait extend one of the whitelisted test classes ?
-		$extendedClassName = $phpcsFile->findExtendedClassName( $stackPtr );
+		$extendedClassName = ObjectDeclarations::findExtendedClassName( $phpcsFile, $stackPtr );
 		if ( false === $extendedClassName ) {
 			return false;
 		}

--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -13,7 +13,6 @@ use PHP_CodeSniffer\Sniffs\Sniff as PHPCS_Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\Utils\Lists;
-use PHPCSUtils\Utils\Namespaces;
 use PHPCSUtils\Utils\PassedParameters;
 use PHPCSUtils\Utils\Scopes;
 use PHPCSUtils\Utils\TextStrings;
@@ -47,31 +46,6 @@ abstract class Sniff implements PHPCS_Sniff {
 	 * @var string
 	 */
 	const REGEX_COMPLEX_VARS = '`(?:(\{)?(?<!\\\\)\$)?(\{)?(?<!\\\\)\$(\{)?(?P<varname>[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*)(?:->\$?(?P>varname)|\[[^\]]+\]|::\$?(?P>varname)|\([^\)]*\))*(?(3)\}|)(?(2)\}|)(?(1)\}|)`';
-
-	/**
-	 * Custom list of classes which test classes can extend.
-	 *
-	 * This property allows end-users to add to the $test_class_whitelist via their ruleset.
-	 * This property will need to be set for each sniff which uses the
-	 * `is_test_class()` method.
-	 * Currently the method is used by the `WordPress.WP.GlobalVariablesOverride`,
-	 * `WordPress.NamingConventions.PrefixAllGlobals` and the `WordPress.Files.Filename` sniffs.
-	 *
-	 * Example usage:
-	 * <rule ref="WordPress.[Subset].[Sniffname]">
-	 *  <properties>
-	 *   <property name="custom_test_class_whitelist" type="array">
-	 *     <element value="My_Plugin_First_Test_Class"/>
-	 *     <element value="My_Plugin_Second_Test_Class"/>
-	 *   </property>
-	 *  </properties>
-	 * </rule>
-	 *
-	 * @since 0.11.0
-	 *
-	 * @var string|string[]
-	 */
-	public $custom_test_class_whitelist = array();
 
 	/**
 	 * List of the functions which verify nonces.
@@ -818,28 +792,6 @@ abstract class Sniff implements PHPCS_Sniff {
 	);
 
 	/**
-	 * Whitelist of classes which test classes can extend.
-	 *
-	 * @since 0.11.0
-	 *
-	 * @var string[]
-	 */
-	protected $test_class_whitelist = array(
-		'WP_UnitTestCase_Base'                       => true,
-		'WP_UnitTestCase'                            => true,
-		'WP_Ajax_UnitTestCase'                       => true,
-		'WP_Canonical_UnitTestCase'                  => true,
-		'WP_Test_REST_TestCase'                      => true,
-		'WP_Test_REST_Controller_Testcase'           => true,
-		'WP_Test_REST_Post_Type_Controller_Testcase' => true,
-		'WP_XMLRPC_UnitTestCase'                     => true,
-		'PHPUnit_Framework_TestCase'                 => true,
-		'PHPUnit\Framework\TestCase'                 => true,
-		// PHPUnit native TestCase class when imported via use statement.
-		'TestCase'                                   => true,
-	);
-
-	/**
 	 * The current file being sniffed.
 	 *
 	 * @since 0.4.0
@@ -1078,80 +1030,6 @@ abstract class Sniff implements PHPCS_Sniff {
 		$lastPtr = ( $nextPtr - 1 );
 
 		return $lastPtr;
-	}
-
-	/**
-	 * Check if a class token is part of a unit test suite.
-	 *
-	 * Unit test classes are identified as such:
-	 * - Class which either extends WP_UnitTestCase or PHPUnit_Framework_TestCase
-	 *   or a custom whitelisted unit test class.
-	 *
-	 * @since 0.12.0 Split off from the `is_token_in_test_method()` method.
-	 * @since 1.0.0  Improved recognition of namespaced class names.
-	 *
-	 * @param int $stackPtr The position of the token to be examined.
-	 *                      This should be a class, anonymous class or trait token.
-	 *
-	 * @return bool True if the class is a unit test class, false otherwise.
-	 */
-	protected function is_test_class( $stackPtr ) {
-
-		if ( isset( $this->tokens[ $stackPtr ], Tokens::$ooScopeTokens[ $this->tokens[ $stackPtr ]['code'] ] ) === false ) {
-			return false;
-		}
-
-		// Add any potentially whitelisted custom test classes to the whitelist.
-		$whitelist = $this->merge_custom_array(
-			$this->custom_test_class_whitelist,
-			$this->test_class_whitelist
-		);
-
-		/*
-		 * Show some tolerance for user input.
-		 * The custom test class names should be passed as FQN without a prefixing `\`.
-		 */
-		foreach ( $whitelist as $k => $v ) {
-			$whitelist[ $k ] = ltrim( $v, '\\' );
-		}
-
-		// Is the class/trait one of the whitelisted test classes ?
-		$namespace = Namespaces::determineNamespace( $this->phpcsFile, $stackPtr );
-		$className = $this->phpcsFile->getDeclarationName( $stackPtr );
-		if ( '' !== $namespace ) {
-			if ( isset( $whitelist[ $namespace . '\\' . $className ] ) ) {
-				return true;
-			}
-		} elseif ( isset( $whitelist[ $className ] ) ) {
-			return true;
-		}
-
-		// Does the class/trait extend one of the whitelisted test classes ?
-		$extendedClassName = $this->phpcsFile->findExtendedClassName( $stackPtr );
-		if ( false === $extendedClassName ) {
-			return false;
-		}
-
-		if ( '\\' === $extendedClassName[0] ) {
-			if ( isset( $whitelist[ substr( $extendedClassName, 1 ) ] ) ) {
-				return true;
-			}
-		} elseif ( '' !== $namespace ) {
-			if ( isset( $whitelist[ $namespace . '\\' . $extendedClassName ] ) ) {
-				return true;
-			}
-		} elseif ( isset( $whitelist[ $extendedClassName ] ) ) {
-			return true;
-		}
-
-		/*
-		 * Not examining imported classes via `use` statements as with the variety of syntaxes,
-		 * this would get very complicated.
-		 * After all, users can add an `<exclude-pattern>` for a particular sniff to their
-		 * custom ruleset to selectively exclude the test directory.
-		 */
-
-		return false;
 	}
 
 	/**

--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -1081,46 +1081,6 @@ abstract class Sniff implements PHPCS_Sniff {
 	}
 
 	/**
-	 * Check if a token is used within a unit test.
-	 *
-	 * Unit test methods are identified as such:
-	 * - Method is within a known unit test class;
-	 * - or Method is within a class/trait which extends a known unit test class.
-	 *
-	 * @since 0.11.0
-	 * @since 1.1.0  Supports anonymous test classes and improved handling of nested scopes.
-	 *
-	 * @param int $stackPtr The position of the token to be examined.
-	 *
-	 * @return bool True if the token is within a unit test, false otherwise.
-	 */
-	protected function is_token_in_test_method( $stackPtr ) {
-		// Is the token inside of a function definition ?
-		$functionToken = $this->phpcsFile->getCondition( $stackPtr, \T_FUNCTION );
-		if ( false === $functionToken ) {
-			// No conditions or no function condition.
-			return false;
-		}
-
-		$conditions = $this->tokens[ $stackPtr ]['conditions'];
-		foreach ( $conditions as $token => $condition ) {
-			if ( $token === $functionToken ) {
-				// Only examine the conditions the function is nested in, not those nested within the function.
-				break;
-			}
-
-			if ( isset( Tokens::$ooScopeTokens[ $condition ] ) ) {
-				$is_test_class = $this->is_test_class( $token );
-				if ( true === $is_test_class ) {
-					return true;
-				}
-			}
-		}
-
-		return false;
-	}
-
-	/**
 	 * Check if a class token is part of a unit test suite.
 	 *
 	 * Unit test classes are identified as such:

--- a/WordPress/Sniffs/Files/FileNameSniff.php
+++ b/WordPress/Sniffs/Files/FileNameSniff.php
@@ -30,7 +30,7 @@ use WordPressCS\WordPress\Helpers\IsUnitTestTrait;
  * @since   0.12.0 Now extends the WordPressCS native `Sniff` class.
  * @since   0.13.0 Class name changed: this class is now namespaced.
  *
- * @uses    \WordPressCS\WordPress\Helpers\IsUnitTestTrait::$custom_test_class_whitelist
+ * @uses    \WordPressCS\WordPress\Helpers\IsUnitTestTrait::$custom_test_classes
  */
 class FileNameSniff extends Sniff {
 

--- a/WordPress/Sniffs/Files/FileNameSniff.php
+++ b/WordPress/Sniffs/Files/FileNameSniff.php
@@ -11,6 +11,7 @@ namespace WordPressCS\WordPress\Sniffs\Files;
 
 use PHPCSUtils\Utils\TextStrings;
 use WordPressCS\WordPress\Sniff;
+use WordPressCS\WordPress\Helpers\IsUnitTestTrait;
 
 /**
  * Ensures filenames do not contain underscores.
@@ -29,9 +30,11 @@ use WordPressCS\WordPress\Sniff;
  * @since   0.12.0 Now extends the WordPressCS native `Sniff` class.
  * @since   0.13.0 Class name changed: this class is now namespaced.
  *
- * @uses    \WordPressCS\WordPress\Sniff::$custom_test_class_whitelist
+ * @uses    \WordPressCS\WordPress\Helpers\IsUnitTestTrait::$custom_test_class_whitelist
  */
 class FileNameSniff extends Sniff {
+
+	use IsUnitTestTrait;
 
 	/**
 	 * Regex for the theme specific exceptions.
@@ -192,7 +195,7 @@ class FileNameSniff extends Sniff {
 		 */
 		if ( true === $this->strict_class_file_names ) {
 			$has_class = $this->phpcsFile->findNext( \T_CLASS, $stackPtr );
-			if ( false !== $has_class && false === $this->is_test_class( $has_class ) ) {
+			if ( false !== $has_class && false === $this->is_test_class( $this->phpcsFile, $has_class ) ) {
 				$class_name = $this->phpcsFile->getDeclarationName( $has_class );
 				$expected   = 'class-' . strtolower( str_replace( '_', '-', $class_name ) );
 

--- a/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
+++ b/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
@@ -29,7 +29,7 @@ use WordPressCS\WordPress\Helpers\IsUnitTestTrait;
  * @since   2.2.0  - Now also checks variables assigned via the list() construct.
  *                 - Now also ignores global functions which are marked as @deprecated.
  *
- * @uses    \WordPressCS\WordPress\Helpers\IsUnitTestTrait::$custom_test_class_whitelist
+ * @uses    \WordPressCS\WordPress\Helpers\IsUnitTestTrait::$custom_test_classes
  */
 class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 

--- a/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
+++ b/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
@@ -9,13 +9,14 @@
 
 namespace WordPressCS\WordPress\Sniffs\NamingConventions;
 
-use WordPressCS\WordPress\AbstractFunctionParameterSniff;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\BackCompat\Helper;
 use PHPCSUtils\Utils\Lists;
 use PHPCSUtils\Utils\Namespaces;
 use PHPCSUtils\Utils\Scopes;
 use PHPCSUtils\Utils\TextStrings;
+use WordPressCS\WordPress\AbstractFunctionParameterSniff;
+use WordPressCS\WordPress\Helpers\IsUnitTestTrait;
 
 /**
  * Verify that everything defined in the global namespace is prefixed with a theme/plugin specific prefix.
@@ -28,9 +29,11 @@ use PHPCSUtils\Utils\TextStrings;
  * @since   2.2.0  - Now also checks variables assigned via the list() construct.
  *                 - Now also ignores global functions which are marked as @deprecated.
  *
- * @uses    \WordPressCS\WordPress\Sniff::$custom_test_class_whitelist
+ * @uses    \WordPressCS\WordPress\Helpers\IsUnitTestTrait::$custom_test_class_whitelist
  */
 class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
+
+	use IsUnitTestTrait;
 
 	/**
 	 * Error message template.
@@ -288,7 +291,7 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 
 		// Ignore test classes.
 		if ( isset( Tokens::$ooScopeTokens[ $this->tokens[ $stackPtr ]['code'] ] )
-			&& true === $this->is_test_class( $stackPtr )
+			&& true === $this->is_test_class( $this->phpcsFile, $stackPtr )
 		) {
 			if ( $this->tokens[ $stackPtr ]['scope_condition'] === $stackPtr && isset( $this->tokens[ $stackPtr ]['scope_closer'] ) ) {
 				// Skip forward to end of test class.

--- a/WordPress/Sniffs/WP/GlobalVariablesOverrideSniff.php
+++ b/WordPress/Sniffs/WP/GlobalVariablesOverrideSniff.php
@@ -9,11 +9,12 @@
 
 namespace WordPressCS\WordPress\Sniffs\WP;
 
-use WordPressCS\WordPress\Sniff;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\Utils\Lists;
 use PHPCSUtils\Utils\Scopes;
 use PHPCSUtils\Utils\TextStrings;
+use WordPressCS\WordPress\Sniff;
+use WordPressCS\WordPress\Helpers\IsUnitTestTrait;
 
 /**
  * Warns about overwriting WordPress native global variables.
@@ -29,9 +30,11 @@ use PHPCSUtils\Utils\TextStrings;
  * @since   1.1.0  The sniff now also detects variables being overriden in the global namespace.
  * @since   2.2.0  The sniff now also detects variable assignments via the list() construct.
  *
- * @uses    \WordPressCS\WordPress\Sniff::$custom_test_class_whitelist
+ * @uses    \WordPressCS\WordPress\Helpers\IsUnitTestTrait::$custom_test_class_whitelist
  */
 class GlobalVariablesOverrideSniff extends Sniff {
+
+	use IsUnitTestTrait;
 
 	/**
 	 * Whether to treat all files as if they were included from
@@ -120,7 +123,7 @@ class GlobalVariablesOverrideSniff extends Sniff {
 		// Ignore variable overrides in test classes.
 		if ( isset( Tokens::$ooScopeTokens[ $token['code'] ] ) ) {
 
-			if ( true === $this->is_test_class( $stackPtr )
+			if ( true === $this->is_test_class( $this->phpcsFile, $stackPtr )
 				&& $token['scope_condition'] === $stackPtr
 				&& isset( $token['scope_closer'] )
 			) {

--- a/WordPress/Sniffs/WP/GlobalVariablesOverrideSniff.php
+++ b/WordPress/Sniffs/WP/GlobalVariablesOverrideSniff.php
@@ -30,7 +30,7 @@ use WordPressCS\WordPress\Helpers\IsUnitTestTrait;
  * @since   1.1.0  The sniff now also detects variables being overriden in the global namespace.
  * @since   2.2.0  The sniff now also detects variable assignments via the list() construct.
  *
- * @uses    \WordPressCS\WordPress\Helpers\IsUnitTestTrait::$custom_test_class_whitelist
+ * @uses    \WordPressCS\WordPress\Helpers\IsUnitTestTrait::$custom_test_classes
  */
 class GlobalVariablesOverrideSniff extends Sniff {
 

--- a/WordPress/Tests/Files/FileNameUnitTests/TestFiles/test-sample-custom-unit.inc
+++ b/WordPress/Tests/Files/FileNameUnitTests/TestFiles/test-sample-custom-unit.inc
@@ -1,6 +1,6 @@
 <!-- Annotation has to be on the second line as errors are thrown on line 1 and errors on annotation lines are ignored. -->
-phpcs:set WordPress.Files.FileName custom_test_class_whitelist[] My_TestClass
+phpcs:set WordPress.Files.FileName custom_test_classes[] My_TestClass
 <?php
 
 class TestSample extends My_TestClass {}
-/* phpcs:set WordPress.Files.FileName custom_test_class_whitelist[] */
+/* phpcs:set WordPress.Files.FileName custom_test_classes[] */

--- a/WordPress/Tests/Files/FileNameUnitTests/TestFiles/test-sample-global-namespace-extends.1.inc
+++ b/WordPress/Tests/Files/FileNameUnitTests/TestFiles/test-sample-global-namespace-extends.1.inc
@@ -1,8 +1,8 @@
 <!-- Annotation has to be on the second line as errors are thrown on line 1 and errors on annotation lines are ignored. -->
-phpcs:set WordPress.Files.FileName custom_test_class_whitelist[] TestSample
+phpcs:set WordPress.Files.FileName custom_test_classes[] TestSample
 <?php
 
 namespace Some\Name;
 
 class TestCase extends \TestSample {}
-/* phpcs:set WordPress.Files.FileName custom_test_class_whitelist[] */
+/* phpcs:set WordPress.Files.FileName custom_test_classes[] */

--- a/WordPress/Tests/Files/FileNameUnitTests/TestFiles/test-sample-global-namespace-extends.2.inc
+++ b/WordPress/Tests/Files/FileNameUnitTests/TestFiles/test-sample-global-namespace-extends.2.inc
@@ -1,8 +1,8 @@
 <!-- Annotation has to be on the second line as errors are thrown on line 1 and errors on annotation lines are ignored. -->
-phpcs:set WordPress.Files.FileName custom_test_class_whitelist[] Some\Name\TestSample
+phpcs:set WordPress.Files.FileName custom_test_classes[] Some\Name\TestSample
 <?php
 
 namespace Some\Name;
 
 class TestCase extends \TestSample {}
-/* phpcs:set WordPress.Files.FileName custom_test_class_whitelist[] */
+/* phpcs:set WordPress.Files.FileName custom_test_classes[] */

--- a/WordPress/Tests/Files/FileNameUnitTests/TestFiles/test-sample-namespaced-declaration.1.inc
+++ b/WordPress/Tests/Files/FileNameUnitTests/TestFiles/test-sample-namespaced-declaration.1.inc
@@ -1,8 +1,8 @@
 <!-- Annotation has to be on the second line as errors are thrown on line 1 and errors on annotation lines are ignored. -->
-phpcs:set WordPress.Files.FileName custom_test_class_whitelist[] Some\Name\TestSample
+phpcs:set WordPress.Files.FileName custom_test_classes[] Some\Name\TestSample
 <?php
 
 namespace Some\Name;
 
 class TestSample {}
-/* phpcs:set WordPress.Files.FileName custom_test_class_whitelist[] */
+/* phpcs:set WordPress.Files.FileName custom_test_classes[] */

--- a/WordPress/Tests/Files/FileNameUnitTests/TestFiles/test-sample-namespaced-declaration.2.inc
+++ b/WordPress/Tests/Files/FileNameUnitTests/TestFiles/test-sample-namespaced-declaration.2.inc
@@ -1,8 +1,8 @@
 <!-- Annotation has to be on the second line as errors are thrown on line 1 and errors on annotation lines are ignored. -->
-phpcs:set WordPress.Files.FileName custom_test_class_whitelist[] TestSample
+phpcs:set WordPress.Files.FileName custom_test_classes[] TestSample
 <?php
 
 namespace Some\Name;
 
 class TestSample {}
-/* phpcs:set WordPress.Files.FileName custom_test_class_whitelist[] */
+/* phpcs:set WordPress.Files.FileName custom_test_classes[] */

--- a/WordPress/Tests/Files/FileNameUnitTests/TestFiles/test-sample-namespaced-declaration.3.inc
+++ b/WordPress/Tests/Files/FileNameUnitTests/TestFiles/test-sample-namespaced-declaration.3.inc
@@ -1,8 +1,8 @@
 <!-- Annotation has to be on the second line as errors are thrown on line 1 and errors on annotation lines are ignored. -->
-phpcs:set WordPress.Files.FileName custom_test_class_whitelist[] Some\Name\TestSample
+phpcs:set WordPress.Files.FileName custom_test_classes[] Some\Name\TestSample
 <?php
 
 namespace Some\Other;
 
 class TestSample {}
-/* phpcs:set WordPress.Files.FileName custom_test_class_whitelist[] */
+/* phpcs:set WordPress.Files.FileName custom_test_classes[] */

--- a/WordPress/Tests/Files/FileNameUnitTests/TestFiles/test-sample-namespaced-declaration.4.inc
+++ b/WordPress/Tests/Files/FileNameUnitTests/TestFiles/test-sample-namespaced-declaration.4.inc
@@ -1,6 +1,6 @@
 <!-- Annotation has to be on the second line as errors are thrown on line 1 and errors on annotation lines are ignored. -->
-phpcs:set WordPress.Files.FileName custom_test_class_whitelist[] Some\Name\TestSample
+phpcs:set WordPress.Files.FileName custom_test_classes[] Some\Name\TestSample
 <?php
 
 class TestSample {}
-/* phpcs:set WordPress.Files.FileName custom_test_class_whitelist[] */
+/* phpcs:set WordPress.Files.FileName custom_test_classes[] */

--- a/WordPress/Tests/Files/FileNameUnitTests/TestFiles/test-sample-namespaced-extends.1.inc
+++ b/WordPress/Tests/Files/FileNameUnitTests/TestFiles/test-sample-namespaced-extends.1.inc
@@ -1,8 +1,8 @@
 <!-- Annotation has to be on the second line as errors are thrown on line 1 and errors on annotation lines are ignored. -->
-phpcs:set WordPress.Files.FileName custom_test_class_whitelist[] Some\Name\TestSample
+phpcs:set WordPress.Files.FileName custom_test_classes[] Some\Name\TestSample
 <?php
 
 namespace Some\Name;
 
 class TestCase extends TestSample {}
-/* phpcs:set WordPress.Files.FileName custom_test_class_whitelist[] */
+/* phpcs:set WordPress.Files.FileName custom_test_classes[] */

--- a/WordPress/Tests/Files/FileNameUnitTests/TestFiles/test-sample-namespaced-extends.2.inc
+++ b/WordPress/Tests/Files/FileNameUnitTests/TestFiles/test-sample-namespaced-extends.2.inc
@@ -1,8 +1,8 @@
 <!-- Annotation has to be on the second line as errors are thrown on line 1 and errors on annotation lines are ignored. -->
-phpcs:set WordPress.Files.FileName custom_test_class_whitelist[] Some\Name\TestSample
+phpcs:set WordPress.Files.FileName custom_test_classes[] Some\Name\TestSample
 <?php
 
 namespace Some\OtherName;
 
 class TestCase extends TestSample {}
-/* phpcs:set WordPress.Files.FileName custom_test_class_whitelist[] */
+/* phpcs:set WordPress.Files.FileName custom_test_classes[] */

--- a/WordPress/Tests/Files/FileNameUnitTests/TestFiles/test-sample-namespaced-extends.3.inc
+++ b/WordPress/Tests/Files/FileNameUnitTests/TestFiles/test-sample-namespaced-extends.3.inc
@@ -1,8 +1,8 @@
 <!-- Annotation has to be on the second line as errors are thrown on line 1 and errors on annotation lines are ignored. -->
-phpcs:set WordPress.Files.FileName custom_test_class_whitelist[] TestSample
+phpcs:set WordPress.Files.FileName custom_test_classes[] TestSample
 <?php
 
 namespace Some\Name;
 
 class TestCase extends TestSample {}
-/* phpcs:set WordPress.Files.FileName custom_test_class_whitelist[] */
+/* phpcs:set WordPress.Files.FileName custom_test_classes[] */

--- a/WordPress/Tests/Files/FileNameUnitTests/TestFiles/test-sample-namespaced-extends.4.inc
+++ b/WordPress/Tests/Files/FileNameUnitTests/TestFiles/test-sample-namespaced-extends.4.inc
@@ -1,6 +1,6 @@
 <!-- Annotation has to be on the second line as errors are thrown on line 1 and errors on annotation lines are ignored. -->
-phpcs:set WordPress.Files.FileName custom_test_class_whitelist[] Some\Name\TestSample
+phpcs:set WordPress.Files.FileName custom_test_classes[] Some\Name\TestSample
 <?php
 
 class MyUnitTest extends TestSample {}
-/* phpcs:set WordPress.Files.FileName custom_test_class_whitelist[] */
+/* phpcs:set WordPress.Files.FileName custom_test_classes[] */

--- a/WordPress/Tests/Files/FileNameUnitTests/TestFiles/test-sample-namespaced-extends.5.inc
+++ b/WordPress/Tests/Files/FileNameUnitTests/TestFiles/test-sample-namespaced-extends.5.inc
@@ -1,6 +1,6 @@
 <!-- Annotation has to be on the second line as errors are thrown on line 1 and errors on annotation lines are ignored. -->
-phpcs:set WordPress.Files.FileName custom_test_class_whitelist[] Some\Name\TestSample
+phpcs:set WordPress.Files.FileName custom_test_classes[] Some\Name\TestSample
 <?php
 
 class TestCase extends \Some\Name\TestSample {}
-/* phpcs:set WordPress.Files.FileName custom_test_class_whitelist[] */
+/* phpcs:set WordPress.Files.FileName custom_test_classes[] */

--- a/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.1.inc
+++ b/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.1.inc
@@ -181,7 +181,7 @@ class Example extends WP_UnitTestCase {
 	function do_something() {}
 }
 
-// phpcs:set WordPress.NamingConventions.PrefixAllGlobals custom_test_class_whitelist[] My_TestClass
+// phpcs:set WordPress.NamingConventions.PrefixAllGlobals custom_test_classes[] My_TestClass
 class Test_Class_D extends My_TestClass {
 
 	const SOME_CONSTANT = 'value';
@@ -190,7 +190,7 @@ class Test_Class_D extends My_TestClass {
 
 	function do_something() {}
 }
-// phpcs:set WordPress.NamingConventions.PrefixAllGlobals custom_test_class_whitelist[]
+// phpcs:set WordPress.NamingConventions.PrefixAllGlobals custom_test_classes[]
 
 
 if ( ! function_exists( 'intdiv' ) ) {

--- a/WordPress/Tests/WP/GlobalVariablesOverrideUnitTest.1.inc
+++ b/WordPress/Tests/WP/GlobalVariablesOverrideUnitTest.1.inc
@@ -108,7 +108,7 @@ trait My_Class {
 }
 
 // Test adding additional test classes to the whitelist.
-// phpcs:set WordPress.WP.GlobalVariablesOverride custom_test_class_whitelist[] My_TestClass
+// phpcs:set WordPress.WP.GlobalVariablesOverride custom_test_classes[] My_TestClass
 class Test_Class_D extends My_TestClass {
 
 	public function test_something() {
@@ -116,7 +116,7 @@ class Test_Class_D extends My_TestClass {
 		$tabs = 50; // Ok.
 	}
 }
-// phpcs:set WordPress.WP.GlobalVariablesOverride custom_test_class_whitelist[]
+// phpcs:set WordPress.WP.GlobalVariablesOverride custom_test_classes[]
 
 // Test detecting within and skipping over anonymous classes.
 global $year;

--- a/WordPress/Tests/WP/GlobalVariablesOverrideUnitTest.4.inc
+++ b/WordPress/Tests/WP/GlobalVariablesOverrideUnitTest.4.inc
@@ -1,6 +1,6 @@
 <?php
 
-// phpcs:set WordPress.WP.GlobalVariablesOverride custom_test_class_whitelist[] My\NameSp\TestClass
+// phpcs:set WordPress.WP.GlobalVariablesOverride custom_test_classes[] My\NameSp\TestClass
 
 namespace My \ /* comment */ NameSp;
 
@@ -11,4 +11,4 @@ class Test_Class_D extends TestClass {
 		$tabs = 50; // Ok.
 	}
 }
-// phpcs:set WordPress.WP.GlobalVariablesOverride custom_test_class_whitelist[]
+// phpcs:set WordPress.WP.GlobalVariablesOverride custom_test_classes[]


### PR DESCRIPTION
This PR will be easiest to review by looking through the individual commits.

Related to #1877

## Commit Details

### :heavy_plus_sign:  Sniff: remove the `is_token_in_test_method()` method :new: 

This method is currently unused in WPCS and it is not 100% clear what the method _should_ do, so removing the method for now.

If needs be it can be brought back later if/when there is more clarity on what the method is supposed to solve.

### Move "is this test code" related utilities to dedicated `IsUnitTestTrait`

The "is this test code" related utilities are only used by a small set of sniffs, so are better placed in a dedicated trait.

This moves the (`public`) `$custom_test_class_whitelist` and the `$custom_test_class_whitelist` properties as well as ~~the `is_token_in_test_method()` and~~ the `is_test_class` method to a new `WordPressCS\WordPress\Helpers\IsUnitTestTrait` and starts using that trait in the relevant sniffs.

The trait has been made stand-alone, i.e. it does not presume that a sniff implementing it extends the `WordPressCS\WordPress\Sniff` class.
This makes it easier to (re-)use the traits, even when a sniff extends an abstract sniff class from PHPCS itself or from PHPCSUtils.

~~Note: the `is_token_in_test_method()` method is currently unused in WPCS, but seems useful enough to keep in place.~~

Related to #1465

### IsUnitTestTrait::is_test_class(): use PHPCSUtils

This implements PHPCSUtils alternatives for PHPCS native methods and other PHPCSUtils utilities in the `IsUnitTestTrait::is_test_class()` code.

The functionality is unchanged (just less buggy).

### :heavy_minus_sign:  ~~IsUnitTestTrait::is_token_in_test_method(): implement PHPCSUtils/improve handling nested functions~~


### IsUnitTestTrait: rename protected property

The protected property `$test_class_whitelist` has been renamed to `$known_test_classes` as a step towards removing whitelist/blacklist terminology.

### IsUnitTestTrait: rename public property

The public property `$custom_test_class_whitelist` has been renamed to `$custom_test_classes` as a step towards removing whitelist/blacklist terminology.

Includes adjusting the property name in all tests which included the property.

Related to #1915

#### To do before release:
- [ ] Annotate this change in the wiki custom properties list

### IsUnitTestTrait: rename local variable

The function local variable `$whitelist` has been renamed to `$known_test_classes` as a step towards removing whitelist/blacklist terminology.

### IsUnitTestTrait: add missing WP Core test case classes

Add two more test cases which were added to `/tests/phpunit/includes/`.

Note: WP Core contains more test cases, but those are in the `tests/phpunit/tests` directory, while the test cases in  `/tests/phpunit/includes/` are supposed to be the "public test API", which is why those are the only ones in this list.

### IsUnitTestTrait: improve documentation 