### PR TITLE
Travis: add build against PHP 8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -129,6 +129,13 @@ jobs:
       env: PHPCS_BRANCH="4.0.x-dev as 3.9.99"
 
     # Builds which need a different distro.
+    - php: 8.0
+      env: PHPCS_BRANCH="dev-master" LINT=1
+    - php: 8.0
+      # PHPCS is only compatible with PHP 8.0 as of version 3.5.7.
+      env: PHPCS_BRANCH="3.5.7"
+
+    # Builds which need a different distro.
     - php: 5.5
       dist: trusty
       env: PHPCS_BRANCH="dev-master" LINT=1
@@ -173,7 +180,7 @@ install:
       fi
     - travis_retry composer require squizlabs/php_codesniffer:"${PHPCS_BRANCH}" --no-update --no-suggest --no-scripts
     - |
-      if [[ $TRAVIS_PHP_VERSION == "nightly" ]]; then
+      if [[ $TRAVIS_PHP_VERSION == "nightly" || $TRAVIS_PHP_VERSION == "8.0" ]]; then
         # PHPUnit 7.x does not allow for installation on PHP 8, so ignore platform
         # requirements to get PHPUnit 7.x to install on nightly.
         travis_retry composer install --ignore-platform-reqs --no-suggest


### PR DESCRIPTION
PHP 8.0 has been branched off two months ago, so `nightly` is now PHP 8.1 and in the mean time PHP 8.0 was released last week.

As of today, there is a PHP 8.0 image available on Travis.

This PR adds two new builds against PHP 8.0 to the matrix and, as PHP 8.0 has been released, these builds are not allowed to fail.