### PR TITLE
Security/EscapeOutput: bug fix - allow for basename() being fully qualified

### DIFF
--- a/WordPress/Sniffs/Security/EscapeOutputSniff.php
+++ b/WordPress/Sniffs/Security/EscapeOutputSniff.php
@@ -218,7 +218,7 @@ class EscapeOutputSniff extends Sniff {
 				}
 
 				// Quick check. This disregards comments.
-				if ( preg_match( '`^basename\s*\(\s*__FILE__\s*\)$`', $first_param['raw'] ) === 1 ) {
+				if ( preg_match( '`^[\\\\]?basename\s*\(\s*__FILE__\s*\)$`', $first_param['raw'] ) === 1 ) {
 					$stackPtr = ( $first_param['end'] + 2 );
 				}
 				unset( $first_param );

--- a/WordPress/Tests/Security/EscapeOutputUnitTest.inc
+++ b/WordPress/Tests/Security/EscapeOutputUnitTest.inc
@@ -298,3 +298,5 @@ _deprecated_file( $file, '1.3.0' ); // Error.
 
 trigger_error(); // Ignore.
 _deprecated_file(); // Ignore.
+
+\_deprecated_file( \basename( __FILE__ ), '1.3.0' ); // Ok.


### PR DESCRIPTION
Not a perfect solution as it doesn't take imported or namespaced functions into account, but that will need to wait for PHPCSUtils.

For now, it can prevent some false positives for fully qualified calls to `basename()`.