### PR TITLE
WP/CronInterval: bug fix for parentheses

### DIFF
--- a/WordPress/Sniffs/WP/CronIntervalSniff.php
+++ b/WordPress/Sniffs/WP/CronIntervalSniff.php
@@ -177,10 +177,15 @@ class CronIntervalSniff extends Sniff {
 					$valueStart = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $operator + 1 ), null, true, null, true );
 					$valueEnd   = $this->phpcsFile->findNext( array( \T_COMMA, \T_CLOSE_PARENTHESIS ), ( $valueStart + 1 ) );
 					$value      = '';
-					for ( $j = $valueStart; $j < $valueEnd; $j++ ) {
+					for ( $j = $valueStart; $j <= $valueEnd; $j++ ) {
 						if ( isset( Tokens::$emptyTokens[ $this->tokens[ $j ]['code'] ] ) ) {
 							continue;
 						}
+
+						if ( $j === $valueEnd && \T_COMMA === $this->tokens[ $j ]['code'] ) {
+							break;
+						}
+
 						$value .= $this->tokens[ $j ]['content'];
 					}
 
@@ -192,8 +197,8 @@ class CronIntervalSniff extends Sniff {
 					// Deal correctly with WP time constants.
 					$value = str_replace( array_keys( $this->wp_time_constants ), array_values( $this->wp_time_constants ), $value );
 
-					// If all digits and operators, eval!
-					if ( preg_match( '#^[\s\d+*/-]+$#', $value ) > 0 ) {
+					// If all parentheses, digits and operators, eval!
+					if ( preg_match( '#^[\s\d()+*/-]+$#', $value ) > 0 ) {
 						$interval = eval( "return ( $value );" ); // phpcs:ignore Squiz.PHP.Eval -- No harm here.
 						break;
 					}

--- a/WordPress/Tests/WP/CronIntervalUnitTest.inc
+++ b/WordPress/Tests/WP/CronIntervalUnitTest.inc
@@ -144,3 +144,19 @@ Custom::add_filter( 'cron_schedules', array( $class, $method ) ); // OK, not the
 add_filter( 'some_hook', array( $place, 'cron_schedules' ) ); // OK, not the hook we're looking for.
 add_filter( function() { return get_hook_name('cron_schedules'); }(), array( $class, $method ) ); // OK, nested in another function call.
 
+// Deal correctly with the time calculations within parentheses.
+add_filter( 'cron_schedules', function ( $schedules ) {
+	$schedules['every_2_days_and_a_bit'] = [
+		'interval' => ( 2 * DAY_IN_SECONDS + 2 * HOUR_IN_SECONDS ),
+		'display' => __( 'Once every 2 days and a bit' )
+	];
+	return $schedules;
+} ); // Ok: > 15 min.
+
+add_filter( 'cron_schedules', function ( $schedules ) {
+	$schedules['every_8_minutes'] = [
+		'interval' => (8 * MINUTE_IN_SECONDS),
+		'display' => __( 'Once every 8 minutes' )
+	];
+	return $schedules;
+} ); // Error: 8 min.

--- a/WordPress/Tests/WP/CronIntervalUnitTest.php
+++ b/WordPress/Tests/WP/CronIntervalUnitTest.php
@@ -51,7 +51,7 @@ class CronIntervalUnitTest extends AbstractSniffUnitTest {
 			108 => 1,
 			115 => 1,
 			133 => 1,
+			156 => 1,
 		);
 	}
-
 }


### PR DESCRIPTION
This allows for a time calculation to be wrapped in parentheses.

Fixes #2025

---

Note: just looking at the code, I can see multiple additional improvements which could/should be made:
* Only search for close parenthesis as a "valueEnd" if the `$valueStart` token is an open parenthesis.
* Allow for more assignment operators - the new schedule could be build up bit by bit and only assigned to the array later.

These additional things are not addressed here. This just addresses the immediate issue.