### PR TITLE
WP/CronInterval: bugfix for fully qualified time constants

### DIFF
--- a/WordPress/Sniffs/WP/CronIntervalSniff.php
+++ b/WordPress/Sniffs/WP/CronIntervalSniff.php
@@ -182,6 +182,11 @@ class CronIntervalSniff extends Sniff {
 							continue;
 						}
 
+						if ( \T_NS_SEPARATOR === $this->tokens[ $j ]['code'] ) {
+							$value .= ' ';
+							continue;
+						}
+
 						if ( $j === $valueEnd && \T_COMMA === $this->tokens[ $j ]['code'] ) {
 							break;
 						}

--- a/WordPress/Tests/WP/CronIntervalUnitTest.inc
+++ b/WordPress/Tests/WP/CronIntervalUnitTest.inc
@@ -160,3 +160,45 @@ add_filter( 'cron_schedules', function ( $schedules ) {
 	];
 	return $schedules;
 } ); // Warning: 8 min.
+
+// Correctly handle fully qualified WP time constants.
+class FQNConstants {
+	public function add_schedules() {
+		add_filter( 'cron_schedules', array( $this, 'add_weekly_schedule' ) ); // Ok: > 15 min.
+		add_filter( 'cron_schedules', array( $this, 'add_eight_minute_schedule' ) ); // Warning: 8 min.
+		add_filter( 'cron_schedules', array( $this, 'add_hundred_minute_schedule' ) ); // Warning: time undetermined.
+		add_filter( 'cron_schedules', array( $this, 'sneaky_fake_wp_constant_schedule' ) ); // Warning: time undetermined.
+	}
+
+	public function add_weekly_schedule( $schedules ) {
+		$schedules['weekly'] = [
+			'interval' => \WEEK_IN_SECONDS,
+			'display'  => \__( 'Once Weekly', 'text-domain' ),
+		];
+		return $schedules;
+	}
+
+	public function add_eight_minute_schedule( $schedules ) {
+		$schedules['every_8_minutes'] = [
+			'interval' => (8 * \MINUTE_IN_SECONDS),
+			'display' => __( 'Once every 8 minutes' )
+		];
+		return $schedules;
+	}
+
+	public function add_hundred_minute_schedule( $schedules ) {
+		$schedules['every_100_minutes'] = [
+			'interval' => (100 * My\Name\MINUTE_IN_SECONDS),
+			'display' => __( 'Once every 100 minutes' )
+		];
+		return $schedules;
+	}
+
+	public function sneaky_fake_wp_constant_schedule( $schedules ) {
+		$schedules['every_100_seconds'] = [
+			'interval' => (100 * MINUTE_\IN_\SECONDS),
+			'display' => __( 'Once every 100 minutes' )
+		];
+		return $schedules;
+	}
+}

--- a/WordPress/Tests/WP/CronIntervalUnitTest.php
+++ b/WordPress/Tests/WP/CronIntervalUnitTest.php
@@ -52,6 +52,9 @@ class CronIntervalUnitTest extends AbstractSniffUnitTest {
 			115 => 1,
 			133 => 1,
 			156 => 1,
+			168 => 1,
+			169 => 1,
+			170 => 1,
 		);
 	}
 }


### PR DESCRIPTION
If the WP time constants would be used in their fully qualified form, as is often encountered in namespaced files, the sniff would no longer be able to correctly determine the interval being scheduled.

Note: To prevent constants from a different namespace accidentally matching the WP native constants, the namespace separator is replace by a space character rather than just ignored. The regex before running the `eval()` will prevent code with identifier names other than the WP time constants from being passed to the `eval()`, meaning those will still be reported as "interval undetermined".

This commit fixes that.
Includes unit tests.