### PR TITLE
Remove typical non-inclusive language from the repo

### DIFF
--- a/WordPress-Extra/ruleset.xml
+++ b/WordPress-Extra/ruleset.xml
@@ -147,11 +147,11 @@
 		 https://github.com/WordPress/WordPress-Coding-Standards/issues/1371 -->
 	<rule ref="WordPress.PHP.PregQuoteDelimiter"/>
 
-	<!-- The Core ruleset respects the whitelist. For `Extra` the sniff is stricter.
+	<!-- The Core ruleset respects the PHP allowed functions list. For `Extra` the sniff is stricter.
 		 https://github.com/WordPress/WordPress-Coding-Standards/pull/1450 -->
 	<rule ref="WordPress.PHP.NoSilencedErrors">
 		<properties>
-			<property name="use_default_whitelist" value="false"/>
+			<property name="usePHPFunctionsList" value="false"/>
 		</properties>
 	</rule>
 

--- a/WordPress/AbstractFunctionRestrictionsSniff.php
+++ b/WordPress/AbstractFunctionRestrictionsSniff.php
@@ -97,14 +97,14 @@ abstract class AbstractFunctionRestrictionsSniff extends Sniff {
 	 *         'message'   => 'Use anonymous functions instead please!',
 	 *         'functions' => array( 'file_get_contents', 'create_function', 'mysql_*' ),
 	 *         // Only useful when using wildcards:
-	 *         'whitelist' => array( 'mysql_to_rfc3339' => true, ),
+	 *         'allow' => array( 'mysql_to_rfc3339' => true, ),
 	 *     )
 	 * )
 	 *
 	 * You can use * wildcards to target a group of functions.
 	 * When you use * wildcards, you may inadvertently restrict too many
-	 * functions. In that case you can add the `whitelist` key to
-	 * whitelist individual functions to prevent false positives.
+	 * functions. In that case you can add the `allow` key to
+	 * safe list individual functions to prevent false positives.
 	 *
 	 * @return array
 	 */
@@ -280,7 +280,7 @@ abstract class AbstractFunctionRestrictionsSniff extends Sniff {
 				continue;
 			}
 
