### PR TITLE
Composer: up the minimum PHPCS version to 3.7.0

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -36,7 +36,7 @@ When you introduce new `public` sniff properties, or your sniff extends a class 
 
 ## Pre-requisites
 * WordPress-Coding-Standards
-* PHP_CodeSniffer 3.6.2 or higher
+* PHP_CodeSniffer 3.7.0 or higher
 * PHPUnit 4.x, 5.x, 6.x or 7.x
 
 The WordPress Coding Standards use the `PHP_CodeSniffer` native unit test suite for unit testing the sniffs.

--- a/.github/ISSUE_TEMPLATE/dependency-change.md
+++ b/.github/ISSUE_TEMPLATE/dependency-change.md
@@ -4,7 +4,7 @@ about: A reminder to take action when a WPCS dependency changes
 
 ---
 
-<!-- PLEASE prefix the title the Issue with the dependency name and version when action should be taken e.g. PHPCS 3.7.0: ... -->
+<!-- PLEASE prefix the title the Issue with the dependency name and version when action should be taken e.g. PHPCS 4.0.0: ... -->
 
 ## Rationale
 

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -36,9 +36,9 @@ jobs:
         phpcs_version: [ 'dev-master' ]
         include:
           - php: '7.3'
-            phpcs_version: '3.6.2'
+            phpcs_version: '3.7.0'
           - php: '5.4'
-            phpcs_version: '3.6.2'
+            phpcs_version: '3.7.0'
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/ruleset-checks-sniffs.yml
+++ b/.github/workflows/ruleset-checks-sniffs.yml
@@ -115,7 +115,7 @@ jobs:
     strategy:
       matrix:
         php: [ '7.4' ]
-        phpcs_version: [ 'dev-master', '3.6.2' ]
+        phpcs_version: [ 'dev-master', '3.7.0' ]
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       matrix:
         php: [ '8.1', '8.0', '7.4', '7.3', '7.2', '7.1', '7.0', '5.6', '5.5', '5.4' ]
-        phpcs_version: [ 'dev-master', '3.6.2' ]
+        phpcs_version: [ 'dev-master', '3.7.0' ]
         allowed_failure: [ false ]
         include:
           # Add extra build to test against PHPCS 4.

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ This project is a collection of [PHP_CodeSniffer](https://github.com/squizlabs/P
 
 ### Requirements
 
-The WordPress Coding Standards require PHP 5.4 or higher and [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) version **3.6.2** or higher.
+The WordPress Coding Standards require PHP 5.4 or higher and [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) version **3.7.0** or higher.
 
 ### Composer
 

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
 	],
 	"require": {
 		"php": ">=5.4",
-		"squizlabs/php_codesniffer": "^3.6.2",
+		"squizlabs/php_codesniffer": "^3.7.0",
 		"phpcsstandards/phpcsutils": "^1.0",
 		"phpcsstandards/phpcsextra": "^1.0"
 	},


### PR DESCRIPTION
PHPCS 3.7.0 has just been released.

As discussed in issue #2048 and PR #2049, to add support for PHP 8.1 features to WPCS and prevent false positives related to PHP 8.1 features, this commit ups the minimum supported PHPCS version to PHPCS 3.7.0.

Includes updating the GH Actions matrixes for this change.

Fixes #2048

Refs: https://github.com/squizlabs/PHP_CodeSniffer/releases/tag/3.7.0