### PR TITLE
Add docs schema

### DIFF
--- a/WordPress/Docs/docs-schema.xsd
+++ b/WordPress/Docs/docs-schema.xsd
@@ -2,7 +2,7 @@
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
     <xs:element name="documentation">
         <xs:complexType>
-            <xs:sequence>
+            <xs:sequence maxOccurs="unbounded">
                 <xs:group ref="rulegroup"/>
             </xs:sequence>
             <xs:attribute name="title" use="required" type="titleType"/>
@@ -13,7 +13,7 @@
     <xs:group name="rulegroup">
         <xs:sequence>
             <xs:element name="standard" type="standardType"/>
-            <xs:element name="code_comparison" type="code_comparisonType"/>
+            <xs:element name="code_comparison" type="code_comparisonType" maxOccurs="unbounded"/>
             <xs:any minOccurs="0"/>
         </xs:sequence>
     </xs:group>

--- a/WordPress/Docs/docs-schema.xsd
+++ b/WordPress/Docs/docs-schema.xsd
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
+
+	<xs:element name="documentation">
+		<xs:complexType>
+			<xs:choice minOccurs="0" maxOccurs="unbounded">
+				<xs:element name="standard" type="xs:string"/>
+				<xs:element name="code_comparison" type="code_comparisonType"/>
+			</xs:choice>
+			<xs:attribute name="title" type="xs:string"/>
+		</xs:complexType>
+	</xs:element>
+
+	<xs:complexType name="code_comparisonType">
+		<xs:sequence>
+			<xs:element name="code" type="codeType" maxOccurs="unbounded" minOccurs="2"/>
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:complexType name="codeType">
+		<xs:simpleContent>
+			<xs:extension base="xs:string">
+				<xs:attribute name="title" use="required" type="xs:string"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+</xs:schema>

--- a/WordPress/Docs/docs-schema.xsd
+++ b/WordPress/Docs/docs-schema.xsd
@@ -6,7 +6,7 @@
                 <xs:group ref="rulegroup"/>
             </xs:sequence>
             <xs:attribute name="title" use="required" type="titleType"/>
-            <xs:anyAttribute/>
+            <xs:anyAttribute processContents="lax"/>
         </xs:complexType>
     </xs:element>
 

--- a/WordPress/Docs/docs-schema.xsd
+++ b/WordPress/Docs/docs-schema.xsd
@@ -1,27 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
 
-	<xs:element name="documentation">
-		<xs:complexType>
-			<xs:choice maxOccurs="unbounded">
-				<xs:element name="standard" type="xs:string"/>
-				<xs:element name="code_comparison" type="code_comparisonType"/>
-			</xs:choice>
-			<xs:attribute name="title" use="required" type="xs:string"/>
-		</xs:complexType>
-	</xs:element>
+    <xs:element name="documentation">
+        <xs:complexType>
+            <xs:choice maxOccurs="unbounded">
+                <xs:element name="standard" type="xs:string"/>
+                <xs:element name="code_comparison" type="code_comparisonType"/>
+            </xs:choice>
+            <xs:attribute name="title" use="required" type="xs:string"/>
+        </xs:complexType>
+    </xs:element>
 
-	<xs:complexType name="code_comparisonType">
-		<xs:sequence>
-			<xs:element name="code" type="codeType" maxOccurs="2" minOccurs="2"/>
-		</xs:sequence>
-	</xs:complexType>
+    <xs:complexType name="code_comparisonType">
+        <xs:sequence>
+            <xs:element name="code" type="codeType" maxOccurs="2" minOccurs="2"/>
+        </xs:sequence>
+    </xs:complexType>
 
-	<xs:complexType name="codeType">
-		<xs:simpleContent>
-			<xs:extension base="xs:string">
-				<xs:attribute name="title" use="required" type="xs:string"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
+    <xs:complexType name="codeType">
+        <xs:simpleContent>
+            <xs:extension base="xs:string">
+                <xs:attribute name="title" use="required" type="xs:string"/>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
 </xs:schema>

