### PR TITLE
CI: various updates

### DIFF
--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -63,10 +63,10 @@ jobs:
           coverage: none
 
       - name: Set PHPCS version
-        run: composer require squizlabs/php_codesniffer:"${{ matrix.phpcs_version }}" --no-update --no-scripts
+        run: composer require squizlabs/php_codesniffer:"${{ matrix.phpcs_version }}" --no-update --no-scripts --no-interaction
 
       - name: Install Composer dependencies
-        uses: ramsey/composer-install@v1
+        uses: ramsey/composer-install@v2
 
       - name: Lint PHP files against parse errors
         if: ${{ matrix.phpcs_version == 'dev-master' }}

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -9,6 +9,12 @@ on:
   # Allow manually triggering the workflow.
   workflow_dispatch:
 
+# Cancels all previous workflow runs for the same branch that have not yet completed.
+concurrency:
+  # The concurrency group contains the workflow name and the branch name.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # Performs some quick tests.
   # This is a much quicker test suite which only runs the unit tests and linting

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -52,7 +52,7 @@ jobs:
           if [ "${{ matrix.phpcs_version }}" != "dev-master" ]; then
             echo '::set-output name=PHP_INI::error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On'
           else
-            echo '::set-output name=PHP_INI::error_reporting=E_ALL, display_errors=On'
+            echo '::set-output name=PHP_INI::error_reporting=-1, display_errors=On'
           fi
 
       - name: Set up PHP

--- a/.github/workflows/ruleset-checks-sniffs.yml
+++ b/.github/workflows/ruleset-checks-sniffs.yml
@@ -6,6 +6,12 @@ on:
   # Allow manually triggering the workflow.
   workflow_dispatch:
 
+# Cancels all previous workflow runs for the same branch that have not yet completed.
+concurrency:
+  # The concurrency group contains the workflow name and the branch name.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # Performs some code-style related checks.
   #

--- a/.github/workflows/ruleset-checks-sniffs.yml
+++ b/.github/workflows/ruleset-checks-sniffs.yml
@@ -48,10 +48,10 @@ jobs:
 
       # Using PHPCS `master` as an early detection system for bugs upstream.
       - name: Set PHPCS version
-        run: composer require squizlabs/php_codesniffer:"dev-master" --no-update --no-scripts
+        run: composer require squizlabs/php_codesniffer:"dev-master" --no-update --no-scripts --no-interaction
 
       - name: Install Composer dependencies
-        uses: ramsey/composer-install@v1
+        uses: ramsey/composer-install@v2
 
       - name: Install xmllint
         run: sudo apt-get install libxml2-utils
@@ -128,10 +128,10 @@ jobs:
           coverage: none
 
       - name: Set PHPCS version
-        run: composer require squizlabs/php_codesniffer:"${{ matrix.phpcs_version }}" --no-update --no-scripts
+        run: composer require squizlabs/php_codesniffer:"${{ matrix.phpcs_version }}" --no-update --no-scripts --no-interaction
 
       - name: Install Composer dependencies
-        uses: ramsey/composer-install@v1
+        uses: ramsey/composer-install@v2
 
       - name: Test the WordPress-Core ruleset
         run: $(pwd)/vendor/bin/phpcs -ps ./Tests/RulesetCheck/class-ruleset-test.inc --standard=WordPress-Core

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -38,6 +38,13 @@ jobs:
         phpcs_version: [ 'dev-master', '3.5.0' ]
         allowed_failure: [ false ]
         include:
+          - php: '8.1'
+            phpcs_version: 'dev-master'
+            allowed_failure: false
+          # PHPCS is only compatible with PHP 8.1 as of version 3.6.1.
+          - php: '8.1'
+            phpcs_version: '3.6.1'
+            allowed_failure: false
           - php: '8.0'
             phpcs_version: 'dev-master'
             allowed_failure: false
@@ -49,7 +56,7 @@ jobs:
           #- php: '7.4'
           #  phpcs_version: '4.0.x-dev as 3.9.99'
           #  allowed_failure: true
-          - php: '8.1'
+          - php: '8.2'
             phpcs_version: 'dev-master'
             allowed_failure: true
 
@@ -101,9 +108,9 @@ jobs:
         run: composer lint-ci | cs2pr
 
       - name: Run the unit tests - PHP 5.4 - 8.0
