### PR TITLE
Reorder core rules

### DIFF
--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -59,7 +59,8 @@
 		 If you're not evaluating anything in the string, use single quotes. -->
 	<rule ref="Squiz.Strings.DoubleQuoteUsage.NotRequired"/>
 
-	<!-- Rule: Text that goes into attributes should be run through esc_attr().
+	<!-- Rule: Text that goes into HTML or XML attributes should be escaped so that
+		 single or double quotes do not end the attribute value.
 		 https://github.com/WordPress/WordPress-Coding-Standards/issues/527 -->
 
 

--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -40,7 +40,7 @@
 
 	<!--
 	#############################################################################
-	Handbook: PHP - No Shorthand PHP Tags.
+	Handbook: General - No Shorthand PHP Tags.
 	Ref: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#no-shorthand-php-tags
 	#############################################################################
 	-->
@@ -51,7 +51,7 @@
 
 	<!--
 	#############################################################################
-	Handbook: PHP - Single and Double Quotes.
+	Handbook: General - Single and Double Quotes.
 	Ref: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#single-and-double-quotes
 	#############################################################################
 	-->
@@ -66,7 +66,7 @@
 
 	<!--
 	#############################################################################
-	Handbook: PHP - Naming Conventions.
+	Handbook: Naming - Naming Conventions.
 	Ref: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#naming-conventions
 	#############################################################################
 	-->
@@ -95,7 +95,7 @@
 
 	<!--
 	#############################################################################
-	Handbook: PHP - Interpolation for Naming Dynamic Hooks.
+	Handbook: Naming - Interpolation for Naming Dynamic Hooks.
 	Ref: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#interpolation-for-naming-dynamic-hooks
 
 	https://github.com/WordPress/WordPress-Coding-Standards/issues/751
@@ -112,7 +112,7 @@
 
 	<!--
 	#############################################################################
-	Handbook: PHP - Space Usage.
+	Handbook: Whitespace - Space Usage.
 	Ref: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#space-usage
 	#############################################################################
 	-->
@@ -126,8 +126,7 @@
 		</properties>
 	</rule>
 
