### PR TITLE
README.md: Update the minimum supported PHP version

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,13 +155,13 @@ The [PHPCompatibilityWP](https://github.com/PHPCompatibility/PHPCompatibilityWP)
 
 Install either as a separate ruleset and run it separately against your code or add it to your custom ruleset, like so:
 ```xml
-<config name="testVersion" value="5.2-"/>
+<config name="testVersion" value="5.6-"/>
 <rule ref="PHPCompatibilityWP">
     <include-pattern>*\.php$</include-pattern>
 </rule>
 ```
 
-Whichever way you run it, do make sure you set the `testVersion` to run the sniffs against. The `testVersion` determines for which PHP versions you will receive compatibility information. The recommended setting for this at this moment is  `5.2-` to support the same PHP versions as WordPress Core supports.
+Whichever way you run it, do make sure you set the `testVersion` to run the sniffs against. The `testVersion` determines for which PHP versions you will receive compatibility information. The recommended setting for this at this moment is  `5.6-` to support the same PHP versions as WordPress Core supports.
 
 For more information about setting the `testVersion`, see:
 * [PHPCompatibility: Sniffing your code for compatibility with specific PHP version(s)](https://github.com/PHPCompatibility/PHPCompatibility#sniffing-your-code-for-compatibility-with-specific-php-versions)


### PR DESCRIPTION
In the readme.md file it is stated that PHP 5.2 is the minimum supported PHP version, while it's already PHP 5.6 for quite some time and technically WP does not work on PHP 5.2-5.5.