### PR TITLE
Support '%i' placeholders for escaping Identifiers

### DIFF
--- a/WordPress/Helpers/MinimumWPVersionTrait.php
+++ b/WordPress/Helpers/MinimumWPVersionTrait.php
@@ -31,10 +31,10 @@ trait MinimumWPVersionTrait {
 	/**
 	 * Minimum supported WordPress version.
 	 *
-	 * Currently used by the `WordPress.WP.AlternativeFunctions`,
-	 * `WordPress.WP.Capabilities`, `WordPress.WP.DeprecatedClasses`,
-	 * `WordPress.WP.DeprecatedFunctions`, `WordPress.WP.DeprecatedParameter`
-	 * and the `WordPress.WP.DeprecatedParameterValues` sniff.
+	 * Currently used by the `WordPress.Security.PreparedSQLPlaceholders`,
+	 * `WordPress.WP.AlternativeFunctions`, `WordPress.WP.Capabilities`,
+	 * `WordPress.WP.DeprecatedClasses`, `WordPress.WP.DeprecatedFunctions`,
+	 * `WordPress.WP.DeprecatedParameter` and the `WordPress.WP.DeprecatedParameterValues` sniff.
 	 *
 	 * These sniffs will adapt their behaviour based on the minimum supported WP version
 	 * indicated.

--- a/WordPress/Tests/DB/PreparedSQLPlaceholdersUnitTest.inc
+++ b/WordPress/Tests/DB/PreparedSQLPlaceholdersUnitTest.inc
@@ -273,4 +273,10 @@ $wpdb->prepare( '
 	$fields
 ); // IdentifierWithinIN.
 
+// phpcs:set WordPress.DB.PreparedSQLPlaceholders minimum_wp_version 5.8
+
+$wpdb->prepare( 'WHERE %1$+10.3i = %s', $field, $value ); // UnsupportedIdentifierPlaceholder.
+$wpdb->prepare( "WHERE '%10i' IS NULL", $field ); // UnsupportedIdentifierPlaceholder + QuotedIdentifierPlaceholder.
+$wpdb->prepare( 'xxx IN ( ' . implode( ',', array_fill( 0, count( $post_types ), '%i' ) ) . ' )', $fields ); // UnsupportedIdentifierPlaceholder + IdentifierWithinIN.
+
 // phpcs:set WordPress.DB.PreparedSQLPlaceholders minimum_wp_version

--- a/WordPress/Tests/DB/PreparedSQLPlaceholdersUnitTest.inc
+++ b/WordPress/Tests/DB/PreparedSQLPlaceholdersUnitTest.inc
@@ -207,3 +207,70 @@ $wpdb->query( $wpdb->prepare( "DELETE FROM $wpdb->wp_options WHERE option_name L
 $where .= $wpdb->prepare( " AND `name` LIKE '%%%%" . '%s' . "%%%%' ", $args['name'] ); // Bad x 2.
 
 $wpdb->query($wpdb->prepare("delete from wp_postmeta where post_id = $target_postId AND meta_key like 'google_snippets'")); // Bad, the PreparedSQL sniff will also kick in and throw an error about `$target_postId`.
+
+// phpcs:set WordPress.DB.PreparedSQLPlaceholders minimum_wp_version 6.2
+
+$wpdb->prepare( 'WHERE %i = %s', $field, $value ); // OK.
+$wpdb->prepare( 'WHERE %i = %s', $value ); // ReplacementsWrongNumber.
+$wpdb->prepare( 'WHERE %i = %x', $field, $value ); // UnsupportedPlaceholder & ReplacementsWrongNumber.
+$wpdb->prepare( 'WHERE %i = %2$s', $field, $value ); // UnquotedComplexPlaceholder.
+$wpdb->prepare( 'WHERE %i = %10s', $field, $value ); // UnquotedComplexPlaceholder.
+$wpdb->prepare( 'WHERE %i = %2$-10s', $field, $value ); // UnquotedComplexPlaceholder.
+
+$wpdb->prepare( 'WHERE %i = "%s"', $field, $value ); // QuotedSimplePlaceholder.
+$wpdb->prepare( 'WHERE "%i" = %s', $field, $value ); // QuotedIdentifierPlaceholder.
+$wpdb->prepare( "WHERE \"%i\" = %s", $field, $value ); // QuotedIdentifierPlaceholder.
+$wpdb->prepare( "WHERE '%i' = %s", $field, $value ); // QuotedIdentifierPlaceholder.
+$wpdb->prepare( 'WHERE \'%i\' = %s', $field, $value ); // QuotedIdentifierPlaceholder.
+$wpdb->prepare( 'WHERE `%i` = %s', $field, $value ); // QuotedIdentifierPlaceholder.
+
+$wpdb->prepare( "WHERE '%10i' IS NULL", $field ); // QuotedIdentifierPlaceholder.
+$wpdb->prepare( 'WHERE "%10i" IS NULL', $field ); // QuotedIdentifierPlaceholder.
+$wpdb->prepare( 'WHERE \'%1$i\' IS NULL', $field ); // QuotedIdentifierPlaceholder.
+$wpdb->prepare( "WHERE \"%10i\" IS NULL", $field ); // QuotedIdentifierPlaceholder.
+
+$wpdb->prepare( 'WHERE %1$i IS NULL', $field ); // OK.
+$wpdb->prepare( 'WHERE %10i IS NULL', $field ); // OK.
+$wpdb->prepare( 'WHERE % i IS NULL', $field ); // UnescapedLiteral & UnfinishedPrepare (while this is valid, should avoid).
+$wpdb->prepare( 'WHERE %1$-10i IS NULL', $field ); // OK.
+$wpdb->prepare( 'WHERE %1$-10.3i IS NULL', $field ); // OK.
+$wpdb->prepare( 'WHERE %1$+10.3i IS NULL', $field ); // OK.
+$wpdb->prepare( 'WHERE %1$ 10.3i IS NULL', $field ); // UnsupportedPlaceholder (parsed as "%1$", which is valid, but should avoid).
+$wpdb->prepare( 'WHERE %1$010.3i IS NULL', $field ); // OK.
+$wpdb->prepare( "WHERE %1$'x10.3i IS NULL", $field ); // OK.
+
+$wpdb->prepare( 'WHERE %.2i IS NULL', 'a``b' ); // Currently ignore, but it might cause a problem (most likely a parse error) "WHERE `a`` IS NULL".
+
+$wpdb->prepare( 'WHERE `%1$i` IS NULL', $field ); // QuotedIdentifierPlaceholder.
+$wpdb->prepare( 'WHERE `%10i` IS NULL', $field ); // QuotedIdentifierPlaceholder.
+$wpdb->prepare( 'WHERE `% i` IS NULL', $field ); // UnescapedLiteral & UnfinishedPrepare (if RegEx matched, then it should be QuotedIdentifierPlaceholder).
+$wpdb->prepare( 'WHERE `%1$-10i` IS NULL', $field ); // QuotedIdentifierPlaceholder.
+$wpdb->prepare( 'WHERE `%1$-10.3i` IS NULL', $field ); // QuotedIdentifierPlaceholder.
+$wpdb->prepare( 'WHERE `%1$+10.3i` IS NULL', $field ); // QuotedIdentifierPlaceholder.
+$wpdb->prepare( 'WHERE `%1$ 10.3i` IS NULL', $field ); // QuotedIdentifierPlaceholder, and UnsupportedPlaceholder (parsed as "%1$", which is valid, but should avoid).
+$wpdb->prepare( 'WHERE `%1$010.3i` IS NULL', $field ); // QuotedIdentifierPlaceholder.
+$wpdb->prepare( "WHERE `%1$'x10.3i` IS NULL", $field ); // QuotedIdentifierPlaceholder.
+
+$wpdb->prepare( 'SELECT ID FROM `%2$i` WHERE `%1$i` = "%3$s"', $field, $wpdb->posts, $value ); // QuotedIdentifierPlaceholder (x2).
+
+$wpdb->prepare( 'SELECT ID FROM %i.%i WHERE %i = "false"', $db, $table, $field ); // OK.
+
+$wpdb->prepare(
+	sprintf(
+		'xxx IN (%s)',
+		implode( ',', array_fill( 0, count($fields), '%i' ) )
+	),
+	$fields
+); // ReplacementsWrongNumber + IdentifierWithinIN.
+
+$wpdb->prepare( '
+	xxx IN ( ' . implode( ',', array_fill( 0, count( $post_types ), '%i' ) ) . ' )',
+	$fields
+); // IdentifierWithinIN.
+
+$wpdb->prepare( '
+	xxx IN ( ' . implode( ',', array_fill( 0, count( $post_types ), "%i" ) ) . ' )',
+	$fields
+); // IdentifierWithinIN.
+
+// phpcs:set WordPress.DB.PreparedSQLPlaceholders minimum_wp_version

--- a/WordPress/Tests/DB/PreparedSQLPlaceholdersUnitTest.php
+++ b/WordPress/Tests/DB/PreparedSQLPlaceholdersUnitTest.php
@@ -92,6 +92,9 @@ final class PreparedSQLPlaceholdersUnitTest extends AbstractSniffUnitTest {
 			261 => 1, // IdentifierWithinIN.
 			267 => 1, // IdentifierWithinIN.
 			272 => 1, // IdentifierWithinIN.
+			278 => 1, // UnsupportedIdentifierPlaceholder.
+			279 => 2, // UnsupportedIdentifierPlaceholder + QuotedIdentifierPlaceholder.
+			280 => 2, // UnsupportedIdentifierPlaceholder + IdentifierWithinIN.
 		);
 	}
 

--- a/WordPress/Tests/DB/PreparedSQLPlaceholdersUnitTest.php
+++ b/WordPress/Tests/DB/PreparedSQLPlaceholdersUnitTest.php
@@ -60,6 +60,38 @@ final class PreparedSQLPlaceholdersUnitTest extends AbstractSniffUnitTest {
 			205 => 1,
 			207 => 2,
 			209 => 1,
+
+			215 => 1, // UnsupportedPlaceholder.
+
+			220 => 1, // QuotedSimplePlaceholder.
+			221 => 1, // QuotedSimplePlaceholder.
+			222 => 1, // QuotedSimplePlaceholder.
+			223 => 1, // QuotedSimplePlaceholder.
+			224 => 1, // QuotedSimplePlaceholder.
+			225 => 1, // QuotedSimplePlaceholder.
+
+			227 => 1, // QuotedIdentifierPlaceholder.
+			228 => 1, // QuotedIdentifierPlaceholder.
+			229 => 1, // QuotedIdentifierPlaceholder.
+			230 => 1, // QuotedIdentifierPlaceholder.
+
+			234 => 1, // UnescapedLiteral.
+			238 => 1, // UnsupportedPlaceholder.
+
+			244 => 1, // QuotedIdentifierPlaceholder.
+			245 => 1, // QuotedIdentifierPlaceholder.
+			246 => 1, // UnescapedLiteral.
+			247 => 1, // QuotedIdentifierPlaceholder.
+			248 => 1, // QuotedIdentifierPlaceholder.
+			249 => 1, // QuotedIdentifierPlaceholder.
+			250 => 2, // QuotedIdentifierPlaceholder.
+			251 => 1, // QuotedIdentifierPlaceholder.
+			252 => 1, // QuotedIdentifierPlaceholder.
+
+			254 => 2, // QuotedIdentifierPlaceholder x2.
+			261 => 1, // IdentifierWithinIN.
+			267 => 1, // IdentifierWithinIN.
+			272 => 1, // IdentifierWithinIN.
 		);
 	}
 
@@ -95,6 +127,14 @@ final class PreparedSQLPlaceholdersUnitTest extends AbstractSniffUnitTest {
 			160 => 2,
 			161 => 2,
 			177 => 1,
+			214 => 1,
+			215 => 1,
+			216 => 1,
+			217 => 1,
+			218 => 1,
+			234 => 1, // UnfinishedPrepare.
+			246 => 1, // UnfinishedPrepare.
+			258 => 1, // ReplacementsWrongNumber.
 		);
 	}
 


### PR DESCRIPTION
Ticket: https://core.trac.wordpress.org/ticket/52506
Change: https://core.trac.wordpress.org/changeset/53575

With WordPress 6.1 ([October 2022](https://make.wordpress.org/core/2022/06/23/wordpress-6-1-planning-roundup/)), the `%i` placeholder will provide a safe way to escape Identifiers (e.g. table/field names).

Technically it's not needed if the variable only contains [permitted characters](https://dev.mysql.com/doc/refman/8.0/en/identifiers.html), is not one of the ~286 [reserved words](https://dev.mysql.com/doc/refman/8.0/en/keywords.html), and is a `literal-string` (a value defined by the developer)... but that's not always possible, or can be hard to prove.