### PR TITLE
Helper classes: explicitly state there is no BC promise

### DIFF
--- a/WordPress/Helpers/DeprecationHelper.php
+++ b/WordPress/Helpers/DeprecationHelper.php
@@ -15,6 +15,11 @@ use PHP_CodeSniffer\Util\Tokens;
 /**
  * Helper utilities for checking whether something has been marked as deprecated.
  *
+ * ---------------------------------------------------------------------------------------------
+ * This class is only intended for internal use by WordPressCS and is not part of the public API.
+ * This also means that it has no promise of backward compatibility. Use at your own risk.
+ * ---------------------------------------------------------------------------------------------
+ *
  * {@internal The functionality in this class will likely be replaced at some point in
  * the future by functions from PHPCSUtils.}
  *

--- a/WordPress/Helpers/TextStringHelper.php
+++ b/WordPress/Helpers/TextStringHelper.php
@@ -12,6 +12,11 @@ namespace WordPressCS\WordPress\Helpers;
 /**
  * Helper utilities for handling text strings.
  *
+ * ---------------------------------------------------------------------------------------------
+ * This class is only intended for internal use by WordPressCS and is not part of the public API.
+ * This also means that it has no promise of backward compatibility. Use at your own risk.
+ * ---------------------------------------------------------------------------------------------
+ *
  * {@internal The functionality in this class will likely be replaced at some point in
  * the future by functions from PHPCSUtils.}
  *


### PR DESCRIPTION
For the `Helper` classes which do not contain WordPress specific code and for which it is likely that PHPCSUtils may at some point replace the functionality, make it very clear that those classes are not covered by a promise of backward-compatibility.

By doing this, we buy ourselves the freedom to remove methods from these classes/the classes completely if/when PHPCSUtils would offer similar functionality, without the need to create a new major release of WPCS when we do.