### PR TITLE
3.0: Move "variable" related utilities to dedicated VariableHelper + use PHPCSUtils + handle match

### DIFF
--- a/WordPress/Helpers/VariableHelper.php
+++ b/WordPress/Helpers/VariableHelper.php
@@ -11,6 +11,7 @@ namespace WordPressCS\WordPress\Helpers;
 
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Utils\GetTokensAsString;
 
 /**
  * Helper utilities for working with variables representing arrays.
@@ -74,9 +75,11 @@ final class VariableHelper {
 				break;
 			}
 
-			$key = $phpcsFile->getTokensAsString(
+			$key = GetTokensAsString::compact(
+				$phpcsFile,
 				( $open_bracket + 1 ),
-				( $tokens[ $open_bracket ]['bracket_closer'] - $open_bracket - 1 )
+				( $tokens[ $open_bracket ]['bracket_closer'] - 1 ),
+				true
 			);
 
 			$keys[]  = trim( $key );

--- a/WordPress/Helpers/VariableHelper.php
+++ b/WordPress/Helpers/VariableHelper.php
@@ -12,6 +12,7 @@ namespace WordPressCS\WordPress\Helpers;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\Utils\GetTokensAsString;
+use PHPCSUtils\Utils\Parentheses;
 
 /**
  * Helper utilities for working with variables.
@@ -146,16 +147,8 @@ final class VariableHelper {
 		}
 
 		// We first check if this is a switch statement (switch ( $var )).
-		if ( isset( $tokens[ $stackPtr ]['nested_parenthesis'] ) ) {
-			$nested_parenthesis = $tokens[ $stackPtr ]['nested_parenthesis'];
-			$close_parenthesis  = end( $nested_parenthesis );
-
-			if (
-				isset( $tokens[ $close_parenthesis ]['parenthesis_owner'] )
-				&& \T_SWITCH === $tokens[ $tokens[ $close_parenthesis ]['parenthesis_owner'] ]['code']
-			) {
-				return true;
-			}
+		if ( Parentheses::lastOwnerIn( $phpcsFile, $stackPtr, array( \T_SWITCH ) ) !== false ) {
+			return true;
 		}
 
 		// Find the previous non-empty token. We check before the var first because

--- a/WordPress/Helpers/VariableHelper.php
+++ b/WordPress/Helpers/VariableHelper.php
@@ -120,7 +120,7 @@ final class VariableHelper {
 	 *
 	 * E.g., $var === 'foo', 1 <= $var, etc.
 	 *
-	 * Also recognizes `switch ( $var )`.
+	 * Also recognizes `switch ( $var )` and `match ( $var )`.
 	 *
 	 * @since 0.5.0
 	 * @since 2.1.0 Added the $include_coalesce parameter.
@@ -146,8 +146,8 @@ final class VariableHelper {
 			unset( $comparisonTokens[ \T_COALESCE ] );
 		}
 
-		// We first check if this is a switch statement (switch ( $var )).
-		if ( Parentheses::lastOwnerIn( $phpcsFile, $stackPtr, array( \T_SWITCH ) ) !== false ) {
+		// We first check if this is a switch or match statement (switch ( $var )).
+		if ( Parentheses::lastOwnerIn( $phpcsFile, $stackPtr, array( \T_SWITCH, \T_MATCH ) ) !== false ) {
 			return true;
 		}
 

--- a/WordPress/Helpers/VariableHelper.php
+++ b/WordPress/Helpers/VariableHelper.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPressCS\WordPress\Helpers;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+
+/**
+ * Helper utilities for working with variables representing arrays.
+ *
+ * ---------------------------------------------------------------------------------------------
+ * This class is only intended for internal use by WordPressCS and is not part of the public API.
+ * This also means that it has no promise of backward compatibility. Use at your own risk.
+ * ---------------------------------------------------------------------------------------------
+ *
+ * {@internal The functionality in this class will likely be replaced at some point in
+ * the future by functions from PHPCSUtils.}
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @since   3.0.0 The methods in this class were previously contained in the
+ *                `WordPressCS\WordPress\Sniff` class and have been moved here.
+ */
+final class VariableHelper {
+
+	/**
+	 * Get the index keys of an array variable.
+	 *
+	 * E.g., "bar" and "baz" in $foo['bar']['baz'].
+	 *
+	 * @since 2.1.0
+	 * @since 3.0.0 - Moved from the Sniff class to this class.
+	 *              - Visibility is now `public` (was `protected`) and the method `static`.
+	 *              - The $phpcsFile parameter was added.
+	 *
+	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+	 * @param int                         $stackPtr  The index of the variable token in the stack.
+	 * @param bool                        $all       Whether to get all keys or only the first.
+	 *                                               Defaults to `true`(= all).
+	 *
+	 * @return array An array of index keys whose value is being accessed.
+	 *               or an empty array if this is not array access.
+	 */
+	public static function get_array_access_keys( File $phpcsFile, $stackPtr, $all = true ) {
+		$tokens = $phpcsFile->getTokens();
+		$keys   = array();
+
+		if ( \T_VARIABLE !== $tokens[ $stackPtr ]['code'] ) {
+			return $keys;
+		}
+
+		$current = $stackPtr;
+
+		do {
+			// Find the next non-empty token.
+			$open_bracket = $phpcsFile->findNext(
+				Tokens::$emptyTokens,
+				( $current + 1 ),
+				null,
+				true
+			);
+
+			// If it isn't a bracket, this isn't an array-access.
+			if ( false === $open_bracket
+				|| \T_OPEN_SQUARE_BRACKET !== $tokens[ $open_bracket ]['code']
+				|| ! isset( $tokens[ $open_bracket ]['bracket_closer'] )
+			) {
+				break;
+			}
+
+			$key = $phpcsFile->getTokensAsString(
+				( $open_bracket + 1 ),
+				( $tokens[ $open_bracket ]['bracket_closer'] - $open_bracket - 1 )
+			);
+
+			$keys[]  = trim( $key );
+			$current = $tokens[ $open_bracket ]['bracket_closer'];
+		} while ( isset( $tokens[ $current ] ) && true === $all );
+
+		return $keys;
+	}
+
+	/**
+	 * Get the index key of an array variable.
+	 *
+	 * E.g., "bar" in $foo['bar'].
+	 *
+	 * @since 0.5.0
+	 * @since 2.1.0 Now uses get_array_access_keys() under the hood.
+	 * @since 3.0.0 - Moved from the Sniff class to this class.
+	 *              - Visibility is now `public` (was `protected`) and the method `static`.
+	 *              - The $phpcsFile parameter was added.
+	 *
+	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+	 * @param int                         $stackPtr  The index of the token in the stack.
+	 *
+	 * @return string|false The array index key whose value is being accessed.
+	 */
+	public static function get_array_access_key( File $phpcsFile, $stackPtr ) {
+		$keys = self::get_array_access_keys( $phpcsFile, $stackPtr, false );
+		if ( isset( $keys[0] ) ) {
+			return $keys[0];
+		}
+
+		return false;
+	}
+}

