### PR TITLE
CS/QA: get rid of (most) warnings

### DIFF
--- a/WordPress/AbstractArrayAssignmentRestrictionsSniff.php
+++ b/WordPress/AbstractArrayAssignmentRestrictionsSniff.php
@@ -153,9 +153,9 @@ abstract class AbstractArrayAssignmentRestrictionsSniff extends Sniff {
 		$inst = array();
 
 		/*
-		 * Covers:
-		 * $foo = array( 'bar' => 'taz' );
-		 * $foo['bar'] = $taz;
+		 * Covers array assignments:
+		 * `$foo = array( 'bar' => 'taz' );`
+		 * `$foo['bar'] = $taz;`
 		 */
 		if ( \in_array( $token['code'], array( \T_CLOSE_SQUARE_BRACKET, \T_DOUBLE_ARROW ), true ) ) {
 			$operator = $stackPtr; // T_DOUBLE_ARROW.
@@ -173,7 +173,7 @@ abstract class AbstractArrayAssignmentRestrictionsSniff extends Sniff {
 				$inst[ $key ][] = array( $val, $token['line'] );
 			}
 		} elseif ( \in_array( $token['code'], array( \T_CONSTANT_ENCAPSED_STRING, \T_DOUBLE_QUOTED_STRING ), true ) ) {
-			// $foo = 'bar=taz&other=thing';
+			// Covers assignments via query parameters: `$foo = 'bar=taz&other=thing';`.
 			if ( preg_match_all( '#(?:^|&)([a-z_]+)=([^&]*)#i', TextStrings::stripQuotes( $token['content'] ), $matches ) <= 0 ) {
 				return; // No assignments here, nothing to check.
 			}

--- a/WordPress/AbstractClassRestrictionsSniff.php
+++ b/WordPress/AbstractClassRestrictionsSniff.php
@@ -150,7 +150,7 @@ abstract class AbstractClassRestrictionsSniff extends AbstractFunctionRestrictio
 			return false;
 		}
 
-		// Nothing to do if 'parent', 'self' or 'static'.
+		// Nothing to do if one of the hierarchy keywords - 'parent', 'self' or 'static' - is used.
 		if ( \in_array( $classname, array( 'parent', 'self', 'static' ), true ) ) {
 			return false;
 		}

--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -1027,9 +1027,7 @@ abstract class Sniff implements PHPCS_Sniff {
 
 		// We've made it to the next line, back up one to the last in the previous line.
 		// We do this for micro-optimization of the above loop.
-		$lastPtr = ( $nextPtr - 1 );
-
-		return $lastPtr;
+		return ( $nextPtr - 1 );
 	}
 
 	/**

--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -1923,7 +1923,7 @@ abstract class Sniff implements PHPCS_Sniff {
 					$prev = $i;
 					do {
 						$prev = $this->phpcsFile->findPrevious( Tokens::$emptyTokens, ( $prev - 1 ), null, true, null, true );
-						// Skip over array keys, like $_GET['key']['subkey'].
+						// Skip over array keys, like `$_GET['key']['subkey']`.
 						if ( \T_CLOSE_SQUARE_BRACKET === $this->tokens[ $prev ]['code'] ) {
 							$prev = $this->tokens[ $prev ]['bracket_opener'];
 							continue;

--- a/WordPress/Sniffs/WP/DeprecatedClassesSniff.php
+++ b/WordPress/Sniffs/WP/DeprecatedClassesSniff.php
@@ -75,7 +75,7 @@ class DeprecatedClassesSniff extends AbstractClassRestrictionsSniff {
 	 */
 	public function getGroups() {
 		// Make sure all array keys are lowercase.
-		$this->deprecated_classes = array_change_key_case( $this->deprecated_classes, CASE_LOWER );
+		$this->deprecated_classes = array_change_key_case( $this->deprecated_classes, \CASE_LOWER );
 
 		return array(
 			'deprecated_classes' => array(

--- a/WordPress/Sniffs/WP/DeprecatedFunctionsSniff.php
+++ b/WordPress/Sniffs/WP/DeprecatedFunctionsSniff.php
@@ -1377,7 +1377,7 @@ class DeprecatedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 	 */
 	public function getGroups() {
 		// Make sure all array keys are lowercase.
-		$this->deprecated_functions = array_change_key_case( $this->deprecated_functions, CASE_LOWER );
+		$this->deprecated_functions = array_change_key_case( $this->deprecated_functions, \CASE_LOWER );
 
 		return array(
 			'deprecated_functions' => array(

--- a/WordPress/Sniffs/WP/EnqueuedResourcesSniff.php
+++ b/WordPress/Sniffs/WP/EnqueuedResourcesSniff.php
@@ -61,7 +61,7 @@ class EnqueuedResourcesSniff extends Sniff {
 			}
 		}
 
-		if ( preg_match_all( '# rel=\\\\?[\'"]?stylesheet\\\\?[\'"]?#', $content, $matches, PREG_OFFSET_CAPTURE ) > 0 ) {
+		if ( preg_match_all( '# rel=\\\\?[\'"]?stylesheet\\\\?[\'"]?#', $content, $matches, \PREG_OFFSET_CAPTURE ) > 0 ) {
 			foreach ( $matches[0] as $match ) {
 				$this->phpcsFile->addError(
 					'Stylesheets must be registered/enqueued via wp_enqueue_style',
@@ -71,7 +71,7 @@ class EnqueuedResourcesSniff extends Sniff {
 			}
 		}
 
-		if ( preg_match_all( '#<script[^>]*(?<=src=)#', $content, $matches, PREG_OFFSET_CAPTURE ) > 0 ) {
+		if ( preg_match_all( '#<script[^>]*(?<=src=)#', $content, $matches, \PREG_OFFSET_CAPTURE ) > 0 ) {
 			foreach ( $matches[0] as $match ) {
 				$this->phpcsFile->addError(
 					'Scripts must be registered/enqueued via wp_enqueue_script',

--- a/WordPress/Sniffs/WP/I18nSniff.php
+++ b/WordPress/Sniffs/WP/I18nSniff.php
@@ -648,7 +648,7 @@ class I18nSniff extends AbstractFunctionRestrictionsSniff {
 		 * Strip surrounding quotes.
 		 */
 		$reader = new \XMLReader();
-		$reader->XML( $content_without_quotes, 'UTF-8', LIBXML_NOERROR | LIBXML_ERR_NONE | LIBXML_NOWARNING );
+		$reader->XML( $content_without_quotes, 'UTF-8', \LIBXML_NOERROR | \LIBXML_ERR_NONE | \LIBXML_NOWARNING );
 
 		// Is the first node an HTML element?
 		if ( ! $reader->read() || \XMLReader::ELEMENT !== $reader->nodeType ) {

--- a/WordPress/Sniffs/WP/I18nSniff.php
+++ b/WordPress/Sniffs/WP/I18nSniff.php
@@ -9,10 +9,11 @@
 
 namespace WordPressCS\WordPress\Sniffs\WP;
 
-use WordPressCS\WordPress\AbstractFunctionRestrictionsSniff;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\BackCompat\Helper;
 use PHPCSUtils\Utils\TextStrings;
+use XMLReader;
+use WordPressCS\WordPress\AbstractFunctionRestrictionsSniff;
 
 /**
  * Makes sure WP internationalization functions are used properly.
@@ -647,11 +648,11 @@ class I18nSniff extends AbstractFunctionRestrictionsSniff {
 		 *
 		 * Strip surrounding quotes.
 		 */
-		$reader = new \XMLReader();
+		$reader = new XMLReader();
 		$reader->XML( $content_without_quotes, 'UTF-8', \LIBXML_NOERROR | \LIBXML_ERR_NONE | \LIBXML_NOWARNING );
 
 		// Is the first node an HTML element?
-		if ( ! $reader->read() || \XMLReader::ELEMENT !== $reader->nodeType ) {
+		if ( ! $reader->read() || XMLReader::ELEMENT !== $reader->nodeType ) {
 			return;
 		}
 

--- a/WordPress/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
@@ -183,7 +183,7 @@ class ControlStructureSpacingSniff extends Sniff {
 
 			} elseif ( \T_BITWISE_AND === $this->tokens[ $parenthesisOpener ]['code'] ) {
 
-				// This function returns by reference (function &function_name() {}).
+				// This function returns by reference, i.e. `function &function_name() {}`.
 				$parenthesisOpener = $this->phpcsFile->findNext(
 					Tokens::$emptyTokens,
 					( $parenthesisOpener + 1 ),
@@ -201,7 +201,7 @@ class ControlStructureSpacingSniff extends Sniff {
 					true
 				);
 
-				// Checking this: function my_function[*](...) {}.
+				// Checking space between name and open parentheses, i.e. `function my_function[*](...) {}`.
 				if ( ( $function_name_ptr + 1 ) !== $parenthesisOpener ) {
 
 					$error = 'Space between function name and opening parenthesis is prohibited.';
@@ -247,7 +247,7 @@ class ControlStructureSpacingSniff extends Sniff {
 			) {
 
 				if ( ( $stackPtr + 1 ) !== $parenthesisOpener ) {
-					// Checking this: function[*](...) {}.
+					// Checking space between keyword and open parenthesis, i.e. `function[*](...) {}`.
 					$error = 'Space before closure opening parenthesis is prohibited';
 					$fix   = $this->phpcsFile->addFixableError( $error, $stackPtr, 'SpaceBeforeClosureOpenParenthesis' );
 
@@ -263,7 +263,7 @@ class ControlStructureSpacingSniff extends Sniff {
 				&& ( $stackPtr + 1 ) === $parenthesisOpener
 			) {
 
-				// Checking this: if[*](...) {}.
+				// Checking space between keyword and open parenthesis, i.e. `if[*](...) {}`.
 				$error = 'No space before opening parenthesis is prohibited';
 				$fix   = $this->phpcsFile->addFixableError( $error, $stackPtr, 'NoSpaceBeforeOpenParenthesis' );
 
@@ -276,7 +276,7 @@ class ControlStructureSpacingSniff extends Sniff {
 		if ( \T_WHITESPACE === $this->tokens[ ( $stackPtr + 1 ) ]['code']
 			&& ' ' !== $this->tokens[ ( $stackPtr + 1 ) ]['content']
 		) {
-			// Checking this: if [*](...) {}.
+			// Checking (too much) space between keyword and open parenthesis, i.e. `if [*](...) {}`.
 			$error = 'Expected exactly one space before opening parenthesis; "%s" found.';
 			$fix   = $this->phpcsFile->addFixableError(
 				$error,
@@ -292,7 +292,7 @@ class ControlStructureSpacingSniff extends Sniff {
 
 		if ( \T_CLOSE_PARENTHESIS !== $this->tokens[ ( $parenthesisOpener + 1 ) ]['code'] ) {
 			if ( \T_WHITESPACE !== $this->tokens[ ( $parenthesisOpener + 1 ) ]['code'] ) {
-				// Checking this: $value = my_function([*]...).
+				// Checking space directly after the open parenthesis, i.e. `$value = my_function([*]...)`.
 				$error = 'No space after opening parenthesis is prohibited';
 				$fix   = $this->phpcsFile->addFixableError( $error, $stackPtr, 'NoSpaceAfterOpenParenthesis' );
 
@@ -304,7 +304,7 @@ class ControlStructureSpacingSniff extends Sniff {
 				&& "\r\n" !== $this->tokens[ ( $parenthesisOpener + 1 ) ]['content'] )
 				&& ! isset( $this->ignore_extra_space_after_open_paren[ $this->tokens[ $stackPtr ]['code'] ] )
 			) {
-				// Checking this: if ([*]...) {}.
+				// Checking (too much) space directly after the open parenthesis, i.e. `if ([*]...) {}`.
 				$error = 'Expected exactly one space after opening parenthesis; "%s" found.';
 				$fix   = $this->phpcsFile->addFixableError(
 					$error,
@@ -325,7 +325,7 @@ class ControlStructureSpacingSniff extends Sniff {
 
 			if ( \T_CLOSE_PARENTHESIS !== $this->tokens[ ( $parenthesisOpener + 1 ) ]['code'] ) {
 
-				// Checking this: if (...[*]) {}.
+				// Checking space directly before the close parenthesis, i.e. `if (...[*]) {}`.
 				if ( \T_WHITESPACE !== $this->tokens[ ( $parenthesisCloser - 1 ) ]['code'] ) {
 					$error = 'No space before closing parenthesis is prohibited';
 					$fix   = $this->phpcsFile->addFixableError( $error, $parenthesisCloser, 'NoSpaceBeforeCloseParenthesis' );
@@ -393,7 +393,7 @@ class ControlStructureSpacingSniff extends Sniff {
 				&& ' ' !== $this->tokens[ ( $parenthesisCloser + 1 ) ]['content']
 			) {
 
-				// Checking this: if (...) [*]{}.
+				// Checking space between the close parenthesis and the open brace, i.e. `if (...) [*]{}`.
 				$error = 'Expected exactly one space between closing parenthesis and opening control structure; "%s" found.';
 				$fix   = $this->phpcsFile->addFixableError(
 					$error,


### PR DESCRIPTION
Though it is by the looks of it only a "beta" feature for the moment, I noticed in PR #1997 that warnings are now being shown for files unrelated to the current PR. To me this is just plain annoying as it is noise which distracts from the actual changes which need reviewing and can be confusing for contributors (should I fix these ? will my changes be accepted even though these warnings are there?).

![image](https://user-images.githubusercontent.com/663378/121969363-62a7da00-cd74-11eb-9105-114b01696b4c.png)


With that in mind, I figured I might as well try to reduce this noise some more as well as fix up some other small issues.

## Commit details

###  CS: get rid of "commented out code" warnings

... which show through in PRs, even when the code in those files has not been adjusted in the PR.

There's only one such warning remaining now, which is _actual_ commented out code.

### QA: remove unnecessary assignment

### QA: use fully qualified global constant references

### QA: import all used classes 
