### PR TITLE
PHP 8.1 compatibility: fix deprecation notice [2]

### DIFF
--- a/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
+++ b/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
@@ -272,9 +272,12 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 	public function process_token( $stackPtr ) {
 
 		// Allow overruling the prefixes set in a ruleset via the command line.
-		$cl_prefixes = trim( Helper::getConfigData( 'prefixes' ) );
+		$cl_prefixes = Helper::getConfigData( 'prefixes' );
 		if ( ! empty( $cl_prefixes ) ) {
-			$this->prefixes = array_filter( array_map( 'trim', explode( ',', $cl_prefixes ) ) );
+			$cl_prefixes = trim( $cl_prefixes );
+			if ( '' !== $cl_prefixes ) {
+				$this->prefixes = array_filter( array_map( 'trim', explode( ',', $cl_prefixes ) ) );
+			}
 		}
 
 		$this->prefixes = $this->merge_custom_array( $this->prefixes, array(), false );

--- a/WordPress/Sniffs/WP/I18nSniff.php
+++ b/WordPress/Sniffs/WP/I18nSniff.php
@@ -192,9 +192,12 @@ class I18nSniff extends AbstractFunctionRestrictionsSniff {
 		$this->text_domain_is_default       = false;
 
 		// Allow overruling the text_domain set in a ruleset via the command line.
-		$cl_text_domain = trim( Helper::getConfigData( 'text_domain' ) );
+		$cl_text_domain = Helper::getConfigData( 'text_domain' );
 		if ( ! empty( $cl_text_domain ) ) {
-			$this->text_domain = array_filter( array_map( 'trim', explode( ',', $cl_text_domain ) ) );
+			$cl_text_domain = trim( $cl_text_domain );
+			if ( '' !== $cl_text_domain ) {
+				$this->text_domain = array_filter( array_map( 'trim', explode( ',', $cl_text_domain ) ) );
+			}
 		}
 
 		$this->text_domain = $this->merge_custom_array( $this->text_domain, array(), false );


### PR DESCRIPTION
PHP 8.1 deprecates passing `null` to PHP native functions where the parameter(s) is not explicitly nullable.

While in PHP 8.1 this is only a deprecation, it should, of course, still be fixed.

This commit contains a fix for the second of the two issues in WordPressCS found related to this so far (based on the unit tests).

Passing `null` to `trim()` is now deprecated, so more defensive coding or explicit type casting is needed.
This comes into play for the `I18nSniff::process_token()` and the `PrefixAllGlobalsSniff::process_token()` methods where the `Helper::getConfigData()` method can return either string or `null`.

Ref: https://phpcsutils.com/phpdoc/classes/PHPCSUtils-BackCompat-Helper.html#method_getConfigData