### PR TITLE
Update composer.json keywords

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,7 @@
 	"keywords": [
 		"phpcs",
 		"standards",
+		"static analysis",
 		"WordPress"
 	],
 	"license": "MIT",


### PR DESCRIPTION
As per getcomposer.org/doc/04-schema.md#keywords by including "static analysis", then later versions of Composer will prompt users if the package is installed with `composer require` instead of `composer require-dev`.