--- a/WordPress/Sniffs/Security/EscapeOutputSniff.php
+++ b/WordPress/Sniffs/Security/EscapeOutputSniff.php
@@ -9,10 +9,11 @@
 
 namespace WordPressCS\WordPress\Sniffs\Security;
 
-use WordPressCS\WordPress\Sniff;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\Utils\PassedParameters;
 use PHPCSUtils\Utils\TextStrings;
+use WordPressCS\WordPress\Helpers\VariableHelper;
+use WordPressCS\WordPress\Sniff;
 
 /**
  * Verifies that all outputted strings are escaped.
@@ -452,7 +453,7 @@ class EscapeOutputSniff extends Sniff {
 
 			// Make the error message a little more informative for array access variables.
 			if ( \T_VARIABLE === $this->tokens[ $ptr ]['code'] ) {
-				$array_keys = $this->get_array_access_keys( $ptr );
+				$array_keys = VariableHelper::get_array_access_keys( $this->phpcsFile, $ptr );
 
 				if ( ! empty( $array_keys ) ) {
 					$content .= '[' . implode( '][', $array_keys ) . ']';

--- a/WordPress/Sniffs/Security/ValidatedSanitizedInputSniff.php
+++ b/WordPress/Sniffs/Security/ValidatedSanitizedInputSniff.php
@@ -11,6 +11,7 @@ namespace WordPressCS\WordPress\Sniffs\Security;
 
 use PHP_CodeSniffer\Util\Tokens;
 use WordPressCS\WordPress\Helpers\TextStringHelper;
+use WordPressCS\WordPress\Helpers\VariableHelper;
 use WordPressCS\WordPress\Sniff;
 
 /**
@@ -125,7 +126,7 @@ class ValidatedSanitizedInputSniff extends Sniff {
 			return;
 		}
 
-		$array_keys = $this->get_array_access_keys( $stackPtr );
+		$array_keys = VariableHelper::get_array_access_keys( $this->phpcsFile, $stackPtr );
 
 		if ( empty( $array_keys ) ) {
 			return;

--- a/WordPress/Sniffs/Security/ValidatedSanitizedInputSniff.php
+++ b/WordPress/Sniffs/Security/ValidatedSanitizedInputSniff.php
@@ -179,7 +179,7 @@ class ValidatedSanitizedInputSniff extends Sniff {
 		}
 
 		// If this is a comparison ('a' == $_POST['foo']), sanitization isn't needed.
-		if ( $this->is_comparison( $stackPtr, false ) ) {
+		if ( VariableHelper::is_comparison( $this->phpcsFile, $stackPtr, false ) ) {
 			return;
 		}
 

--- a/WordPress/Sniffs/WP/GlobalVariablesOverrideSniff.php
+++ b/WordPress/Sniffs/WP/GlobalVariablesOverrideSniff.php
@@ -13,8 +13,9 @@ use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\Utils\Lists;
 use PHPCSUtils\Utils\Scopes;
 use PHPCSUtils\Utils\TextStrings;
-use WordPressCS\WordPress\Sniff;
 use WordPressCS\WordPress\Helpers\IsUnitTestTrait;
+use WordPressCS\WordPress\Helpers\VariableHelper;
+use WordPressCS\WordPress\Sniff;
 
 /**
  * Warns about overwriting WordPress native global variables.
@@ -384,7 +385,7 @@ class GlobalVariablesOverrideSniff extends Sniff {
 				foreach ( $var_pointers as $ptr ) {
 					$var_name = $this->tokens[ $ptr ]['content'];
 					if ( '$GLOBALS' === $var_name ) {
-						$var_name = '$' . TextStrings::stripQuotes( $this->get_array_access_key( $ptr ) );
+						$var_name = '$' . TextStrings::stripQuotes( VariableHelper::get_array_access_key( $this->phpcsFile, $ptr ) );
 					}
 
 					if ( \in_array( $var_name, $search, true ) ) {

--- a/WordPress/Tests/Security/ValidatedSanitizedInputUnitTest.inc
+++ b/WordPress/Tests/Security/ValidatedSanitizedInputUnitTest.inc
@@ -333,3 +333,6 @@ function test_using_different_unslashing_functions() {
 }
 
 echo wp_sanitize_redirect( wp_unslash( $_GET['test'] ) ); // OK.
+
+$result = match ( $_POST['foo'] ) {}; // Ok.
+$result = match ( do_something( wp_unslash( $_POST['foo'] ) ) ) {}; // Bad.

--- a/WordPress/Tests/Security/ValidatedSanitizedInputUnitTest.php
+++ b/WordPress/Tests/Security/ValidatedSanitizedInputUnitTest.php
@@ -80,6 +80,7 @@ class ValidatedSanitizedInputUnitTest extends AbstractSniffUnitTest {
 			315 => 2,
 			317 => 1,
 			323 => 1,
+			338 => 1,
 		);
 	}
 


### PR DESCRIPTION
### Move "array access keys" related utilities to dedicated VariableHelper

The "array access keys" related utilities are only used by a small set of sniffs, so are better placed in a dedicated class.

This commit moves the `get_array_access_keys()` method and the `get_array_access_key()` method to a new `WordPressCS\WordPress\Helpers\VariableHelper` and starts using that class in the relevant sniffs.

In contrast to some of the other "move methods out of the Sniff class" PRs, these methods have been moved to a class and made `static` - instead of moved to a `trait`.
The reason for this difference is that the methods in other "moves" are setting properties which the sniff classes would need access to, while these methods are 100% stand-alone.

**Note**:
It is expected for PHPCSUtils to have dedicated methods for the same at some point in the future. If/when those methods become available, it is recommended for the sniffs to start using the PHPCSUtils methods. With this in mind, this class has been marked as "internal" without BC promise.

Related to #1465

### VariableHelper::get_array_access_keys() use PHPCSUtils

Use the PHPCSUtils `GetTokensAsString::compact()` method to retrieve array access keys without extraneous whitespace or comments.

### Move "is comparison" related utility to dedicated VariableHelper

The "is comparison" related utility method is only used by a small set of sniffs, so is better placed in a dedicated class.

As this method also expects a `T_VARIABLE` token as input, the `VariableHelper` class seems appropriate.

This commit moves the `is_comparison()` method to the new `WordPressCS\WordPress\Helpers\VariableHelper` and starts using that class in the relevant sniffs.

**Note**:
It is expected for PHPCSUtils to have dedicated methods for the same at some point in the future. If/when those methods become available, it is recommended for the sniffs to start using the PHPCSUtils methods.

Related to #1465

### VariableHelper::is_comparison(): use PHPCSUtils

... to get the potential parentheses opener.

### PHP 8.0 | VariableHelper::is_comparison(): add support for variables being compared in a `match` expression

PHP 8.0 introduced `match` expressions, which do a (strict) comparison on the value in the condition against the options in the `match` body.
Ref: https://www.php.net/manual/en/control-structures.match.php

This commit updates the `is_comparison()` method to allow for variables in the "condition" part of a `match` expression to be considered part of a comparison.

Tested via the `ValidatedSanitizedInput` sniff.


---

N.B. While reviewing the "array access keys" methods, I noticed that the methods do not account for array assignments without a key, i.e. `$var[]`. This may need improved handling at some point, but is outside the scope of this PR.