### PR TITLE
GH Actions: report CS violations in the PR

### DIFF
--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -55,7 +55,6 @@ jobs:
           php-version: ${{ matrix.php }}
           ini-values: ${{ steps.set_ini.outputs.PHP_INI }}
           coverage: none
-          tools: cs2pr
 
       - name: Set PHPCS version
         run: composer require squizlabs/php_codesniffer:"${{ matrix.phpcs_version }}" --no-update --no-scripts
@@ -65,7 +64,7 @@ jobs:
 
       - name: Lint PHP files against parse errors
         if: ${{ matrix.phpcs_version == 'dev-master' }}
-        run: composer lint-ci | cs2pr
+        run: composer lint-ci
 
       - name: Run unit tests
         run: composer run-tests

--- a/.github/workflows/ruleset-checks-sniffs.yml
+++ b/.github/workflows/ruleset-checks-sniffs.yml
@@ -38,6 +38,7 @@ jobs:
         with:
           php-version: '7.4'
           coverage: none
+          tools: cs2pr
 
       # Using PHPCS `master` as an early detection system for bugs upstream.
       - name: Set PHPCS version
@@ -57,7 +58,11 @@ jobs:
       # @link https://github.com/WordPress/WordPress-Coding-Standards
       # @link http://pear.php.net/package/PHP_CodeSniffer/
       - name: Run PHPCS ignoring warnings
-        run: vendor/bin/phpcs --runtime-set ignore_warnings_on_exit 1
+        continue-on-error: true
+        run: vendor/bin/phpcs --runtime-set ignore_warnings_on_exit 1 --report-full --report-checkstyle=./phpcs-report.xml
+
+      - name: Show PHPCS results in PR
+        run: cs2pr ./phpcs-report.xml --graceful-warnings
 
       # Validate the XML files.
       # @link http://xmlsoft.org/xmllint.html


### PR DESCRIPTION
### GH Actions: report CS violations in the PR

The cs2pr tool will allow to display the results from an action run in checkstyle format in-line in the PR code view, which should improve usability of the workflow results.

Ref: https://github.com/staabm/annotate-pull-request-from-checkstyle

### GH Actions: don't use cs2pr in quicktest

... as the `quicktest` workflow is run on `push` events, not on PRs, so displaying results in a PR is not relevant (and is done via the `test` workflow which _is_ run on `pull` events anyhow).