-	<!-- Covers rule: Put spaces on both sides of the opening and closing parenthesis of
-		 if, elseif, foreach, for, and switch blocks. -->
+	<!-- Covers rule: Put spaces on both sides of the opening and closing parentheses of control structure blocks. -->
 	<rule ref="WordPress.WhiteSpace.ControlStructureSpacing"/>
 
 	<!-- Covers rule: Define a function like so: function my_function( $param1 = 'foo', $param2 = 'bar' ) { -->
@@ -165,7 +164,7 @@
 
 	<!-- Covers rule: Type casts must be lowercase. Always prefer the short form
 		 of type casts, (int) instead of (integer) and (bool) rather than (boolean).
-		 For float casts use (float). -->
+		 For float casts use (float), not (real) which is deprecated in PHP 7.4, and removed in PHP 8. -->
 	<rule ref="Generic.Formatting.SpaceAfterCast"/>
 	<rule ref="Squiz.WhiteSpace.CastSpacing"/>
 	<rule ref="WordPress.WhiteSpace.CastStructureSpacing"/>
@@ -177,12 +176,12 @@
 	<!-- Covers rule: ... array items, only include a space around the index if it is a variable. -->
 	<rule ref="WordPress.Arrays.ArrayKeySpacingRestrictions"/>
 
-	<!-- Rule: In a switch block, there must be no space before the colon for a case statement. -->
+	<!-- Rule: In a switch block, there must be no space between the case condition and the colon. -->
 	<!-- Covered by the PSR2.ControlStructures.SwitchDeclaration sniff. -->
 
 	<!-- Rule: Similarly, there should be no space before the colon on return type declarations. -->
 
-	<!-- Covers rule: Unless otherwise specified, parentheses should have spaces inside of them. -->
+	<!-- Covers rule: Unless otherwise specified, parentheses should have spaces inside them. -->
 	<rule ref="Generic.WhiteSpace.ArbitraryParenthesesSpacing">
 		<properties>
 			<property name="spacing" value="1"/>
@@ -193,7 +192,7 @@
 
 	<!--
 	#############################################################################
-	Handbook: PHP - Indentation.
+	Handbook: Whitespace - Indentation.
 	Ref: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#indentation
 	#############################################################################
 	-->
@@ -260,7 +259,7 @@
 
 	<!--
 	#############################################################################
-	Handbook: PHP - Remove Trailing Spaces.
+	Handbook: Whitespace - Remove Trailing Spaces.
 	Ref: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#remove-trailing-spaces
 	#############################################################################
 	-->
@@ -272,7 +271,7 @@
 
 	<!--
 	#############################################################################
-	Handbook: PHP - Brace Style.
+	Handbook: Formatting - Brace Style.
 	Ref: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#brace-style
 	#############################################################################
 	-->
@@ -285,7 +284,7 @@
 
 	<!--
 	#############################################################################
-	Handbook: PHP - Declaring Arrays.
+	Handbook: Formatting - Declaring Arrays.
 	Ref: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#declaring-arrays
 	#############################################################################
 	-->
@@ -295,7 +294,7 @@
 
 	<!--
 	#############################################################################
-	Handbook: PHP - Multiline Function Calls.
+	Handbook: Formatting - Multiline Function Calls.
 	Ref: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#multiline-function-calls
 	#############################################################################
 	-->
@@ -310,7 +309,7 @@
 
 	<!--
 	#############################################################################
-	Handbook: PHP - Only One Object Structure (Class/Interface/Trait) per File.
+	Handbook: Object-Oriented Programming - Only One Object Structure (Class/Interface/Trait) per File.
 	Ref: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#only-one-object-structure-class-interface-trait-per-file
 	#############################################################################
 	-->
@@ -322,7 +321,7 @@
 
 	<!--
 	#############################################################################
-	Handbook: PHP - Use elseif, not else if.
+	Handbook: Control Structures - Use elseif, not else if.
 	Ref: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#use-elseif-not-else-if
 	#############################################################################
 	-->
@@ -332,12 +331,12 @@
 
 	<!--
 	#############################################################################
-	Handbook: PHP - Yoda Conditions.
+	Handbook: Control Structures - Yoda Conditions.
 	Ref: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#yoda-conditions
 	#############################################################################
 	-->
-	<!-- Covers rule: When doing logical comparisons, always put the variable on the right side,
-		 constants or literals on the left. -->
+	<!-- Covers rule: When doing logical comparisons involving variables, always put the variable on the right side
+		 and put constants, literals, or function calls on the left side. -->
 	<rule ref="WordPress.PHP.YodaConditions"/>
 
 	<!-- Rule: Yoda conditions for <, >, <= or >= are significantly more difficult to read
@@ -346,11 +345,11 @@
 
 	<!--
 	#############################################################################
-	Handbook: PHP - Ternary Operator.
+	Handbook: Operators - Ternary Operator.
 	Ref: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#ternary-operator
 	#############################################################################
 	-->
-	<!-- Rule: Always have Ternaries test if the statement is true, not false.
+	<!-- Rule: Always have ternaries test if the statement is true, not false.
 		 An exception would be using ! empty(), as testing for false here is generally more intuitive.
 		 https://github.com/WordPress/WordPress-Coding-Standards/issues/643 -->
 
@@ -360,7 +359,7 @@
 
 	<!--
 	#############################################################################
-	Handbook: PHP - (No) Error Control Operator @.
+	Handbook: Operators - (No) Error Control Operator @.
 	Ref: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#error-control-operator
 	#############################################################################
 	-->
@@ -371,7 +370,7 @@
 
 	<!--
 	#############################################################################
-	Handbook: PHP - Database Queries.
+	Handbook: Database - Database Queries.
 	Ref: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#database-queries
 	#############################################################################
 	-->
@@ -382,7 +381,7 @@
 
 	<!--
 	#############################################################################
-	Handbook: PHP - Formatting SQL statements.
+	Handbook: Database - Formatting SQL statements.
 	Ref: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#formatting-sql-statements
 	#############################################################################
 	-->
@@ -393,18 +392,18 @@
 		 SQL slash escaping when passed.
 		 https://github.com/WordPress/WordPress-Coding-Standards/issues/640 -->
 
+	<!-- Covers rule: Escaping should be done as close to the time of the query
+		 as possible, preferably by using $wpdb->prepare(). -->
+	<rule ref="WordPress.DB.PreparedSQL"/>
+
 	<!-- Rule: in $wpdb->prepare - %s is used for string placeholders and %d is used for integer
 		 placeholders. Note that they are not 'quoted'! -->
 	<rule ref="WordPress.DB.PreparedSQLPlaceholders"/>
 
-	<!-- Covers rule:  Escaping should be done as close to the time of the query
-		 as possible, preferably by using $wpdb->prepare(). -->
-	<rule ref="WordPress.DB.PreparedSQL"/>
-
 
 	<!--
 	#############################################################################
-	Handbook: PHP - Self-Explanatory Flag Values for Function Arguments.
+	Handbook: Recommendations - Self-Explanatory Flag Values for Function Arguments.
 	Ref: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#self-explanatory-flag-values-for-function-arguments
 	#############################################################################
 	-->
@@ -412,7 +411,7 @@
 
 	<!--
 	#############################################################################
-	Handbook: PHP - Clever Code.
+	Handbook: Recommendations - Clever Code.
 	Ref: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#clever-code
 	#############################################################################
 	-->
@@ -452,13 +451,23 @@
 	</rule>
 
 	<!-- Rule: create_function() function, which internally performs an eval(),
-		 is deprecated in PHP 7.2. ... these must not be used. -->
+		 is deprecated in PHP 7.2 and has been removed in PHP 8.0. ... these must not be used. -->
 	<rule ref="WordPress.PHP.RestrictedPHPFunctions"/>
 
 
 	<!--
 	#############################################################################
-	Handbook: PHP - Regular Expressions.
+	Handbook: Recommendations - Closures.
+	Ref: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#closures-anonymous-functions
+	#############################################################################
+	-->
+	<!-- Rule: Closures should not be passed as filter or action callbacks.
+		 https://github.com/WordPress/WordPress-Coding-Standards/issues/1486 -->
+
+
+	<!--
+	#############################################################################
+	Handbook: Recommendations - Regular Expressions.
 	Ref: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#regular-expressions
 	#############################################################################
 	-->
@@ -475,7 +484,7 @@
 
 	<!--
 	#############################################################################
-	Handbook: PHP - Don't extract().
+	Handbook: Recommendations - Don't extract().
 	Ref: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#dont-extract
 	#############################################################################
 	-->

--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -314,8 +314,7 @@
 	Ref: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#only-one-object-structure-class-interface-trait-per-file
 	#############################################################################
 	-->
-	<!-- Encourage having only one class/interface/trait per file.
-		 Moved from Extra to Core after discussion on Slack. -->
+	<!-- Covers rule: Only One Object Structure (Class/Interface/Trait) per file. -->
 	<rule ref="Generic.Files.OneObjectStructurePerFile">
 		<message>Best practices: Declare only one class/interface/trait in a file.</message>
 	</rule>

--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -17,7 +17,7 @@
 
 	<!--
 	#############################################################################
-	Handbook: PHP - Opening and Closing PHP Tags.
+	Handbook: General - Opening and Closing PHP Tags.
 	Ref: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#opening-and-closing-php-tags
 	#############################################################################
 	-->

--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -15,7 +15,7 @@
 	-->
 	<rule ref="PHPCSUtils"/>
 
-<!--
+	<!--
 	#############################################################################
 	Handbook: PHP - Opening and Closing PHP Tags.
 	Ref: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#opening-and-closing-php-tags

--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -18,7 +18,7 @@
 <!--
 	#############################################################################
 	Handbook: PHP - Opening and Closing PHP Tags.
-	Ref: https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#opening-and-closing-php-tags
+	Ref: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#opening-and-closing-php-tags
 	#############################################################################
 	-->
 	<!-- Covers rule: When embedding multi-line PHP snippets within a HTML block, the
@@ -41,7 +41,7 @@
 	<!--
 	#############################################################################
 	Handbook: PHP - No Shorthand PHP Tags.
-	Ref: https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#no-shorthand-php-tags
+	Ref: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#no-shorthand-php-tags
 	#############################################################################
 	-->
 	<!-- Covers rule: Never use shorthand PHP start tags. Always use full PHP tags. -->
@@ -52,7 +52,7 @@
 	<!--
 	#############################################################################
 	Handbook: PHP - Single and Double Quotes.
-	Ref: https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#single-and-double-quotes
+	Ref: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#single-and-double-quotes
 	#############################################################################
 	-->
 	<!-- Covers rule: Use single and double quotes when appropriate.
@@ -66,7 +66,7 @@
 	<!--
 	#############################################################################
 	Handbook: PHP - Naming Conventions.
-	Ref: https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#naming-conventions
+	Ref: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#naming-conventions
 	#############################################################################
 	-->
 	<!-- Covers rule: Use lowercase letters in variable, action/filter, and function names.
@@ -95,7 +95,7 @@
 	<!--
 	#############################################################################
 	Handbook: PHP - Interpolation for Naming Dynamic Hooks.
-	Ref: https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#interpolation-for-naming-dynamic-hooks
+	Ref: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#interpolation-for-naming-dynamic-hooks
 
 	https://github.com/WordPress/WordPress-Coding-Standards/issues/751
 	#############################################################################
@@ -112,7 +112,7 @@
 	<!--
 	#############################################################################
 	Handbook: PHP - Space Usage.
-	Ref: https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#space-usage
+	Ref: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#space-usage
 	#############################################################################
 	-->
 	<!-- Covers rule: Always put spaces after commas, and on both sides of logical,
@@ -193,7 +193,7 @@
 	<!--
 	#############################################################################
 	Handbook: PHP - Indentation.
-	Ref: https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#indentation
+	Ref: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#indentation
 	#############################################################################
 	-->
 	<!-- Covers rule: Your indentation should always reflect logical structure. -->
@@ -259,7 +259,7 @@
 	<!--
 	#############################################################################
 	Handbook: PHP - Remove Trailing Spaces.
-	Ref: https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#remove-trailing-spaces
+	Ref: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#remove-trailing-spaces
 	#############################################################################
 	-->
 	<!-- Covers rule: Remove trailing whitespace at the end of each line of code. -->
@@ -271,7 +271,7 @@
 	<!--
 	#############################################################################
 	Handbook: PHP - Brace Style.
-	Ref: https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#brace-style
+	Ref: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#brace-style
 	#############################################################################
 	-->
 	<!-- Covers rule: Braces shall be used for all blocks. -->
@@ -284,7 +284,7 @@
 	<!--
 	#############################################################################
 	Handbook: PHP - Declaring Arrays.
-	Ref: https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#declaring-arrays
+	Ref: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#declaring-arrays
 	#############################################################################
 	-->
 	<!-- Covers rule: Arrays must be declared using long array syntax. -->
@@ -294,7 +294,7 @@
 	<!--
 	#############################################################################
 	Handbook: PHP - Multiline Function Calls.
-	Ref: https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#multiline-function-calls
+	Ref: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#multiline-function-calls
 	#############################################################################
 	-->
 	<!-- Rule: When splitting a function call over multiple lines, each parameter must be on a separate line.
@@ -322,7 +322,7 @@
 	<!--
 	#############################################################################
 	Handbook: PHP - Use elseif, not else if.
-	Ref: https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#use-elseif-not-else-if
+	Ref: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#use-elseif-not-else-if
 	#############################################################################
 	-->
 	<!-- Covers rule: ... use elseif for conditionals. -->
@@ -332,7 +332,7 @@
 	<!--
 	#############################################################################
 	Handbook: PHP - Yoda Conditions.
-	Ref: https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#yoda-conditions
+	Ref: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#yoda-conditions
 	#############################################################################
 	-->
 	<!-- Covers rule: When doing logical comparisons, always put the variable on the right side,
@@ -346,7 +346,7 @@
 	<!--
 	#############################################################################
 	Handbook: PHP - Ternary Operator.
-	Ref: https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#ternary-operator
+	Ref: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#ternary-operator
 	#############################################################################
 	-->
 	<!-- Rule: Always have Ternaries test if the statement is true, not false.
@@ -360,7 +360,7 @@
 	<!--
 	#############################################################################
 	Handbook: PHP - (No) Error Control Operator @.
-	Ref: https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#error-control-operator
+	Ref: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#error-control-operator
 	#############################################################################
 	-->
 	<!-- Covers rule: This operator is often used lazily instead of doing proper error checking.
@@ -371,7 +371,7 @@
 	<!--
 	#############################################################################
 	Handbook: PHP - Database Queries.
-	Ref: https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#database-queries
+	Ref: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#database-queries
 	#############################################################################
 	-->
 	<!-- Covers rule: Avoid touching the database directly. -->
@@ -382,7 +382,7 @@
 	<!--
 	#############################################################################
 	Handbook: PHP - Formatting SQL statements.
-	Ref: https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#formatting-sql-statements
+	Ref: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#formatting-sql-statements
 	#############################################################################
 	-->
 	<!-- Rule: Always capitalize the SQL parts of the statement like UPDATE or WHERE.
@@ -405,7 +405,7 @@
 	<!--
 	#############################################################################
 	Handbook: PHP - Self-Explanatory Flag Values for Function Arguments.
-	Ref: https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#self-explanatory-flag-values-for-function-arguments
+	Ref: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#self-explanatory-flag-values-for-function-arguments
 	#############################################################################
 	-->
 
@@ -413,7 +413,7 @@
 	<!--
 	#############################################################################
 	Handbook: PHP - Clever Code.
-	Ref: https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#clever-code
+	Ref: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#clever-code
 	#############################################################################
 	-->
 	<!-- Rule: In general, readability is more important than cleverness or brevity.
@@ -459,7 +459,7 @@
 	<!--
 	#############################################################################
 	Handbook: PHP - Regular Expressions.
-	Ref: https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#regular-expressions
+	Ref: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#regular-expressions
 	#############################################################################
 	-->
 	<!-- Covers rule: Perl compatible regular expressions should be used in preference
@@ -476,7 +476,7 @@
 	<!--
 	#############################################################################
 	Handbook: PHP - Don't extract().
-	Ref: https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#dont-extract
+	Ref: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#dont-extract
 	#############################################################################
 	-->
 	<rule ref="WordPress.PHP.DontExtract"/>
@@ -507,7 +507,7 @@
 	<rule ref="Generic.CodeAnalysis.EmptyPHPStatement"/>
 
 	<!-- Lowercase PHP constants, like true, false and null. -->
-	<!-- https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#naming-conventions -->
+	<!-- https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#naming-conventions -->
 	<rule ref="Generic.PHP.LowerCaseConstant"/>
 
 	<!-- Lowercase PHP keywords, like class, function and case. -->

--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -15,152 +15,7 @@
 	-->
 	<rule ref="PHPCSUtils"/>
 
-	<!--
-	#############################################################################
-	Handbook: PHP - Single and Double Quotes.
-	Ref: https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#single-and-double-quotes
-	#############################################################################
-	-->
-	<!-- Covers rule: Use single and double quotes when appropriate.
-		 If you're not evaluating anything in the string, use single quotes. -->
-	<rule ref="Squiz.Strings.DoubleQuoteUsage.NotRequired"/>
-
-	<!-- Rule: Text that goes into attributes should be run through esc_attr().
-		 https://github.com/WordPress/WordPress-Coding-Standards/issues/527 -->
-
-
-	<!--
-	#############################################################################
-	Handbook: PHP - Indentation.
-	Ref: https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#indentation
-	#############################################################################
-	-->
-	<!-- Covers rule: Your indentation should always reflect logical structure. -->
-	<rule ref="Generic.WhiteSpace.ScopeIndent">
-		<properties>
-			<property name="exact" value="false"/>
-			<property name="indent" value="4"/>
-			<property name="tabIndent" value="true"/>
-			<property name="ignoreIndentationTokens" type="array">
-				<element value="T_HEREDOC"/>
-				<element value="T_NOWDOC"/>
-				<element value="T_INLINE_HTML"/>
-			</property>
-		</properties>
-	</rule>
-	<rule ref="WordPress.Arrays.ArrayIndentation"/>
-
-	<!-- Covers rule: Use real tabs and not spaces. -->
-	<rule ref="Generic.WhiteSpace.DisallowSpaceIndent"/>
-	<rule ref="WordPress.WhiteSpace.PrecisionAlignment"/>
-
-	<!-- Generic array layout check. -->
-	<!-- Covers rule: For associative arrays, each item should start on a new line
-		 when the array contains more than one item.
-		 Also covers various single-line array whitespace issues. -->
-	<rule ref="WordPress.Arrays.ArrayDeclarationSpacing"/>
-
-	<!-- Covers rule: Note the comma after the last array item: this is recommended. -->
-	<rule ref="WordPress.Arrays.CommaAfterArrayItem"/>
-
-	<!-- Covers rule: For switch structures case should indent one tab from the
-		 switch statement and break one tab from the case statement. -->
-	<rule ref="PSR2.ControlStructures.SwitchDeclaration"/>
-	<!-- Prevent duplicate messages for the same issue. Covered by other sniffs. -->
-	<rule ref="PSR2.ControlStructures.SwitchDeclaration.NotLower">
-		<severity>0</severity>
-	</rule>
-	<rule ref="PSR2.ControlStructures.SwitchDeclaration.BreakNotNewLine">
-		<severity>0</severity>
-	</rule>
-	<rule ref="PSR2.ControlStructures.SwitchDeclaration.BodyOnNextLine">
-		<severity>0</severity>
-	</rule>
-
-	<!-- Covers rule: ... while spaces can be used mid-line for alignment. -->
-	<rule ref="Universal.WhiteSpace.DisallowInlineTabs"/>
-
-	<!-- Implied through the examples: align the assignment operator in a block of assignments. -->
-	<rule ref="Generic.Formatting.MultipleStatementAlignment">
-		<properties>
-			<property name="maxPadding" value="40"/>
-		</properties>
-	</rule>
-
-	<!-- Implied through the examples: align the double arrows. -->
-	<rule ref="WordPress.Arrays.MultipleStatementAlignment">
-		<properties>
-			<property name="maxColumn" value="60"/>
-		</properties>
-	</rule>
-
-
-	<!--
-	#############################################################################
-	Handbook: PHP - Brace Style.
-	Ref: https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#brace-style
-	#############################################################################
-	-->
-	<!-- Covers rule: Braces shall be used for all blocks. -->
-	<rule ref="Squiz.ControlStructures.ControlSignature"/>
-
-	<!-- Covers rule: Braces should always be used, even when they are not required. -->
-	<rule ref="Generic.ControlStructures.InlineControlStructure"/>
-
-
-	<!--
-	#############################################################################
-	Handbook: PHP - Declaring Arrays.
-	Ref: https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#declaring-arrays
-	#############################################################################
-	-->
-	<!-- Covers rule: Arrays must be declared using long array syntax. -->
-	<rule ref="Universal.Arrays.DisallowShortArraySyntax"/>
-
-
-	<!--
-	#############################################################################
-	Handbook: PHP - Use elseif, not else if.
-	Ref: https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#use-elseif-not-else-if
-	#############################################################################
-	-->
-	<!-- Covers rule: ... use elseif for conditionals. -->
-	<rule ref="PSR2.ControlStructures.ElseIfDeclaration"/>
-
-
-	<!--
-	#############################################################################
-	Handbook: PHP - Multiline Function Calls.
-	Ref: https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#multiline-function-calls
-	#############################################################################
-	-->
-	<!-- Rule: When splitting a function call over multiple lines, each parameter must be on a separate line.
-		 Covered via PEAR.Functions.FunctionCallSignature in Space Usage section. -->
-
-	<!-- Rule: Single line inline comments can take up their own line. -->
-	<!-- Rule: Each parameter must take up no more than a single line. Multi-line parameter
-		 values must be assigned to a variable and then that variable should be passed to the function call.
-		 https://github.com/WordPress/WordPress-Coding-Standards/issues/1330 -->
-
-
-	<!--
-	#############################################################################
-	Handbook: PHP - Regular Expressions.
-	Ref: https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#regular-expressions
-	#############################################################################
-	-->
-	<!-- Covers rule: Perl compatible regular expressions should be used in preference
-		 to their POSIX counterparts. -->
-	<rule ref="WordPress.PHP.POSIXFunctions"/>
-
-	<!-- Rule: Never use the /e switch, use preg_replace_callback instead.
-		 https://github.com/WordPress/WordPress-Coding-Standards/issues/632 -->
-
-	<!-- Rule: It's most convenient to use single-quoted strings for regular expressions.
-		 Already covered by Squiz.Strings.DoubleQuoteUsage -->
-
-
-	<!--
+<!--
 	#############################################################################
 	Handbook: PHP - Opening and Closing PHP Tags.
 	Ref: https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#opening-and-closing-php-tags
@@ -196,15 +51,62 @@
 
 	<!--
 	#############################################################################
-	Handbook: PHP - Remove Trailing Spaces.
-	Ref: https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#remove-trailing-spaces
+	Handbook: PHP - Single and Double Quotes.
+	Ref: https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#single-and-double-quotes
 	#############################################################################
 	-->
-	<!-- Covers rule: Remove trailing whitespace at the end of each line of code. -->
-	<rule ref="Squiz.WhiteSpace.SuperfluousWhitespace"/>
+	<!-- Covers rule: Use single and double quotes when appropriate.
+		 If you're not evaluating anything in the string, use single quotes. -->
+	<rule ref="Squiz.Strings.DoubleQuoteUsage.NotRequired"/>
 
-	<!-- Covers rule: Omitting the closing PHP tag at the end of a file is preferred. -->
-	<rule ref="PSR2.Files.ClosingTag"/>
+	<!-- Rule: Text that goes into attributes should be run through esc_attr().
+		 https://github.com/WordPress/WordPress-Coding-Standards/issues/527 -->
+
+
+	<!--
+	#############################################################################
+	Handbook: PHP - Naming Conventions.
+	Ref: https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#naming-conventions
+	#############################################################################
+	-->
+	<!-- Covers rule: Use lowercase letters in variable, action/filter, and function names.
+		 Separate words via underscores. -->
+	<rule ref="WordPress.NamingConventions.ValidFunctionName"/>
+	<rule ref="WordPress.NamingConventions.ValidHookName"/>
+	<rule ref="WordPress.NamingConventions.ValidVariableName"/>
+
+	<!-- Covers rule: Class names should use capitalized words separated by underscores. -->
+	<rule ref="PEAR.NamingConventions.ValidClassName"/>
+
+	<!-- Covers rule: Constants should be in all upper-case with underscores separating words. -->
+	<rule ref="Generic.NamingConventions.UpperCaseConstantName"/>
+
+	<!-- Covers rule: Files should be named descriptively using lowercase letters.
+		 Hyphens should separate words. -->
+	<!-- Covers rule: Class file names should be based on the class name with "class-"
+		 prepended and the underscores in the class name replaced with hyphens.
+		 https://github.com/WordPress/WordPress-Coding-Standards/issues/642 -->
+	<!-- Covers rule: Files containing template tags in wp-includes should have "-template"
+		 appended to the end of the name.
+		 https://github.com/WordPress/WordPress-Coding-Standards/issues/642 -->
+	<rule ref="WordPress.Files.FileName"/>
+
+
+	<!--
+	#############################################################################
+	Handbook: PHP - Interpolation for Naming Dynamic Hooks.
+	Ref: https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#interpolation-for-naming-dynamic-hooks
+
+	https://github.com/WordPress/WordPress-Coding-Standards/issues/751
+	#############################################################################
+	-->
+	<!-- Rule: Dynamic hooks should be named using interpolation rather than concatenation. -->
+
+	<!-- Rule: Variables used in hook tags should be wrapped in curly braces { and },
+		 with the complete outer tag name wrapped in double quotes. -->
+
+	<!-- Rule: Where possible, dynamic values in tag names should also be as succinct
+		 and to the point as possible. -->
 
 
 	<!--
@@ -290,6 +192,195 @@
 
 	<!--
 	#############################################################################
+	Handbook: PHP - Indentation.
+	Ref: https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#indentation
+	#############################################################################
+	-->
+	<!-- Covers rule: Your indentation should always reflect logical structure. -->
+	<rule ref="Generic.WhiteSpace.ScopeIndent">
+		<properties>
+			<property name="exact" value="false"/>
+			<property name="indent" value="4"/>
+			<property name="tabIndent" value="true"/>
+			<property name="ignoreIndentationTokens" type="array">
+				<element value="T_HEREDOC"/>
+				<element value="T_NOWDOC"/>
+				<element value="T_INLINE_HTML"/>
+			</property>
+		</properties>
+	</rule>
+	<rule ref="WordPress.Arrays.ArrayIndentation"/>
+
+	<!-- Covers rule: Use real tabs and not spaces. -->
+	<rule ref="Generic.WhiteSpace.DisallowSpaceIndent"/>
+	<rule ref="WordPress.WhiteSpace.PrecisionAlignment"/>
+
+	<!-- Generic array layout check. -->
+	<!-- Covers rule: For associative arrays, each item should start on a new line
+		 when the array contains more than one item.
+		 Also covers various single-line array whitespace issues. -->
+	<rule ref="WordPress.Arrays.ArrayDeclarationSpacing"/>
+
+	<!-- Covers rule: Note the comma after the last array item: this is recommended. -->
+	<rule ref="WordPress.Arrays.CommaAfterArrayItem"/>
+
+	<!-- Covers rule: For switch structures case should indent one tab from the
+		 switch statement and break one tab from the case statement. -->
+	<rule ref="PSR2.ControlStructures.SwitchDeclaration"/>
+	<!-- Prevent duplicate messages for the same issue. Covered by other sniffs. -->
+	<rule ref="PSR2.ControlStructures.SwitchDeclaration.NotLower">
+		<severity>0</severity>
+	</rule>
+	<rule ref="PSR2.ControlStructures.SwitchDeclaration.BreakNotNewLine">
+		<severity>0</severity>
+	</rule>
+	<rule ref="PSR2.ControlStructures.SwitchDeclaration.BodyOnNextLine">
+		<severity>0</severity>
+	</rule>
+
+	<!-- Covers rule: ... while spaces can be used mid-line for alignment. -->
+	<rule ref="Universal.WhiteSpace.DisallowInlineTabs"/>
+
+	<!-- Implied through the examples: align the assignment operator in a block of assignments. -->
+	<rule ref="Generic.Formatting.MultipleStatementAlignment">
+		<properties>
+			<property name="maxPadding" value="40"/>
+		</properties>
+	</rule>
+
+	<!-- Implied through the examples: align the double arrows. -->
+	<rule ref="WordPress.Arrays.MultipleStatementAlignment">
+		<properties>
+			<property name="maxColumn" value="60"/>
+		</properties>
+	</rule>
+
+
+	<!--
+	#############################################################################
+	Handbook: PHP - Remove Trailing Spaces.
+	Ref: https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#remove-trailing-spaces
+	#############################################################################
+	-->
+	<!-- Covers rule: Remove trailing whitespace at the end of each line of code. -->
+	<rule ref="Squiz.WhiteSpace.SuperfluousWhitespace"/>
+
+	<!-- Covers rule: Omitting the closing PHP tag at the end of a file is preferred. -->
+	<rule ref="PSR2.Files.ClosingTag"/>
+
+	<!--
+	#############################################################################
+	Handbook: PHP - Brace Style.
+	Ref: https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#brace-style
+	#############################################################################
+	-->
+	<!-- Covers rule: Braces shall be used for all blocks. -->
+	<rule ref="Squiz.ControlStructures.ControlSignature"/>
+
+	<!-- Covers rule: Braces should always be used, even when they are not required. -->
+	<rule ref="Generic.ControlStructures.InlineControlStructure"/>
+
+
+	<!--
+	#############################################################################
+	Handbook: PHP - Declaring Arrays.
+	Ref: https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#declaring-arrays
+	#############################################################################
+	-->
+	<!-- Covers rule: Arrays must be declared using long array syntax. -->
+	<rule ref="Universal.Arrays.DisallowShortArraySyntax"/>
+
+
+	<!--
+	#############################################################################
+	Handbook: PHP - Multiline Function Calls.
+	Ref: https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#multiline-function-calls
+	#############################################################################
+	-->
+	<!-- Rule: When splitting a function call over multiple lines, each parameter must be on a separate line.
+		 Covered via PEAR.Functions.FunctionCallSignature in Space Usage section. -->
+
+	<!-- Rule: Single line inline comments can take up their own line. -->
+	<!-- Rule: Each parameter must take up no more than a single line. Multi-line parameter
+		 values must be assigned to a variable and then that variable should be passed to the function call.
+		 https://github.com/WordPress/WordPress-Coding-Standards/issues/1330 -->
+
+
+	<!--
+	#############################################################################
+	Handbook: PHP - Only One Object Structure (Class/Interface/Trait) per File.
+	Ref: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#only-one-object-structure-class-interface-trait-per-file
+	#############################################################################
+	-->
+	<!-- Encourage having only one class/interface/trait per file.
+		 Moved from Extra to Core after discussion on Slack. -->
+	<rule ref="Generic.Files.OneObjectStructurePerFile">
+		<message>Best practices: Declare only one class/interface/trait in a file.</message>
+	</rule>
+
+
+	<!--
+	#############################################################################
+	Handbook: PHP - Use elseif, not else if.
+	Ref: https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#use-elseif-not-else-if
+	#############################################################################
+	-->
+	<!-- Covers rule: ... use elseif for conditionals. -->
+	<rule ref="PSR2.ControlStructures.ElseIfDeclaration"/>
+
+
+	<!--
+	#############################################################################
+	Handbook: PHP - Yoda Conditions.
+	Ref: https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#yoda-conditions
+	#############################################################################
+	-->
+	<!-- Covers rule: When doing logical comparisons, always put the variable on the right side,
+		 constants or literals on the left. -->
+	<rule ref="WordPress.PHP.YodaConditions"/>
+
+	<!-- Rule: Yoda conditions for <, >, <= or >= are significantly more difficult to read
+		 and are best avoided. -->
+
+
+	<!--
+	#############################################################################
+	Handbook: PHP - Ternary Operator.
+	Ref: https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#ternary-operator
+	#############################################################################
+	-->
+	<!-- Rule: Always have Ternaries test if the statement is true, not false.
+		 An exception would be using ! empty(), as testing for false here is generally more intuitive.
+		 https://github.com/WordPress/WordPress-Coding-Standards/issues/643 -->
+
+	<!-- Rule: The short ternary operator must not be used. -->
+	<rule ref="Universal.Operators.DisallowShortTernary"/>
+
+
+	<!--
+	#############################################################################
+	Handbook: PHP - (No) Error Control Operator @.
+	Ref: https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#error-control-operator
+	#############################################################################
+	-->
+	<!-- Covers rule: This operator is often used lazily instead of doing proper error checking.
+		 Its use is highly discouraged. -->
+	<rule ref="WordPress.PHP.NoSilencedErrors"/>
+
+
+	<!--
+	#############################################################################
+	Handbook: PHP - Database Queries.
+	Ref: https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#database-queries
+	#############################################################################
+	-->
+	<!-- Covers rule: Avoid touching the database directly. -->
+	<rule ref="WordPress.DB.RestrictedFunctions"/>
+	<rule ref="WordPress.DB.RestrictedClasses"/>
+
+
+	<!--
+	#############################################################################
 	Handbook: PHP - Formatting SQL statements.
 	Ref: https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#formatting-sql-statements
 	#############################################################################
@@ -313,94 +404,11 @@
 
 	<!--
 	#############################################################################
-	Handbook: PHP - Database Queries.
-	Ref: https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#database-queries
-	#############################################################################
-	-->
-	<!-- Covers rule: Avoid touching the database directly. -->
-	<rule ref="WordPress.DB.RestrictedFunctions"/>
-	<rule ref="WordPress.DB.RestrictedClasses"/>
-
-
-	<!--
-	#############################################################################
-	Handbook: PHP - Naming Conventions.
-	Ref: https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#naming-conventions
-	#############################################################################
-	-->
-	<!-- Covers rule: Use lowercase letters in variable, action/filter, and function names.
-		 Separate words via underscores. -->
-	<rule ref="WordPress.NamingConventions.ValidFunctionName"/>
-	<rule ref="WordPress.NamingConventions.ValidHookName"/>
-	<rule ref="WordPress.NamingConventions.ValidVariableName"/>
-
-	<!-- Covers rule: Class names should use capitalized words separated by underscores. -->
-	<rule ref="PEAR.NamingConventions.ValidClassName"/>
-
-	<!-- Covers rule: Constants should be in all upper-case with underscores separating words. -->
-	<rule ref="Generic.NamingConventions.UpperCaseConstantName"/>
-
-	<!-- Covers rule: Files should be named descriptively using lowercase letters.
-		 Hyphens should separate words. -->
-	<!-- Covers rule: Class file names should be based on the class name with "class-"
-		 prepended and the underscores in the class name replaced with hyphens.
-		 https://github.com/WordPress/WordPress-Coding-Standards/issues/642 -->
-	<!-- Covers rule: Files containing template tags in wp-includes should have "-template"
-		 appended to the end of the name.
-		 https://github.com/WordPress/WordPress-Coding-Standards/issues/642 -->
-	<rule ref="WordPress.Files.FileName"/>
-
-
-	<!--
-	#############################################################################
 	Handbook: PHP - Self-Explanatory Flag Values for Function Arguments.
 	Ref: https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#self-explanatory-flag-values-for-function-arguments
 	#############################################################################
 	-->
 
-
-	<!--
-	#############################################################################
-	Handbook: PHP - Interpolation for Naming Dynamic Hooks.
-	Ref: https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#interpolation-for-naming-dynamic-hooks
-
-	https://github.com/WordPress/WordPress-Coding-Standards/issues/751
-	#############################################################################
-	-->
-	<!-- Rule: Dynamic hooks should be named using interpolation rather than concatenation. -->
-
-	<!-- Rule: Variables used in hook tags should be wrapped in curly braces { and },
-		 with the complete outer tag name wrapped in double quotes. -->
-
-	<!-- Rule: Where possible, dynamic values in tag names should also be as succinct
-		 and to the point as possible. -->
-
-
-	<!--
-	#############################################################################
-	Handbook: PHP - Ternary Operator.
-	Ref: https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#ternary-operator
-	#############################################################################
-	-->
-	<!-- Rule: Always have Ternaries test if the statement is true, not false.
-		 An exception would be using ! empty(), as testing for false here is generally more intuitive.
-		 https://github.com/WordPress/WordPress-Coding-Standards/issues/643 -->
-
-	<!-- Rule: The short ternary operator must not be used. -->
-	<rule ref="Universal.Operators.DisallowShortTernary"/>
-
-	<!--
-	#############################################################################
-	Handbook: PHP - Yoda Conditions.
-	Ref: https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#yoda-conditions
-	#############################################################################
-	-->
-	<!-- Covers rule: When doing logical comparisons, always put the variable on the right side,
-		 constants or literals on the left. -->
-	<rule ref="WordPress.PHP.YodaConditions"/>
-
-	<!-- Rule: Yoda conditions for <, >, <= or >= are significantly more difficult to read
-		 and are best avoided. -->
 
 	<!--
 	#############################################################################
@@ -420,7 +428,7 @@
 	</rule>
 	<rule ref="WordPress.PHP.StrictInArray"/>
 
-	<!-- Rule: Assignments must not be placed in placed in conditionals.
+	<!-- Rule: Assignments must not be placed in conditionals.
 		 Note: sniff is a duplicate of upstream. Can be removed once minimum PHPCS requirement has gone up.
 		 https://github.com/squizlabs/PHP_CodeSniffer/pull/1594
 		 Update: the "assignment in ternary" part of the sniff is currently not yet covered in
@@ -450,13 +458,19 @@
 
 	<!--
 	#############################################################################
-	Handbook: PHP - (No) Error Control Operator @.
-	Ref: https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#error-control-operator
+	Handbook: PHP - Regular Expressions.
+	Ref: https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#regular-expressions
 	#############################################################################
 	-->
-	<!-- Covers rule: This operator is often used lazily instead of doing proper error checking.
-		 Its use is highly discouraged. -->
-	<rule ref="WordPress.PHP.NoSilencedErrors"/>
+	<!-- Covers rule: Perl compatible regular expressions should be used in preference
+		 to their POSIX counterparts. -->
+	<rule ref="WordPress.PHP.POSIXFunctions"/>
+
+	<!-- Rule: Never use the /e switch, use preg_replace_callback instead.
+		 https://github.com/WordPress/WordPress-Coding-Standards/issues/632 -->
+
+	<!-- Rule: It's most convenient to use single-quoted strings for regular expressions.
+		 Already covered by Squiz.Strings.DoubleQuoteUsage -->
 
 
 	<!--
@@ -515,12 +529,6 @@
 	<rule ref="Squiz.Classes.SelfMemberReference"/>
 	<rule ref="Squiz.Classes.SelfMemberReference.NotUsed">
 		<severity>0</severity>
-	</rule>
-
-	<!-- Encourage having only one class/interface/trait per file.
-		 Moved from Extra to Core after discussion on Slack. -->
-	<rule ref="Generic.Files.OneObjectStructurePerFile">
-		<message>Best practices: Declare only one class/interface/trait in a file.</message>
 	</rule>
 
 	<!-- Error on merge conflict markers. -->

--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -225,8 +225,9 @@
 	<!-- Covers rule: Note the comma after the last array item: this is recommended. -->
 	<rule ref="WordPress.Arrays.CommaAfterArrayItem"/>
 
-	<!-- Covers rule: For switch structures case should indent one tab from the
-		 switch statement and break one tab from the case statement. -->
+	<!-- Covers rule: For switch control structures, case statements should be indented one tab
+		 from the switch statement and the contents of the case should be indented one tab
+		 from the case condition statement. -->
 	<rule ref="PSR2.ControlStructures.SwitchDeclaration"/>
 	<!-- Prevent duplicate messages for the same issue. Covered by other sniffs. -->
 	<rule ref="PSR2.ControlStructures.SwitchDeclaration.NotLower">

--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -397,9 +397,8 @@
 		 placeholders. Note that they are not 'quoted'! -->
 	<rule ref="WordPress.DB.PreparedSQLPlaceholders"/>
 
-	<!-- Covers rule:  $wpdb->prepare()... The benefit of this is that we don't have to remember
-		 to manually use esc_sql(), and also that it is easy to see at a glance whether something
-		 has been escaped or not, because it happens right when the query happens. -->
+	<!-- Covers rule:  Escaping should be done as close to the time of the query
+		 as possible, preferably by using $wpdb->prepare(). -->
 	<rule ref="WordPress.DB.PreparedSQL"/>
 
 


### PR DESCRIPTION
This PR will reorder the core ruleset to match the current [WordPress PHP Coding Standards handbook](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/) chapters.

The links to the handbook has been updated as well.

Closes #2064

