### PR TITLE
PHP 8.1 compatibility: fix deprecation notice [1]

### DIFF
--- a/WordPress/Helpers/MinimumWPVersionTrait.php
+++ b/WordPress/Helpers/MinimumWPVersionTrait.php
@@ -86,8 +86,13 @@ trait MinimumWPVersionTrait {
 	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
 	 */
 	protected function get_wp_version_from_cli( File $phpcsFile ) {
-		$cli_supported_version = trim( Helper::getCommandLineData( $phpcsFile, 'minimum_supported_wp_version' ) );
+		$cli_supported_version = Helper::getCommandLineData( $phpcsFile, 'minimum_supported_wp_version' );
 
+		if ( empty( $cli_supported_version ) ) {
+			return;
+		}
+
+		$cli_supported_version = trim( $cli_supported_version );
 		if ( ! empty( $cli_supported_version )
 			&& filter_var( $cli_supported_version, \FILTER_VALIDATE_FLOAT ) !== false
 		) {


### PR DESCRIPTION
PHP 8.1 deprecates passing `null` to PHP native functions where the parameter(s) is not explicitly nullable.

While in PHP 8.1 this is only a deprecation, it should, of course, still be fixed.

This commit contains a fix for the one of the two issues in WordPressCS found related to this so far (based on the unit tests).

Passing `null` to `trim()` is now deprecated, so more defensive coding or explicit type casting is needed.
This comes into play for the `MinimumWPVersionTrait::get_wp_version_from_cli()` method where the `Helper::getCommandLineData()` method can return either string or `null`.

Ref: https://phpcsutils.com/phpdoc/classes/PHPCSUtils-BackCompat-Helper.html#method_getCommandLineData