--- a/WordPress/Docs/docs-schema.xsd
+++ b/WordPress/Docs/docs-schema.xsd
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
-
     <xs:element name="documentation">
         <xs:complexType>
-            <xs:choice maxOccurs="unbounded">
+            <xs:sequence maxOccurs="unbounded">
                 <xs:element name="standard" type="xs:string"/>
                 <xs:element name="code_comparison" type="code_comparisonType"/>
-            </xs:choice>
+            </xs:sequence>
             <xs:attribute name="title" use="required" type="xs:string"/>
+            <xs:anyAttribute/>
         </xs:complexType>
     </xs:element>
 

--- a/WordPress/Docs/docs-schema.xsd
+++ b/WordPress/Docs/docs-schema.xsd
@@ -2,14 +2,27 @@
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
     <xs:element name="documentation">
         <xs:complexType>
-            <xs:sequence maxOccurs="unbounded">
-                <xs:element name="standard" type="xs:string"/>
-                <xs:element name="code_comparison" type="code_comparisonType"/>
+            <xs:sequence>
+                <xs:group ref="rulegroup"/>
             </xs:sequence>
-            <xs:attribute name="title" use="required" type="xs:string"/>
+            <xs:attribute name="title" use="required" type="titleType"/>
             <xs:anyAttribute/>
         </xs:complexType>
     </xs:element>
+
+    <xs:group name="rulegroup">
+        <xs:sequence>
+            <xs:element name="standard" type="standardType"/>
+            <xs:element name="code_comparison" type="code_comparisonType"/>
+            <xs:any minOccurs="0"/>
+        </xs:sequence>
+    </xs:group>
+
+    <xs:simpleType name="titleType">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="58"/>
+        </xs:restriction>
+    </xs:simpleType>
 
     <xs:complexType name="code_comparisonType">
         <xs:sequence>
@@ -21,6 +34,14 @@
         <xs:simpleContent>
             <xs:extension base="xs:string">
                 <xs:attribute name="title" use="required" type="xs:string"/>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+
+    <xs:complexType name="standardType">
+        <xs:simpleContent>
+            <xs:extension base="xs:string">
+                <xs:anyAttribute/>
             </xs:extension>
         </xs:simpleContent>
     </xs:complexType>

--- a/WordPress/Docs/docs-schema.xsd
+++ b/WordPress/Docs/docs-schema.xsd
@@ -3,17 +3,17 @@
 
 	<xs:element name="documentation">
 		<xs:complexType>
-			<xs:choice minOccurs="0" maxOccurs="unbounded">
+			<xs:choice maxOccurs="unbounded">
 				<xs:element name="standard" type="xs:string"/>
 				<xs:element name="code_comparison" type="code_comparisonType"/>
 			</xs:choice>
-			<xs:attribute name="title" type="xs:string"/>
+			<xs:attribute name="title" use="required" type="xs:string"/>
 		</xs:complexType>
 	</xs:element>
 
 	<xs:complexType name="code_comparisonType">
 		<xs:sequence>
-			<xs:element name="code" type="codeType" maxOccurs="unbounded" minOccurs="2"/>
+			<xs:element name="code" type="codeType" maxOccurs="2" minOccurs="2"/>
 		</xs:sequence>
 	</xs:complexType>
 


### PR DESCRIPTION
This PR addresses the #1722 issue.

I've made some schema examples with automated tools (PhpStorm and XMLSpy), then went ahead and abstracted things according to [default `phpcs.xsd` schema](https://github.com/squizlabs/PHP_CodeSniffer/blob/master/phpcs.xsd).

Once added every documentation type should define the 

```xml
xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
```

and 

```xml
xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/WordPress/WordPress-Coding-Standards/develop/WordPress/Docs/docs-schema.xsd"
```

tags in the main `documentation` tag of the documentation xml files.

Like:

```xml
<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/WordPress/WordPress-Coding-Standards/develop/WordPress/Docs/docs-schema.xsd title="Array Indentation">
```

I've added the `xsd` file in the `Docs` folder, kinda felt natural, but we can move it to the root of the project.