### PR TITLE
GH Actions: get the tests running on PHP 8.1 (nightly)

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -94,5 +94,10 @@ jobs:
         if: ${{ matrix.phpcs_version == 'dev-master' }}
         run: composer lint-ci | cs2pr
 
-      - name: Run unit tests
+      - name: Run the unit tests - PHP 5.4 - 8.0
+        if: ${{ matrix.php != '8.1' }}
         run: composer run-tests
+
+      - name: Run the unit tests - PHP 8.1
+        if: ${{ matrix.php == '8.1' }}
+        run: composer run-tests -- --no-configuration --bootstrap=./Tests/bootstrap.php --dont-report-useless-tests


### PR DESCRIPTION
Letting PHPUnit read the config file causes an error on PHP 8.1 in combination with PHPUnit 7.

For now, special case the test run on PHP 8.1 and pass the only necessary config from the configuration file via CLI arguments.