### PR TITLE
Composer: up the minimum PHPCS version to 3.6.2

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -36,7 +36,7 @@ When you introduce new `public` sniff properties, or your sniff extends a class 
 
 ## Pre-requisites
 * WordPress-Coding-Standards
-* PHP_CodeSniffer 3.3.1 or higher
+* PHP_CodeSniffer 3.6.2 or higher
 * PHPUnit 4.x, 5.x, 6.x or 7.x
 
 The WordPress Coding Standards use the `PHP_CodeSniffer` native unit test suite for unit testing the sniffs.

--- a/.github/ISSUE_TEMPLATE/dependency-change.md
+++ b/.github/ISSUE_TEMPLATE/dependency-change.md
@@ -4,7 +4,7 @@ about: A reminder to take action when a WPCS dependency changes
 
 ---
 
-<!-- PLEASE prefix the title the Issue with the dependency name and version when action should be taken e.g. PHPCS 3.5: ... -->
+<!-- PLEASE prefix the title the Issue with the dependency name and version when action should be taken e.g. PHPCS 3.7.0: ... -->
 
 ## Rationale
 

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -36,9 +36,9 @@ jobs:
         phpcs_version: [ 'dev-master' ]
         include:
           - php: '7.3'
-            phpcs_version: '3.5.0'
+            phpcs_version: '3.6.2'
           - php: '5.4'
-            phpcs_version: '3.5.0'
+            phpcs_version: '3.6.2'
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/ruleset-checks-sniffs.yml
+++ b/.github/workflows/ruleset-checks-sniffs.yml
@@ -115,7 +115,7 @@ jobs:
     strategy:
       matrix:
         php: [ '7.4' ]
-        phpcs_version: [ 'dev-master', '3.5.0' ]
+        phpcs_version: [ 'dev-master', '3.6.2' ]
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -34,24 +34,10 @@ jobs:
     continue-on-error: ${{ matrix.allowed_failure }}
     strategy:
       matrix:
-        php: [ '7.4', '7.3', '7.2', '7.1', '7.0', '5.6', '5.5', '5.4' ]
-        phpcs_version: [ 'dev-master', '3.5.0' ]
+        php: [ '8.1', '8.0', '7.4', '7.3', '7.2', '7.1', '7.0', '5.6', '5.5', '5.4' ]
+        phpcs_version: [ 'dev-master', '3.6.2' ]
         allowed_failure: [ false ]
         include:
-          - php: '8.1'
-            phpcs_version: 'dev-master'
-            allowed_failure: false
-          # PHPCS is only compatible with PHP 8.1 as of version 3.6.1.
-          - php: '8.1'
-            phpcs_version: '3.6.1'
-            allowed_failure: false
-          - php: '8.0'
-            phpcs_version: 'dev-master'
-            allowed_failure: false
-          # PHPCS is only compatible with PHP 8.0 as of version 3.5.7.
-          - php: '8.0'
-            phpcs_version: '3.5.7'
-            allowed_failure: false
           # Add extra build to test against PHPCS 4.
           #- php: '7.4'
           #  phpcs_version: '4.0.x-dev as 3.9.99'

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ This project is a collection of [PHP_CodeSniffer](https://github.com/squizlabs/P
 
 ### Requirements
 
-The WordPress Coding Standards require PHP 5.4 or higher and [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) version **3.3.1** or higher.
+The WordPress Coding Standards require PHP 5.4 or higher and [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) version **3.6.2** or higher.
 
 ### Composer
 

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
 	],
 	"require": {
 		"php": ">=5.4",
-		"squizlabs/php_codesniffer": "^3.5.0",
+		"squizlabs/php_codesniffer": "^3.6.2",
 		"phpcsstandards/phpcsutils": "^1.0",
 		"phpcsstandards/phpcsextra": "^1.0"
 	},


### PR DESCRIPTION
While the minimum PHPCS version has already been upped to PHPCS 3.5.0 previously for the WPCS 3.0.0 branch, I'm proposing to up it yet further to the latest PHPCS version available.

PHP 8.0 and 8.1 introduced a lot of new syntaxes and, while a lot of this can be supported for older PHPCS versions via PHPCSUtils, this will always impact performance and precision, so it is strongly advisable to use the latest PHPCS version as the new minimum if we want to support the newly available PHP syntaxes.

For now, I'm upping the minimum version to PHPCS 3.6.2, which is the latest PHPCS release. This will unblock PRs to add support for PHP 8.0 features to WPCS.
Once PHPCS 3.7.0 has been released, the minimum PHPCS version should be upped again to unblock adding support for PHP 8.1 features to WPCS.

Includes updating the GH Actions matrixes for this change.

Also see #2048