### PR TITLE
Core: add the `Generic.VersionControl.GitMergeConflict` sniff

### DIFF
--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -523,6 +523,9 @@
 		<message>Best practices: Declare only one class/interface/trait in a file.</message>
 	</rule>
 
+	<!-- Error on merge conflict markers. -->
+	<rule ref="Generic.VersionControl.GitMergeConflict"/>
+
 	<!--
 	#############################################################################
 	Not in the coding standard handbook: WP specific sniffs.


### PR DESCRIPTION
Fixes #1500

Note: as this isn't so much about coding standards, but about error prevention, I don't think this needs an entry in the Coding Standards docs.