-        if: ${{ matrix.php != '8.1' }}
+        if: ${{ matrix.php < '8.1' }}
         run: composer run-tests
 
       - name: Run the unit tests - PHP 8.1
-        if: ${{ matrix.php == '8.1' }}
+        if: ${{ matrix.php >= '8.1' }}
         run: composer run-tests -- --no-configuration --bootstrap=./Tests/bootstrap.php --dont-report-useless-tests

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -8,6 +8,12 @@ on:
   # Allow manually triggering the workflow.
   workflow_dispatch:
 
+# Cancels all previous workflow runs for the same branch that have not yet completed.
+concurrency:
+  # The concurrency group contains the workflow name and the branch name.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # Runs the test suite against all supported branches and combinations.
   #

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -91,15 +91,15 @@ jobs:
         run: composer config preferred-install.squizlabs/php_codesniffer source
 
       - name: Set PHPCS version
-        run: composer require squizlabs/php_codesniffer:"${{ matrix.phpcs_version }}" --no-update --no-scripts
+        run: composer require squizlabs/php_codesniffer:"${{ matrix.phpcs_version }}" --no-update --no-scripts --no-interaction
 
       - name: Install Composer dependencies (PHP < 8.0 )
         if: ${{ matrix.php < 8.0 }}
-        uses: ramsey/composer-install@v1
+        uses: ramsey/composer-install@v2
 
       - name: Install Composer dependencies (PHP >= 8.0)
         if: ${{ matrix.php >= 8.0 }}
-        uses: ramsey/composer-install@v1
+        uses: ramsey/composer-install@v2
         with:
           composer-options: --ignore-platform-reqs
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -65,7 +65,7 @@ jobs:
           if [ "${{ matrix.phpcs_version }}" != "dev-master" ]; then
             echo '::set-output name=PHP_INI::error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On'
           else
-            echo '::set-output name=PHP_INI::error_reporting=E_ALL, display_errors=On'
+            echo '::set-output name=PHP_INI::error_reporting=-1, display_errors=On'
           fi
 
       - name: Set up PHP

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,11 @@
 		"php-parallel-lint/php-parallel-lint": "^1.0",
 		"php-parallel-lint/php-console-highlighter": "^0.5"
 	},
+	"config": {
+		"allow-plugins": {
+			"dealerdirect/phpcodesniffer-composer-installer": true
+		}
+	},
 	"minimum-stability": "dev",
 	"prefer-stable": true,
 	"scripts": {


### PR DESCRIPTION
### Composer: allow the PHPCS plugin

The `dealerdirect/phpcodesniffer-composer-installer` Composer plugin is used to register external PHPCS standards with PHPCS.

As of Composer 2.2.0, Composer plugins need to be explicitly allowed to run. This adds the necessary configuration for that.

Refs:
* https://blog.packagist.com/composer-2-2/#more-secure-plugin-execution

### GH Actions: auto-cancel previous builds for same branch

Previously, in Travis, when the same branch was pushed again and the "Auto cancellation" option on the "Settings" page had been turned on (as it was for most repos), any still running builds for the same branch would be stopped in favour of starting the build for the newly pushed version of the branch.

To enable this behaviour in GH Actions, a `concurrency` configuration needs to be added to each workflow for which this should applied to.

More than anything, this is a way to be kind to GitHub by not wasting resources which they so kindly provide to us for free.

Refs:
* https://github.blog/changelog/2021-04-19-github-actions-limit-workflow-run-or-job-concurrency/
* https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#concurrency

### GH Actions: use error_reporting=-1

... as `E_ALL` does not always contain _all_ errors across PHP versions.

### GH Actions: update for the release of PHP 8.1

This commit makes the necessary adjustments to the test matrix to account for that.

Note: the protected branch settings should be adjusted after this change to include the two new PHP 8.1 builds.

### 🆕 GH Actions: version update for `ramsey/composer-install`

The action used to install Composer packages and handle the caching has released a new major (and some follow-up patch releases), which means, the action reference needs to be updated to benefit from it.

Includes adding `--no-interaction` to "plain" Composer commands to potentially prevent CI hanging if, for whatever reason, interaction would be needed in the future.

Refs:
* https://github.com/ramsey/composer-install/releases/tag/2.0.0
* https://github.com/ramsey/composer-install/releases/tag/2.0.1
* https://github.com/ramsey/composer-install/releases/tag/2.0.2