-			if ( isset( $group['whitelist'][ $token_content ] ) ) {
+			if ( isset( $group['allow'][ $token_content ] ) ) {
 				continue;
 			}
 

--- a/WordPress/Helpers/IsUnitTestTrait.php
+++ b/WordPress/Helpers/IsUnitTestTrait.php
@@ -140,7 +140,7 @@ trait IsUnitTestTrait {
 			$known_test_classes[ $k ] = ltrim( $v, '\\' );
 		}
 
-		// Is the class/trait one of the whitelisted test classes ?
+		// Is the class/trait one of the known test classes ?
 		$namespace = Namespaces::determineNamespace( $phpcsFile, $stackPtr );
 		$className = ObjectDeclarations::getName( $phpcsFile, $stackPtr );
 		if ( '' !== $namespace ) {
@@ -151,7 +151,7 @@ trait IsUnitTestTrait {
 			return true;
 		}
 
-		// Does the class/trait extend one of the whitelisted test classes ?
+		// Does the class/trait extend one of the known test classes ?
 		$extendedClassName = ObjectDeclarations::findExtendedClassName( $phpcsFile, $stackPtr );
 		if ( false === $extendedClassName ) {
 			return false;

--- a/WordPress/Sniffs/DB/PreparedSQLPlaceholdersSniff.php
+++ b/WordPress/Sniffs/DB/PreparedSQLPlaceholdersSniff.php
@@ -34,10 +34,6 @@ use WordPressCS\WordPress\Sniff;
  * created using code along the lines of:
  * `sprintf( 'query .... IN (%s) ...', implode( ',', array_fill( 0, count( $something ), '%s' ) ) )`.
  *
- * A "PreparedSQLPlaceholders replacement count" whitelist comment is supported
- * specifically to silence the `ReplacementsWrongNumber` and `UnfinishedPrepare`
- * error codes. The other error codes are not affected by it.
- *
  * @link https://developer.wordpress.org/reference/classes/wpdb/prepare/
  * @link https://core.trac.wordpress.org/changeset/41496
  * @link https://core.trac.wordpress.org/changeset/41471

--- a/WordPress/Sniffs/DB/RestrictedFunctionsSniff.php
+++ b/WordPress/Sniffs/DB/RestrictedFunctionsSniff.php
@@ -56,7 +56,7 @@ class RestrictedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 					'mysqlnd_memcache_*',
 					'maxdb_*',
 				),
-				'whitelist' => array(
+				'allow'     => array(
 					'mysql_to_rfc3339' => true,
 				),
 			),

--- a/WordPress/Sniffs/DB/SlowDBQuerySniff.php
+++ b/WordPress/Sniffs/DB/SlowDBQuerySniff.php
@@ -19,9 +19,6 @@ use WordPressCS\WordPress\AbstractArrayAssignmentRestrictionsSniff;
  * @package WPCS\WordPressCodingStandards
  *
  * @since   0.3.0
- * @since   0.12.0 Introduced new and more intuitively named 'slow query' whitelist
- *                 comment, replacing the 'tax_query' whitelist comment which is now
- *                 deprecated.
  * @since   0.13.0 Class name changed: this class is now namespaced.
  * @since   1.0.0  This sniff has been moved from the `VIP` category to the `DB` category.
  */

--- a/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
+++ b/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
@@ -64,13 +64,14 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 	public $prefixes = '';
 
 	/**
-	 * Prefix blacklist.
+	 * Prefix blocklist.
 	 *
 	 * @since 0.12.0
+	 * @since 3.0.0  Renamed from `$prefix_blacklist` to `$prefix_blocklist`.
 	 *
 	 * @var string[]
 	 */
-	protected $prefix_blacklist = array(
+	protected $prefix_blocklist = array(
 		'wordpress' => true,
 		'wp'        => true,
 		'_'         => true,
@@ -949,7 +950,7 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 	 * Validate an array of prefixes as passed through a custom property or via the command line.
 	 *
 	 * Checks that the prefix:
-	 * - is not one of the blacklisted ones.
+	 * - is not one of the blocked ones.
 	 * - complies with the PHP rules for valid function, class, variable, constant names.
 	 *
 	 * @since 0.12.0
@@ -968,7 +969,7 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 		foreach ( $this->prefixes as $key => $prefix ) {
 			$prefixLC = strtolower( $prefix );
 
-			if ( isset( $this->prefix_blacklist[ $prefixLC ] ) ) {
+			if ( isset( $this->prefix_blocklist[ $prefixLC ] ) ) {
 				$this->phpcsFile->addError(
 					'The "%s" prefix is not allowed.',
 					0,

--- a/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
+++ b/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
@@ -148,6 +148,7 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 	 * A list of core constants that are allowed to be defined by plugins and themes.
 	 *
 	 * @since 1.0.0
+	 * @since 3.0.0 Renamed from `$whitelisted_core_constants` to `$allowed_core_constants`.
 	 *
 	 * Source: {@link https://core.trac.wordpress.org/browser/trunk/src/wp-includes/default-constants.php#L0}
 	 * The constants are listed in the order they are found in the source file
@@ -157,7 +158,7 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 	 *
 	 * @var array
 	 */
-	protected $whitelisted_core_constants = array(
+	protected $allowed_core_constants = array(
 		'WP_MEMORY_LIMIT'      => true,
 		'WP_MAX_MEMORY_LIMIT'  => true,
 		'WP_CONTENT_DIR'       => true,
@@ -468,7 +469,7 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 						return;
 					}
 
-					if ( isset( $this->whitelisted_core_constants[ $item_name ] ) ) {
+					if ( isset( $this->allowed_core_constants[ $item_name ] ) ) {
 						// Defining a WP Core constant intended for overruling.
 						return;
 					}
@@ -809,7 +810,7 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 		if ( ( 'define' !== $matched_content
 			&& isset( $this->allowed_core_hooks[ $raw_content ] ) )
 			|| ( 'define' === $matched_content
-			&& isset( $this->whitelisted_core_constants[ $raw_content ] ) )
+			&& isset( $this->allowed_core_constants[ $raw_content ] ) )
 		) {
 			return;
 		}

--- a/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
+++ b/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
@@ -637,7 +637,7 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 		$variable_name = substr( $this->tokens[ $stackPtr ]['content'], 1 ); // Strip the dollar sign.
 
 		// Bow out early if we know for certain no prefix is needed.
-		if ( $this->variable_prefixed_or_whitelisted( $stackPtr, $variable_name ) === true ) {
+		if ( $this->variable_prefixed_or_allowed( $stackPtr, $variable_name ) === true ) {
 			return;
 		}
 
@@ -659,7 +659,7 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 
 			// Check whether a prefix is needed.
 			if ( isset( Tokens::$stringTokens[ $this->tokens[ $array_key ]['code'] ] )
-				&& $this->variable_prefixed_or_whitelisted( $stackPtr, $variable_name ) === true
+				&& $this->variable_prefixed_or_allowed( $stackPtr, $variable_name ) === true
 			) {
 				return;
 			}
@@ -670,7 +670,7 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 				$exploded = explode( '$', $variable_name );
 				$first    = rtrim( $exploded[0], '{' );
 				if ( '' !== $first ) {
-					if ( $this->variable_prefixed_or_whitelisted( $array_key, $first ) === true ) {
+					if ( $this->variable_prefixed_or_allowed( $array_key, $first ) === true ) {
 						return;
 					}
 				} else {
@@ -930,14 +930,15 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 	 *
 	 * @since 0.12.0
 	 * @since 1.0.1  Added $stackPtr parameter.
+	 * @since 3.0.0  Renamed from `variable_prefixed_or_whitelisted()` to `variable_prefixed_or_allowed()`.
 	 *
 	 * @param int    $stackPtr The position of the token to record the metric against.
 	 * @param string $name     Variable name without the dollar sign.
 	 *
-	 * @return bool True if the variable name is whitelisted or already prefixed.
+	 * @return bool True if the variable name is allowed or already prefixed.
 	 *              False otherwise.
 	 */
-	private function variable_prefixed_or_whitelisted( $stackPtr, $name ) {
+	private function variable_prefixed_or_allowed( $stackPtr, $name ) {
 		// Ignore superglobals and WP global variables.
 		if ( isset( $this->superglobals[ $name ] ) || isset( $this->wp_globals[ $name ] ) ) {
 			return true;

--- a/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
+++ b/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
@@ -135,10 +135,11 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 	 * A list of core hooks that are allowed to be called by plugins and themes.
 	 *
 	 * @since 0.14.0
+	 * @since 3.0.0 Renamed from `$whitelisted_core_hooks` to `$allowed_core_hooks`.
 	 *
 	 * @var array
 	 */
-	protected $whitelisted_core_hooks = array(
+	protected $allowed_core_hooks = array(
 		'widget_title'   => true,
 		'add_meta_boxes' => true,
 	);
@@ -806,7 +807,7 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 		$raw_content = TextStrings::stripQuotes( $parameters[1]['raw'] );
 
 		if ( ( 'define' !== $matched_content
-			&& isset( $this->whitelisted_core_hooks[ $raw_content ] ) )
+			&& isset( $this->allowed_core_hooks[ $raw_content ] ) )
 			|| ( 'define' === $matched_content
 			&& isset( $this->whitelisted_core_constants[ $raw_content ] ) )
 		) {

--- a/WordPress/Sniffs/NamingConventions/ValidPostTypeSlugSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidPostTypeSlugSniff.php
@@ -38,14 +38,15 @@ class ValidPostTypeSlugSniff extends AbstractFunctionParameterSniff {
 	const POST_TYPE_MAX_LENGTH = 20;
 
 	/**
-	 * Regex that whitelists characters that can be used as the post type slug.
+	 * Regex to validate the characters that can be used as the post type slug.
 	 *
 	 * @link https://developer.wordpress.org/reference/functions/register_post_type/
 	 * @since 2.2.0
+	 * @since 3.0.0 Renamed from `POST_TYPE_CHARACTER_WHITELIST` to `VALID_POST_TYPE_CHARACTERS`.
 	 *
 	 * @var string
 	 */
-	const POST_TYPE_CHARACTER_WHITELIST = '/^[a-z0-9_-]+$/';
+	const VALID_POST_TYPE_CHARACTERS = '/^[a-z0-9_-]+$/';
 
 	/**
 	 * Array of functions that must be checked.
@@ -165,7 +166,7 @@ class ValidPostTypeSlugSniff extends AbstractFunctionParameterSniff {
 			$post_type = TextStringHelper::strip_interpolated_variables( $post_type );
 		}
 
-		if ( preg_match( self::POST_TYPE_CHARACTER_WHITELIST, $post_type ) === 0 ) {
+		if ( preg_match( self::VALID_POST_TYPE_CHARACTERS, $post_type ) === 0 ) {
 			// Error for invalid characters.
 			$this->phpcsFile->addError(
 				'register_post_type() called with invalid post type %s. Post type contains invalid characters. Only lowercase alphanumeric characters, dashes, and underscores are allowed.',

--- a/WordPress/Sniffs/NamingConventions/ValidVariableNameSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidVariableNameSniff.php
@@ -117,7 +117,7 @@ class ValidVariableNameSniff extends PHPCS_AbstractVariableSniff {
 		}
 
 		// Merge any custom variables with the defaults.
-		$this->mergeWhiteList();
+		$this->merge_allow_lists();
 
 		// Likewise if it is a mixed-case var used by WordPress core.
 		if ( isset( $this->wordpress_mixed_case_vars[ $var_name ] ) ) {
@@ -212,7 +212,7 @@ class ValidVariableNameSniff extends PHPCS_AbstractVariableSniff {
 		}
 
 		// Merge any custom variables with the defaults.
-		$this->mergeWhiteList();
+		$this->merge_allow_lists();
 
 		if ( ! isset( $this->allowed_mixed_case_member_var_names[ $var_name ] ) && false === self::isSnakeCase( $var_name ) ) {
 			$error = 'Member variable "$%s" is not in valid snake_case format, try "$%s"';
@@ -240,7 +240,7 @@ class ValidVariableNameSniff extends PHPCS_AbstractVariableSniff {
 		if ( preg_match_all( '|[^\\\]\${?([a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*)|', $tokens[ $stack_ptr ]['content'], $matches ) > 0 ) {
 
 			// Merge any custom variables with the defaults.
-			$this->mergeWhiteList();
+			$this->merge_allow_lists();
 
 			foreach ( $matches[1] as $var_name ) {
 				// If it's a php reserved var, then its ok.
@@ -276,15 +276,16 @@ class ValidVariableNameSniff extends PHPCS_AbstractVariableSniff {
 	}
 
 	/**
-	 * Merge a custom whitelist provided via a custom ruleset with the predefined whitelist,
+	 * Merge a custom allow list provided via a custom ruleset with the predefined allow list,
 	 * if we haven't already.
 	 *
 	 * @since 0.10.0
 	 * @since 2.0.0  Removed unused $phpcs_file parameter.
+	 * @since 3.0.0  Renamed from `mergeWhiteList()` to `merge_allow_lists()`.
 	 *
 	 * @return void
 	 */
-	protected function mergeWhiteList() {
+	protected function merge_allow_lists() {
 		if ( $this->allowed_custom_properties !== $this->addedCustomProperties['properties'] ) {
 			// Fix property potentially passed as comma-delimited string.
 			$customProperties = Sniff::merge_custom_array( $this->allowed_custom_properties, array(), false );

--- a/WordPress/Sniffs/NamingConventions/ValidVariableNameSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidVariableNameSniff.php
@@ -76,10 +76,11 @@ class ValidVariableNameSniff extends PHPCS_AbstractVariableSniff {
 	 * Custom list of properties which can have mixed case.
 	 *
 	 * @since 0.11.0
+	 * @since 3.0.0  Renamed from `$customPropertiesWhitelist` to `$allowed_custom_properties`.
 	 *
 	 * @var string|string[]
 	 */
-	public $customPropertiesWhitelist = array();
+	public $allowed_custom_properties = array();
 
 	/**
 	 * Cache of previously added custom functions.
@@ -284,16 +285,16 @@ class ValidVariableNameSniff extends PHPCS_AbstractVariableSniff {
 	 * @return void
 	 */
 	protected function mergeWhiteList() {
-		if ( $this->customPropertiesWhitelist !== $this->addedCustomProperties['properties'] ) {
+		if ( $this->allowed_custom_properties !== $this->addedCustomProperties['properties'] ) {
 			// Fix property potentially passed as comma-delimited string.
-			$customProperties = Sniff::merge_custom_array( $this->customPropertiesWhitelist, array(), false );
+			$customProperties = Sniff::merge_custom_array( $this->allowed_custom_properties, array(), false );
 
 			$this->allowed_mixed_case_member_var_names = Sniff::merge_custom_array(
 				$customProperties,
 				$this->allowed_mixed_case_member_var_names
 			);
 
-			$this->addedCustomProperties['properties'] = $this->customPropertiesWhitelist;
+			$this->addedCustomProperties['properties'] = $this->allowed_custom_properties;
 		}
 	}
 

--- a/WordPress/Sniffs/NamingConventions/ValidVariableNameSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidVariableNameSniff.php
@@ -59,10 +59,11 @@ class ValidVariableNameSniff extends PHPCS_AbstractVariableSniff {
 	 *
 	 * @since 0.9.0
 	 * @since 0.11.0 Changed from public to protected.
+	 * @since 3.0.0  Renamed from `$whitelisted_mixed_case_member_var_names` to `$allowed_mixed_case_member_var_names`.
 	 *
 	 * @var array
 	 */
-	protected $whitelisted_mixed_case_member_var_names = array(
+	protected $allowed_mixed_case_member_var_names = array(
 		'ID'                => true,
 		'comment_ID'        => true,
 		'comment_post_ID'   => true,
@@ -139,7 +140,7 @@ class ValidVariableNameSniff extends PHPCS_AbstractVariableSniff {
 						$obj_var_name = substr( $obj_var_name, 1 );
 					}
 
-					if ( ! isset( $this->whitelisted_mixed_case_member_var_names[ $obj_var_name ] ) && self::isSnakeCase( $obj_var_name ) === false ) {
+					if ( ! isset( $this->allowed_mixed_case_member_var_names[ $obj_var_name ] ) && self::isSnakeCase( $obj_var_name ) === false ) {
 						$error = 'Object property "$%s" is not in valid snake_case format, try "$%s"';
 						$data  = array(
 							$original_var_name,
@@ -168,7 +169,7 @@ class ValidVariableNameSniff extends PHPCS_AbstractVariableSniff {
 		}
 
 		if ( self::isSnakeCase( $var_name ) === false ) {
-			if ( $in_class && ! isset( $this->whitelisted_mixed_case_member_var_names[ $var_name ] ) ) {
+			if ( $in_class && ! isset( $this->allowed_mixed_case_member_var_names[ $var_name ] ) ) {
 				$error      = 'Object property "$%s" is not in valid snake_case format, try "$%s"';
 				$error_name = 'UsedPropertyNotSnakeCase';
 			} elseif ( ! $in_class ) {
@@ -212,7 +213,7 @@ class ValidVariableNameSniff extends PHPCS_AbstractVariableSniff {
 		// Merge any custom variables with the defaults.
 		$this->mergeWhiteList();
 
-		if ( ! isset( $this->whitelisted_mixed_case_member_var_names[ $var_name ] ) && false === self::isSnakeCase( $var_name ) ) {
+		if ( ! isset( $this->allowed_mixed_case_member_var_names[ $var_name ] ) && false === self::isSnakeCase( $var_name ) ) {
 			$error = 'Member variable "$%s" is not in valid snake_case format, try "$%s"';
 			$data  = array(
 				$var_name,
@@ -287,9 +288,9 @@ class ValidVariableNameSniff extends PHPCS_AbstractVariableSniff {
 			// Fix property potentially passed as comma-delimited string.
 			$customProperties = Sniff::merge_custom_array( $this->customPropertiesWhitelist, array(), false );
 
-			$this->whitelisted_mixed_case_member_var_names = Sniff::merge_custom_array(
+			$this->allowed_mixed_case_member_var_names = Sniff::merge_custom_array(
 				$customProperties,
-				$this->whitelisted_mixed_case_member_var_names
+				$this->allowed_mixed_case_member_var_names
 			);
 
 			$this->addedCustomProperties['properties'] = $this->customPropertiesWhitelist;

--- a/WordPress/Sniffs/PHP/IniSetSniff.php
+++ b/WordPress/Sniffs/PHP/IniSetSniff.php
@@ -142,8 +142,8 @@ class IniSetSniff extends AbstractFunctionParameterSniff {
 		$option_name  = TextStrings::stripQuotes( $parameters[1]['raw'] );
 		$option_value = TextStrings::stripQuotes( $parameters[2]['raw'] );
 		if ( isset( $this->safe_options[ $option_name ] ) ) {
-			$whitelisted_option = $this->safe_options[ $option_name ];
-			if ( ! isset( $whitelisted_option['valid_values'] ) || in_array( strtolower( $option_value ), $whitelisted_option['valid_values'], true ) ) {
+			$safe_option = $this->safe_options[ $option_name ];
+			if ( ! isset( $safe_option['valid_values'] ) || in_array( strtolower( $option_value ), $safe_option['valid_values'], true ) ) {
 				return;
 			}
 		}

--- a/WordPress/Sniffs/PHP/IniSetSniff.php
+++ b/WordPress/Sniffs/PHP/IniSetSniff.php
@@ -16,7 +16,7 @@ use WordPressCS\WordPress\AbstractFunctionParameterSniff;
  * Detect use of the `ini_set()` function.
  *
  * - Won't throw notices for "safe" ini directives as listed in the safe-list.
- * - Throws errors for ini directives listed in the blacklist.
+ * - Throws errors for ini directives listed in the disallow-list.
  * - A warning will be thrown in all other cases.
  *
  * @package WPCS\WordPressCodingStandards
@@ -70,16 +70,17 @@ class IniSetSniff extends AbstractFunctionParameterSniff {
 	 * Array of PHP configuration options that are not allowed to be manipulated.
 	 *
 	 * @since 2.1.0
+	 * @since 3.0.0 Renamed from `$blacklisted_options` to `$disallowed_options`.
 	 *
 	 * @var array Multidimensional array with parameter details.
-	 *     $blacklisted_options = array(
+	 *     $disallowed_options = array(
 	 *         (string) option name. = array(
 	 *             (string[]) 'invalid_values' = array()
 	 *             (string) 'message'
 	 *         )
 	 *     );
 	 */
-	protected $blacklisted_options = array(
+	protected $disallowed_options = array(
 		'bcmath.scale' => array(
 			'message' => 'Use `bcscale()` instead.',
 		),
@@ -125,7 +126,7 @@ class IniSetSniff extends AbstractFunctionParameterSniff {
 	/**
 	 * Process the parameter of a matched function.
 	 *
-	 * Errors if an option is found in the blacklist. Warns as
+	 * Errors if an option is found in the disallow-list. Warns as
 	 * 'risky' when the option is not found in the safe-list.
 	 *
 	 * @since 2.1.0
@@ -147,8 +148,8 @@ class IniSetSniff extends AbstractFunctionParameterSniff {
 			}
 		}
 
-		if ( isset( $this->blacklisted_options[ $option_name ] ) ) {
-			$blacklisted_option = $this->blacklisted_options[ $option_name ];
+		if ( isset( $this->disallowed_options[ $option_name ] ) ) {
+			$blacklisted_option = $this->disallowed_options[ $option_name ];
 			if ( ! isset( $blacklisted_option['invalid_values'] ) || in_array( strtolower( $option_value ), $blacklisted_option['invalid_values'], true ) ) {
 				$this->phpcsFile->addError(
 					'%s(%s, %s) found. %s',

--- a/WordPress/Sniffs/PHP/IniSetSniff.php
+++ b/WordPress/Sniffs/PHP/IniSetSniff.php
@@ -149,8 +149,8 @@ class IniSetSniff extends AbstractFunctionParameterSniff {
 		}
 
 		if ( isset( $this->disallowed_options[ $option_name ] ) ) {
-			$blacklisted_option = $this->disallowed_options[ $option_name ];
-			if ( ! isset( $blacklisted_option['invalid_values'] ) || in_array( strtolower( $option_value ), $blacklisted_option['invalid_values'], true ) ) {
+			$disallowed_option = $this->disallowed_options[ $option_name ];
+			if ( ! isset( $disallowed_option['invalid_values'] ) || in_array( strtolower( $option_value ), $disallowed_option['invalid_values'], true ) ) {
 				$this->phpcsFile->addError(
 					'%s(%s, %s) found. %s',
 					$stackPtr,
@@ -159,7 +159,7 @@ class IniSetSniff extends AbstractFunctionParameterSniff {
 						$matched_content,
 						$parameters[1]['raw'],
 						$parameters[2]['raw'],
-						$blacklisted_option['message'],
+						$disallowed_option['message'],
 					)
 				);
 				return;

--- a/WordPress/Sniffs/PHP/IniSetSniff.php
+++ b/WordPress/Sniffs/PHP/IniSetSniff.php
@@ -41,7 +41,8 @@ class IniSetSniff extends AbstractFunctionParameterSniff {
 	);
 
 	/**
-	 * Array of PHP configuration options that are allowed to be manipulated.
+	 * Array of PHP configuration options that are safe to be manipulated, as changing
+	 * the value of these, won't cause interoperability issues between WP/plugins/themes.
 	 *
 	 * @since 2.1.0
 	 * @since 3.0.0 Renamed from `$whitelisted_options` to `$safe_options`.
@@ -67,7 +68,8 @@ class IniSetSniff extends AbstractFunctionParameterSniff {
 	);
 
 	/**
-	 * Array of PHP configuration options that are not allowed to be manipulated.
+	 * Array of PHP configuration options that are not allowed to be manipulated, as changing
+	 * the value of these, will be problematic for interoperability between WP/plugins/themes.
 	 *
 	 * @since 2.1.0
 	 * @since 3.0.0 Renamed from `$blacklisted_options` to `$disallowed_options`.

--- a/WordPress/Sniffs/PHP/IniSetSniff.php
+++ b/WordPress/Sniffs/PHP/IniSetSniff.php
@@ -15,7 +15,7 @@ use WordPressCS\WordPress\AbstractFunctionParameterSniff;
 /**
  * Detect use of the `ini_set()` function.
  *
- * - Won't throw notices for "safe" ini directives as listed in the whitelist.
+ * - Won't throw notices for "safe" ini directives as listed in the safe-list.
  * - Throws errors for ini directives listed in the blacklist.
  * - A warning will be thrown in all other cases.
  *
@@ -44,15 +44,16 @@ class IniSetSniff extends AbstractFunctionParameterSniff {
 	 * Array of PHP configuration options that are allowed to be manipulated.
 	 *
 	 * @since 2.1.0
+	 * @since 3.0.0 Renamed from `$whitelisted_options` to `$safe_options`.
 	 *
 	 * @var array Multidimensional array with parameter details.
-	 *     $whitelisted_options = array(
+	 *     $safe_options = array(
 	 *         (string) option name. = array(
 	 *             (string[]) 'valid_values' = array()
 	 *         )
 	 *     );
 	 */
-	protected $whitelisted_options = array(
+	protected $safe_options = array(
 		'auto_detect_line_endings' => array(),
 		'highlight.bg'             => array(),
 		'highlight.comment'        => array(),
@@ -125,7 +126,7 @@ class IniSetSniff extends AbstractFunctionParameterSniff {
 	 * Process the parameter of a matched function.
 	 *
 	 * Errors if an option is found in the blacklist. Warns as
-	 * 'risky' when the option is not found in the whitelist.
+	 * 'risky' when the option is not found in the safe-list.
 	 *
 	 * @since 2.1.0
 	 *
@@ -139,8 +140,8 @@ class IniSetSniff extends AbstractFunctionParameterSniff {
 	public function process_parameters( $stackPtr, $group_name, $matched_content, $parameters ) {
 		$option_name  = TextStrings::stripQuotes( $parameters[1]['raw'] );
 		$option_value = TextStrings::stripQuotes( $parameters[2]['raw'] );
-		if ( isset( $this->whitelisted_options[ $option_name ] ) ) {
-			$whitelisted_option = $this->whitelisted_options[ $option_name ];
+		if ( isset( $this->safe_options[ $option_name ] ) ) {
+			$whitelisted_option = $this->safe_options[ $option_name ];
 			if ( ! isset( $whitelisted_option['valid_values'] ) || in_array( strtolower( $option_value ), $whitelisted_option['valid_values'], true ) ) {
 				return;
 			}

--- a/WordPress/Sniffs/PHP/IniSetSniff.php
+++ b/WordPress/Sniffs/PHP/IniSetSniff.php
@@ -154,7 +154,7 @@ class IniSetSniff extends AbstractFunctionParameterSniff {
 				$this->phpcsFile->addError(
 					'%s(%s, %s) found. %s',
 					$stackPtr,
-					$this->string_to_errorcode( $option_name . '_Blacklisted' ),
+					$this->string_to_errorcode( $option_name . '_Disallowed' ),
 					array(
 						$matched_content,
 						$parameters[1]['raw'],

--- a/WordPress/Sniffs/PHP/NoSilencedErrorsSniff.php
+++ b/WordPress/Sniffs/PHP/NoSilencedErrorsSniff.php
@@ -40,8 +40,8 @@ class NoSilencedErrorsSniff extends Sniff {
 	 *
 	 * Defaults to true.
 	 *
-	 * This property only affects whether the standard function list is
-	 * used. The custom whitelist, if set, will always be respected.
+	 * This property only affects whether the standard function list is used.
+	 * The custom allowed functions list, if set, will always be respected.
 	 *
 	 * @since 1.1.0
 	 * @since 3.0.0 Renamed from `$use_default_whitelist` to `$usePHPFunctionsList`.
@@ -51,16 +51,17 @@ class NoSilencedErrorsSniff extends Sniff {
 	public $usePHPFunctionsList = true;
 
 	/**
-	 * User defined whitelist.
+	 * User defined function list.
 	 *
-	 * Allows users to pass a list of additional functions to whitelist
-	 * from their custom ruleset.
+	 * Allows users to pass a list of additional functions for which to allow
+	 * the use of the silence operator. This list can be set in a custom ruleset.
 	 *
 	 * @since 1.1.0
+	 * @since 3.0.0 Renamed from `$custom_whitelist` to `$customAllowedFunctionsList`.
 	 *
 	 * @var array
 	 */
-	public $custom_whitelist = array();
+	public $customAllowedFunctionsList = array();
 
 	/**
 	 * PHP native function whitelist.
@@ -180,9 +181,9 @@ class NoSilencedErrorsSniff extends Sniff {
 	 * @param int $stackPtr The position of the current token in the stack.
 	 */
 	public function process_token( $stackPtr ) {
-		// Handle the user-defined custom function whitelist.
-		$this->custom_whitelist = $this->merge_custom_array( $this->custom_whitelist, array(), false );
-		$this->custom_whitelist = array_map( 'strtolower', $this->custom_whitelist );
+		// Handle the user-defined custom function list.
+		$this->customAllowedFunctionsList = $this->merge_custom_array( $this->customAllowedFunctionsList, array(), false );
+		$this->customAllowedFunctionsList = array_map( 'strtolower', $this->customAllowedFunctionsList );
 
 		/*
 		 * Check if the error silencing is done for one of the whitelisted functions.
@@ -197,8 +198,8 @@ class NoSilencedErrorsSniff extends Sniff {
 				$function_name = strtolower( $this->tokens[ $next_non_empty ]['content'] );
 				if ( ( true === $this->usePHPFunctionsList
 					&& isset( $this->function_whitelist[ $function_name ] ) === true )
-					|| ( ! empty( $this->custom_whitelist )
-					&& in_array( $function_name, $this->custom_whitelist, true ) === true )
+					|| ( ! empty( $this->customAllowedFunctionsList )
+					&& in_array( $function_name, $this->customAllowedFunctionsList, true ) === true )
 				) {
 					$this->phpcsFile->recordMetric( $stackPtr, 'Error silencing', 'whitelisted function call: ' . $function_name );
 					return;

--- a/WordPress/Sniffs/PHP/NoSilencedErrorsSniff.php
+++ b/WordPress/Sniffs/PHP/NoSilencedErrorsSniff.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Util\Tokens;
  * Discourage the use of the PHP error silencing operator.
  *
  * This sniff allows the error operator to be used with a select list
- * of whitelisted functions, as no amount of error checking can prevent
+ * of functions, as no amount of error checking can prevent
  * PHP from throwing errors when those functions are used.
  *
  * @package WPCS\WordPressCodingStandards
@@ -40,14 +40,15 @@ class NoSilencedErrorsSniff extends Sniff {
 	 *
 	 * Defaults to true.
 	 *
-	 * This property only affects whether the standard function whitelist is
+	 * This property only affects whether the standard function list is
 	 * used. The custom whitelist, if set, will always be respected.
 	 *
 	 * @since 1.1.0
+	 * @since 3.0.0 Renamed from `$use_default_whitelist` to `$usePHPFunctionsList`.
 	 *
 	 * @var bool
 	 */
-	public $use_default_whitelist = true;
+	public $usePHPFunctionsList = true;
 
 	/**
 	 * User defined whitelist.
@@ -194,7 +195,7 @@ class NoSilencedErrorsSniff extends Sniff {
 			$has_parenthesis = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $next_non_empty + 1 ), null, true, null, true );
 			if ( false !== $has_parenthesis && \T_OPEN_PARENTHESIS === $this->tokens[ $has_parenthesis ]['code'] ) {
 				$function_name = strtolower( $this->tokens[ $next_non_empty ]['content'] );
-				if ( ( true === $this->use_default_whitelist
+				if ( ( true === $this->usePHPFunctionsList
 					&& isset( $this->function_whitelist[ $function_name ] ) === true )
 					|| ( ! empty( $this->custom_whitelist )
 					&& in_array( $function_name, $this->custom_whitelist, true ) === true )

--- a/WordPress/Sniffs/PHP/NoSilencedErrorsSniff.php
+++ b/WordPress/Sniffs/PHP/NoSilencedErrorsSniff.php
@@ -36,7 +36,7 @@ class NoSilencedErrorsSniff extends Sniff {
 	public $context_length = 6;
 
 	/**
-	 * Whether or not the `$function_whitelist` should be used.
+	 * Whether or not the `$allowedFunctionsList` should be used.
 	 *
 	 * Defaults to true.
 	 *
@@ -64,7 +64,7 @@ class NoSilencedErrorsSniff extends Sniff {
 	public $customAllowedFunctionsList = array();
 
 	/**
-	 * PHP native function whitelist.
+	 * PHP native functions allow list.
 	 *
 	 * Errors caused by calls to any of these native PHP functions
 	 * are allowed to be silenced as file system permissions and such
@@ -78,10 +78,11 @@ class NoSilencedErrorsSniff extends Sniff {
 	 * error will be thrown on failure are accepted into this list.
 	 *
 	 * @since 1.1.0
+	 * @since 3.0.0 Renamed from `$function_whitelist` to `$allowedFunctionsList`.
 	 *
 	 * @var array <string function name> => <bool true>
 	 */
-	protected $function_whitelist = array(
+	protected $allowedFunctionsList = array(
 		// Directory extension.
 		'chdir'                        => true,
 		'opendir'                      => true,
@@ -197,7 +198,7 @@ class NoSilencedErrorsSniff extends Sniff {
 			if ( false !== $has_parenthesis && \T_OPEN_PARENTHESIS === $this->tokens[ $has_parenthesis ]['code'] ) {
 				$function_name = strtolower( $this->tokens[ $next_non_empty ]['content'] );
 				if ( ( true === $this->usePHPFunctionsList
-					&& isset( $this->function_whitelist[ $function_name ] ) === true )
+					&& isset( $this->allowedFunctionsList[ $function_name ] ) === true )
 					|| ( ! empty( $this->customAllowedFunctionsList )
 					&& in_array( $function_name, $this->customAllowedFunctionsList, true ) === true )
 				) {

--- a/WordPress/Sniffs/PHP/NoSilencedErrorsSniff.php
+++ b/WordPress/Sniffs/PHP/NoSilencedErrorsSniff.php
@@ -202,7 +202,7 @@ class NoSilencedErrorsSniff extends Sniff {
 					|| ( ! empty( $this->customAllowedFunctionsList )
 					&& in_array( $function_name, $this->customAllowedFunctionsList, true ) === true )
 				) {
-					$this->phpcsFile->recordMetric( $stackPtr, 'Error silencing', 'whitelisted function call: ' . $function_name );
+					$this->phpcsFile->recordMetric( $stackPtr, 'Error silencing', 'silencing allowed function call: ' . $function_name );
 					return;
 				}
 			}

--- a/WordPress/Sniffs/PHP/NoSilencedErrorsSniff.php
+++ b/WordPress/Sniffs/PHP/NoSilencedErrorsSniff.php
@@ -187,9 +187,9 @@ class NoSilencedErrorsSniff extends Sniff {
 		$this->customAllowedFunctionsList = array_map( 'strtolower', $this->customAllowedFunctionsList );
 
 		/*
-		 * Check if the error silencing is done for one of the whitelisted functions.
+		 * Check if the error silencing is done for one of the allowed functions.
 		 *
-		 * @internal The function call name determination is done even when there is no whitelist active
+		 * @internal The function call name determination is done even when there is no allow list active
 		 * to allow the metrics to be more informative.
 		 */
 		$next_non_empty = $this->phpcsFile->findNext( $this->empty_tokens, ( $stackPtr + 1 ), null, true, null, true );

--- a/WordPress/Sniffs/WP/AlternativeFunctionsSniff.php
+++ b/WordPress/Sniffs/WP/AlternativeFunctionsSniff.php
@@ -94,7 +94,7 @@ class AlternativeFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 				'functions' => array(
 					'curl_*',
 				),
-				'whitelist' => array(
+				'allow'     => array(
 					'curl_version' => true,
 				),
 			),

--- a/WordPress/Sniffs/WP/GlobalVariablesOverrideSniff.php
+++ b/WordPress/Sniffs/WP/GlobalVariablesOverrideSniff.php
@@ -54,7 +54,7 @@ class GlobalVariablesOverrideSniff extends Sniff {
 	public $treat_files_as_scoped = false;
 
 	/**
-	 * Whitelist select variables from the Sniff::$wp_globals array.
+	 * Allow select variables from the Sniff::$wp_globals array to be overwritten.
 	 *
 	 * A few select variables in WP Core are _intended_ to be overwritten
 	 * by themes/plugins. This sniff should not throw an error for those.

--- a/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.1.inc
+++ b/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.1.inc
@@ -399,7 +399,7 @@ class Some_Test_Class extends NonTestClass { // Bad.
 }
 
 // phpcs:set WordPress.NamingConventions.PrefixAllGlobals prefixes[] wordpress,somethingelse
-// The above line adds an issue to line 1 about a blacklisted prefix.
+// The above line adds an issue to line 1 about a blocked prefix.
 function wordpress_do_something() {} // Bad.
 function somethingelse_do_something() {} // OK.
 

--- a/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.1.inc
+++ b/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.1.inc
@@ -157,7 +157,7 @@ namespace Acronym {
 
 
 /*
- * OK - exceptions whitelisted by default.
+ * OK - exceptions ignored by default.
  */
 $_POST['something'] = 'value';
 
@@ -319,7 +319,7 @@ namespace TGMPA\Testing {
 	define( 'MY\\' . __NAMESPACE__, __FILE__ ); // OK, even though strangely setup, the constant is in a namespace.
 }
 
-// OK: whitelisted core hooks.
+// OK: ignored core hooks.
 apply_filters( 'widget_title', $title );
 do_action( 'add_meta_boxes' );
 

--- a/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.php
+++ b/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.php
@@ -32,7 +32,7 @@ class PrefixAllGlobalsUnitTest extends AbstractSniffUnitTest {
 		switch ( $testFile ) {
 			case 'PrefixAllGlobalsUnitTest.1.inc':
 				return array(
-					1   => 8, // 2 x error for blacklisted prefix passed. 4 x error for short prefixes. 2 x no prefix.
+					1   => 8, // 2 x error for blocked prefix passed. 4 x error for short prefixes. 2 x no prefix.
 					10  => 1,
 					18  => 1,
 					21  => 1,
@@ -86,7 +86,7 @@ class PrefixAllGlobalsUnitTest extends AbstractSniffUnitTest {
 
 			case 'PrefixAllGlobalsUnitTest.4.inc':
 				return array(
-					1  => 1, // 1 x error for blacklisted prefix passed.
+					1  => 1, // 1 x error for blocked prefix passed.
 					18 => 1,
 				);
 

--- a/WordPress/Tests/NamingConventions/ValidVariableNameUnitTest.inc
+++ b/WordPress/Tests/NamingConventions/ValidVariableNameUnitTest.inc
@@ -129,13 +129,13 @@ echo "This is $PHP_SELF with $HTTP_RAW_POST_DATA"; // Ok.
 /*
  * Unit test whitelisting.
  */
-// phpcs:set WordPress.NamingConventions.ValidVariableName customPropertiesWhitelist[] varName,DOMProperty
-echo MyClass::$varName; // Ok, whitelisted.
-echo $this->DOMProperty; // Ok, whitelisted.
-echo $object->varName;  // Ok, whitelisted.
-// phpcs:set WordPress.NamingConventions.ValidVariableName customPropertiesWhitelist[]
+// phpcs:set WordPress.NamingConventions.ValidVariableName allowed_custom_properties[] varName,DOMProperty
+echo MyClass::$varName; // Ok, allowed.
+echo $this->DOMProperty; // Ok, allowed.
+echo $object->varName;  // Ok, allowed.
+// phpcs:set WordPress.NamingConventions.ValidVariableName allowed_custom_properties[]
 
-echo $object->varName;  // Bad, no longer whitelisted.
+echo $object->varName;  // Bad, no longer allowed.
 
 // Code style independent token checking.
 echo $object

--- a/WordPress/Tests/NamingConventions/ValidVariableNameUnitTest.inc
+++ b/WordPress/Tests/NamingConventions/ValidVariableNameUnitTest.inc
@@ -127,7 +127,7 @@ echo "This is a $comment_ID"; // Bad
 echo "This is $PHP_SELF with $HTTP_RAW_POST_DATA"; // Ok.
 
 /*
- * Unit test whitelisting.
+ * Ignoring unit tests.
  */
 // phpcs:set WordPress.NamingConventions.ValidVariableName allowed_custom_properties[] varName,DOMProperty
 echo MyClass::$varName; // Ok, allowed.

--- a/WordPress/Tests/PHP/NoSilencedErrorsUnitTest.inc
+++ b/WordPress/Tests/PHP/NoSilencedErrorsUnitTest.inc
@@ -39,11 +39,11 @@ if ( @ftp_fget($conn_id, $handle, $remote_file, FTP_ASCII, 0 ) ) { // Bad.
 }
 @ftp_close($conn_id); // Bad.
 
-// phpcs:set WordPress.PHP.NoSilencedErrors custom_whitelist[] fgetcsv,hex2bin
+// phpcs:set WordPress.PHP.NoSilencedErrors customAllowedFunctionsList[] fgetcsv,hex2bin
 while ( ( $csvdata = @fgetcsv( $handle, 2000, $separator ) ) !== false ) {}
 echo @some_userland_function( $param ); // Bad.
 $decoded = @hex2bin( $data );
-// phpcs:set WordPress.PHP.NoSilencedErrors custom_whitelist[]
+// phpcs:set WordPress.PHP.NoSilencedErrors customAllowedFunctionsList[]
 
 $decoded = @hex2bin( $data ); // Bad.
 
@@ -71,12 +71,12 @@ if (@is_dir($dir)) { // Bad.
 $files1 = @ & scandir($dir); // Bad.
 
 /*
- * Custom whitelist will be respected even when `usePHPFunctionsList` is set to false.
+ * The custom allowed functions list will be respected even when `usePHPFunctionsList` is set to false.
  */
-// phpcs:set WordPress.PHP.NoSilencedErrors custom_whitelist[] fgetcsv,hex2bin
+// phpcs:set WordPress.PHP.NoSilencedErrors customAllowedFunctionsList[] fgetcsv,hex2bin
 while ( ( $csvdata = @fgetcsv( $handle, 2000, $separator ) ) !== false ) {}
 echo @some_userland_function( $param ); // Bad.
 $decoded = @hex2bin( $data );
-// phpcs:set WordPress.PHP.NoSilencedErrors custom_whitelist[]
+// phpcs:set WordPress.PHP.NoSilencedErrors customAllowedFunctionsList[]
 
 // phpcs:set WordPress.PHP.NoSilencedErrors usePHPFunctionsList true

--- a/WordPress/Tests/PHP/NoSilencedErrorsUnitTest.inc
+++ b/WordPress/Tests/PHP/NoSilencedErrorsUnitTest.inc
@@ -50,7 +50,7 @@ $decoded = @hex2bin( $data ); // Bad.
 $unserialized = @unserialize( $str );
 
 /*
- * ... and test the same principle again, but now without using the whitelist.
+ * ... and test the same principle again, but now without using the PHP function allow list.
  */
 // phpcs:set WordPress.PHP.NoSilencedErrors usePHPFunctionsList false
 

--- a/WordPress/Tests/PHP/NoSilencedErrorsUnitTest.inc
+++ b/WordPress/Tests/PHP/NoSilencedErrorsUnitTest.inc
@@ -52,7 +52,7 @@ $unserialized = @unserialize( $str );
 /*
  * ... and test the same principle again, but now without using the whitelist.
  */
-// phpcs:set WordPress.PHP.NoSilencedErrors use_default_whitelist false
+// phpcs:set WordPress.PHP.NoSilencedErrors usePHPFunctionsList false
 
 // File extension.
 if ( @&file_exists( $filename ) && @ /*comment*/ is_readable( $filename ) ) { // Bad x2.
@@ -71,7 +71,7 @@ if (@is_dir($dir)) { // Bad.
 $files1 = @ & scandir($dir); // Bad.
 
 /*
- * Custom whitelist will be respected even when `use_default_whitelist` is set to false.
+ * Custom whitelist will be respected even when `usePHPFunctionsList` is set to false.
  */
 // phpcs:set WordPress.PHP.NoSilencedErrors custom_whitelist[] fgetcsv,hex2bin
 while ( ( $csvdata = @fgetcsv( $handle, 2000, $separator ) ) !== false ) {}
@@ -79,4 +79,4 @@ echo @some_userland_function( $param ); // Bad.
 $decoded = @hex2bin( $data );
 // phpcs:set WordPress.PHP.NoSilencedErrors custom_whitelist[]
 
-// phpcs:set WordPress.PHP.NoSilencedErrors use_default_whitelist true
+// phpcs:set WordPress.PHP.NoSilencedErrors usePHPFunctionsList true

--- a/WordPress/Tests/Security/NonceVerificationUnitTest.inc
+++ b/WordPress/Tests/Security/NonceVerificationUnitTest.inc
@@ -165,7 +165,7 @@ function foo_8() {
  * Using a superglobal in a is_...() function is OK as long as a nonce check is done
  * before the variable is *really* used.
  */
-function test_whitelisting_use_in_type_test_functions() {
+function test_ignoring_use_in_type_test_functions() {
 	if ( ! is_numeric ( $_POST['foo'] ) ) { // OK.
 		return;
 	}

--- a/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.4.inc
+++ b/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.4.inc
@@ -67,7 +67,7 @@ _x( $text, $context, $variableTextdomain );
 _ex( $text, $context, CONSTANT_TEXTDOMAIN );
 
 /*
- * Text domains *not* in the whitelisted "old" domain list should be ignored.
+ * Text domains *not* in the "old" domain list should be ignored.
  */
 load_plugin_textdomain( 'tgmpa', false, '/languages/' );
 _e( $text, 'default' );

--- a/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.4.inc.fixed
+++ b/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.4.inc.fixed
@@ -67,7 +67,7 @@ _x( $text, $context, $variableTextdomain );
 _ex( $text, $context, CONSTANT_TEXTDOMAIN );
 
 /*
- * Text domains *not* in the whitelisted "old" domain list should be ignored.
+ * Text domains *not* in the "old" domain list should be ignored.
  */
 load_plugin_textdomain( 'tgmpa', false, '/languages/' );
 _e( $text, 'default' );

--- a/WordPress/Tests/WP/GlobalVariablesOverrideUnitTest.1.inc
+++ b/WordPress/Tests/WP/GlobalVariablesOverrideUnitTest.1.inc
@@ -107,7 +107,7 @@ trait My_Class {
 	}
 }
 
-// Test adding additional test classes to the whitelist.
+// Test adding additional test classes to the custom test classes list.
 // phpcs:set WordPress.WP.GlobalVariablesOverride custom_test_classes[] My_TestClass
 class Test_Class_D extends My_TestClass {
 

--- a/WordPress/Tests/WhiteSpace/PrecisionAlignmentUnitTest.2.inc
+++ b/WordPress/Tests/WhiteSpace/PrecisionAlignmentUnitTest.2.inc
@@ -19,24 +19,24 @@ phpcs:set WordPress.WhiteSpace.PrecisionAlignment ignoreAlignmentTokens[] T_COMM
 	/**
 	 * OK: Doc comments are indented with tabs and one space.
 	 *
-	  * @var string  <= Bad, but not reported as token type is whitelisted.
+	  * @var string  <= Bad, but not reported as token type is ignored.
 	 * @access private
 	 */
 
 	/*
 	 * OK: Multi-line comments are indented with tabs and one space.
 	 *
-	   * <= Bad, but not reported as token type is whitelisted
+	   * <= Bad, but not reported as token type is ignored
 	 */
 
-	 function exampleFunctionD() {} // Bad, but not reported as token type is whitelisted.
-	  function exampleFunctionE() {} // Bad, but not reported as token type is whitelisted.
-	   function exampleFunctionF() {} // Bad, but not reported as token type is whitelisted.
+	 function exampleFunctionD() {} // Bad, but not reported as token type is ignored.
+	  function exampleFunctionE() {} // Bad, but not reported as token type is ignored.
+	   function exampleFunctionF() {} // Bad, but not reported as token type is ignored.
 
 ?>
 
 	<p>
-	  Bad: Some text with precision alignment, but not reported as token type is whitelisted.
+	  Bad: Some text with precision alignment, but not reported as token type is ignored.
 	</p>
 
 <?php

--- a/WordPress/Tests/WhiteSpace/PrecisionAlignmentUnitTest.7a.inc
+++ b/WordPress/Tests/WhiteSpace/PrecisionAlignmentUnitTest.7a.inc
@@ -9,7 +9,7 @@ phpcs:set WordPress.WhiteSpace.PrecisionAlignment ignoreAlignmentTokens[] T_COMM
  * 7a, 7b and 7c test files together test (against) the issue.
  */
 
-  // Bad, but not reported as token type is whitelisted.
-	 function exampleFunctionD() {} // Bad, but not reported as token type is whitelisted.
-	  function exampleFunctionE() {} // Bad, but not reported as token type is whitelisted.
-	   function exampleFunctionF() {} // Bad, but not reported as token type is whitelisted.
+  // Bad, but not reported as token type is ignored.
+	 function exampleFunctionD() {} // Bad, but not reported as token type is ignored.
+	  function exampleFunctionE() {} // Bad, but not reported as token type is ignored.
+	   function exampleFunctionF() {} // Bad, but not reported as token type is ignored.

--- a/WordPress/Tests/WhiteSpace/PrecisionAlignmentUnitTest.7b.inc
+++ b/WordPress/Tests/WhiteSpace/PrecisionAlignmentUnitTest.7b.inc
@@ -9,7 +9,7 @@
  * This file should inherit the property settings from the 7a test case file.
  */
 
-  // Bad, but not reported as token type is whitelisted.
-	 function exampleFunctionD() {} // Bad, but not reported as token type is (still) whitelisted.
-	  function exampleFunctionE() {} // Bad, but not reported as token type is (still) whitelisted.
-	   function exampleFunctionF() {} // Bad, but not reported as token type is (still) whitelisted.
+  // Bad, but not reported as token type is ignored.
+	 function exampleFunctionD() {} // Bad, but not reported as token type is (still) ignored.
+	  function exampleFunctionE() {} // Bad, but not reported as token type is (still) ignored.
+	   function exampleFunctionF() {} // Bad, but not reported as token type is (still) ignored.

--- a/WordPress/Tests/WhiteSpace/PrecisionAlignmentUnitTest.7c.inc
+++ b/WordPress/Tests/WhiteSpace/PrecisionAlignmentUnitTest.7c.inc
@@ -9,9 +9,9 @@
  * This file should inherit the property settings from the 7a test case file.
  */
 
-  // Bad, but not reported as token type is whitelisted.
-	 function exampleFunctionD() {} // Bad, but not reported as token type is (still) whitelisted.
-	  function exampleFunctionE() {} // Bad, but not reported as token type is (still) whitelisted.
-	   function exampleFunctionF() {} // Bad, but not reported as token type is (still) whitelisted.
+  // Bad, but not reported as token type is ignored.
+	 function exampleFunctionD() {} // Bad, but not reported as token type is (still) ignored.
+	  function exampleFunctionE() {} // Bad, but not reported as token type is (still) ignored.
+	   function exampleFunctionF() {} // Bad, but not reported as token type is (still) ignored.
 
 // phpcs:set WordPress.WhiteSpace.PrecisionAlignment ignoreAlignmentTokens[]


### PR DESCRIPTION
Note: not claiming completeness - this PR is based on a code-base wide search for the terms `whitelist` and `blacklist`. Other potential non-inclusive terminology is not (yet) addressed, though I expect there won't be much else.

Related to #1915

---

### AbstractFunctionRestrictionsSniff: rename array key

... and update sniffs using that array key.

👉🏻 Note: this is a breaking change for any external sniffs extending this base class.

### PrefixAllGlobals: rename property [1]

As this is a `protected` property, this is an internal change only (unless an external standard would be extending the sniff).

### PrefixAllGlobals: rename property [2]
As this is a `protected` property, this is an internal change only (unless an external standard would be extending the sniff).

### PrefixAllGlobals: rename property [3]

As this is a `protected` property, this is an internal change only (unless an external standard would be extending the sniff).

### PrefixAllGlobals: rename (private) method

### ValidPostTypeSlug: rename constant

### ValidVariableName: rename property [1]

As this is a `protected` property, this is an internal change only (unless an external standard would be extending the sniff).

### ValidVariableName: rename property [2]

👉🏻 As this is a `public` property, this is a BC-break and should be annotated as such in the upgrade guide/changelog.

### ValidVariableNameSniff: rename method

### IniSet: rename property [1]

As this is a `protected` property, this is an internal change only (unless an external standard would be extending the sniff).

### IniSet: rename property [2]

As this is a `protected` property, this is an internal change only (unless an external standard would be extending the sniff).

### IniSet: rename local variable [1]

### IniSet: rename local variable [2]

### IniSet: rename error code

### NoSilencedErrors: rename property [1]

👉🏻 As this is a `public` property, this is a BC-break and should be annotated as such in the upgrade guide/changelog.

Also note that the new name is in line with the name for the same property in an upcoming replacement sniff in PHPCSExtra. This should make the switch over to the replacement sniff more straight-forward (if and when).

### NoSilencedErrors: rename property [2]

👉🏻 As this is a `public` property, this is a BC-break and should be annotated as such in the upgrade guide/changelog.

Also note that the new name is in line with the name for the same property in an upcoming replacement sniff in PHPCSExtra. This should make the switch over to the replacement sniff more straight-forward (if and when).

### NoSilencedErrors: rename property [3]

As this is a `protected` property, this is an internal change only (unless an external standard would be extending the sniff).

Also note that the new name is in line with the name for the same property in an upcoming replacement sniff in PHPCSExtra. This should make the switch over to the replacement sniff more straight-forward (if and when).

### NoSilencedErrors: fix up comments

### NoSilencedErrors: rename a metric

### Various language usage updates in comments

Includes:
* Removing a reference to a custom ignore annotation which was already removed in PR 1908.
* Removing a (class-level) changelog entry referring to a custom ignore annotation which doesn't exist anymore.
* Use more inclusive language in various other comments.