### PR TITLE
Composer/GH Actions: start using PHPCSDevTools 1.2.0

### DIFF
--- a/.github/workflows/ruleset-checks-sniffs.yml
+++ b/.github/workflows/ruleset-checks-sniffs.yml
@@ -72,13 +72,17 @@ jobs:
       - name: Show PHPCS results in PR
         run: cs2pr ./phpcs-report.xml --graceful-warnings
 
-      # Validate the XML files.
+      # Validate the Ruleset XML files.
       # @link http://xmlsoft.org/xmllint.html
       - name: Validate the WordPress rulesets
         run: xmllint --noout --schema vendor/squizlabs/php_codesniffer/phpcs.xsd ./*/ruleset.xml
 
       - name: Validate the sample ruleset
         run: xmllint --noout --schema vendor/squizlabs/php_codesniffer/phpcs.xsd ./phpcs.xml.dist.sample
+
+      # Validate the Documentation XML files.
+      - name: Validate documentation against schema
+        run: xmllint --noout --schema vendor/phpcsstandards/phpcsdevtools/DocsXsd/phpcsdocs.xsd ./WordPress/Docs/*/*Standard.xml
 
       - name: Check the code-style consistency of the xml files
         run: |

--- a/WordPress/Docs/Arrays/ArrayIndentationStandard.xml
+++ b/WordPress/Docs/Arrays/ArrayIndentationStandard.xml
@@ -1,4 +1,8 @@
-<documentation title="Array Indentation">
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Array Indentation"
+    >
     <standard>
     <![CDATA[
       The array closing bracket indentation should line up with the start of the content on the line containing the array opener.

--- a/WordPress/Docs/Arrays/ArrayKeySpacingRestrictionsStandard.xml
+++ b/WordPress/Docs/Arrays/ArrayKeySpacingRestrictionsStandard.xml
@@ -1,4 +1,8 @@
-<documentation title="Array Key Spacing Restrictions">
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Array Key Spacing Restrictions"
+    >
     <standard>
     <![CDATA[
       When referring to array items, only include a space around the index if it is a variable or the key is concatenated.

--- a/WordPress/Docs/Arrays/CommaAfterArrayItemStandard.xml
+++ b/WordPress/Docs/Arrays/CommaAfterArrayItemStandard.xml
@@ -1,4 +1,8 @@
-<documentation title="Comma After Array Item">
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Comma After Array Item"
+    >
     <standard>
     <![CDATA[
     There should be no space between an array item and the comma following it.

--- a/WordPress/Docs/Arrays/MultipleStatementAlignmentStandard.xml
+++ b/WordPress/Docs/Arrays/MultipleStatementAlignmentStandard.xml
@@ -1,4 +1,8 @@
-<documentation title="Multiple Statement Alignment">
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Array Multiple Statement Alignment"
+    >
     <standard>
     <![CDATA[
         When declaring arrays, there should be one space on either side of a double arrow operator used to assign a value to a key.

--- a/WordPress/Docs/Classes/ClassInstantiationStandard.xml
+++ b/WordPress/Docs/Classes/ClassInstantiationStandard.xml
@@ -1,4 +1,8 @@
-<documentation title="Class Instantiation">
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Class Instantiation"
+    >
     <standard>
     <![CDATA[
     Instantiation of an object should be done with parenthesis.

--- a/WordPress/Docs/CodeAnalysis/EscapedNotTranslatedStandard.xml
+++ b/WordPress/Docs/CodeAnalysis/EscapedNotTranslatedStandard.xml
@@ -1,4 +1,8 @@
-<documentation title="Escaped Not Translated Text">
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Escaped Not Translated"
+    >
     <standard>
     <![CDATA[
     Text intended for translation needs to be wrapped in a localization function call.

--- a/WordPress/Docs/DateTime/CurrentTimeTimestampStandard.xml
+++ b/WordPress/Docs/DateTime/CurrentTimeTimestampStandard.xml
@@ -1,4 +1,8 @@
-<documentation title="Current Time Timestamp">
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Current Time Timestamp"
+    >
     <standard>
     <![CDATA[
     Don't use current_time() to get a timestamp as it doesn't produce a Unix (UTC) timestamp, but a "WordPress timestamp", i.e. a Unix timestamp with current timezone offset.

--- a/WordPress/Docs/DateTime/RestrictedFunctionsStandard.xml
+++ b/WordPress/Docs/DateTime/RestrictedFunctionsStandard.xml
@@ -1,4 +1,8 @@
-<documentation title="Restricted Date and Time Functions">
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Restricted Date and Time Functions"
+    >
     <standard>
     <![CDATA[
     The restricted functions date_default_timezone_set() and date() should not be used.

--- a/WordPress/Docs/NamingConventions/PrefixAllGlobalsStandard.xml
+++ b/WordPress/Docs/NamingConventions/PrefixAllGlobalsStandard.xml
@@ -1,4 +1,8 @@
-<documentation title="Prefix All Globals">
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Prefix All Globals"
+    >
     <standard>
     <![CDATA[
     All globals terms must be prefixed with a theme/plugin specific term. Global terms include Namespace names, Class/Interface/Trait names (when not namespaced), Functions (when not namespaced or in an OO structure), Constants/Variable names declared in the global namespace, and Hook names.

--- a/WordPress/Docs/NamingConventions/ValidHookNameStandard.xml
+++ b/WordPress/Docs/NamingConventions/ValidHookNameStandard.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0"?>
-<documentation title="Valid Hook Name">
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Valid Hook Name"
+    >
     <standard>
     <![CDATA[
     Use lowercase letters in action and filter names. Separate words using underscores.

--- a/WordPress/Docs/NamingConventions/ValidPostTypeSlugStandard.xml
+++ b/WordPress/Docs/NamingConventions/ValidPostTypeSlugStandard.xml
@@ -1,4 +1,8 @@
-<documentation title="Validate post type slugs">
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Valid Post Type Slug"
+    >
     <standard>
     <![CDATA[
     The post type slug used in register_post_type() must be between 1 and 20 characters.

--- a/WordPress/Docs/PHP/IniSetStandard.xml
+++ b/WordPress/Docs/PHP/IniSetStandard.xml
@@ -1,4 +1,8 @@
-<documentation title="Detect use of `ini_set()`">
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Detect Use Of `ini_set()"
+    >
     <standard>
     <![CDATA[
       Using ini_set() and similar functions for altering PHP settings at runtime is discouraged. Changing runtime configuration might break other plugins and themes, and even WordPress itself.

--- a/WordPress/Docs/PHP/StrictInArrayStandard.xml
+++ b/WordPress/Docs/PHP/StrictInArrayStandard.xml
@@ -1,4 +1,8 @@
-<documentation title="Strict In Array Syntax">
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Strict In Array Syntax"
+    >
     <standard>
     <![CDATA[
     When using functions which compare a value to a range of values in an array, make sure a strict comparison is executed.

--- a/WordPress/Docs/PHP/YodaConditionsStandard.xml
+++ b/WordPress/Docs/PHP/YodaConditionsStandard.xml
@@ -1,4 +1,8 @@
-<documentation title="Yoda Conditions">
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Yoda Conditions"
+    >
     <standard>
     <![CDATA[
     When doing logical comparisons involving variables, the variable must be placed on the right side. All constants, literals, and function calls must be placed on the left side. If neither side is a variable, the order is unimportant.

--- a/WordPress/Docs/Security/SafeRedirectStandard.xml
+++ b/WordPress/Docs/Security/SafeRedirectStandard.xml
@@ -1,4 +1,8 @@
-<documentation title="Safe Redirect">
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Safe Redirect"
+    >
     <standard>
     <![CDATA[
     wp_safe_redirect() should be used whenever possible to prevent open redirect vulnerabilities. One of the main uses of an open redirect vulnerability is to make phishing attacks more credible. In this case the user sees your (trusted) domain and might get redirected to an attacker controlled website aimed at stealing private information.

--- a/WordPress/Docs/WP/CapitalPDangitStandard.xml
+++ b/WordPress/Docs/WP/CapitalPDangitStandard.xml
@@ -1,4 +1,8 @@
-<documentation title="Capital P Dangit">
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Capital P Dangit"
+    >
     <standard>
     <![CDATA[
 The correct spelling of "WordPress" should be used in text strings, comments and object names.

--- a/WordPress/Docs/WP/CronIntervalStandard.xml
+++ b/WordPress/Docs/WP/CronIntervalStandard.xml
@@ -1,4 +1,8 @@
-<documentation title="Cron interval">
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Cron Interval"
+    >
     <standard>
     <![CDATA[
     Cron schedules running more often than once every 15 minutes are discouraged. Crons running that frequently can negatively impact the performance of a site.

--- a/WordPress/Docs/WP/DeprecatedClassesStandard.xml
+++ b/WordPress/Docs/WP/DeprecatedClassesStandard.xml
@@ -1,4 +1,8 @@
-<documentation title="Deprecated Classes">
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Deprecated Classes"
+    >
     <standard>
     <![CDATA[
     Please refrain from using deprecated WordPress classes. 

--- a/WordPress/Docs/WP/DeprecatedFunctionsStandard.xml
+++ b/WordPress/Docs/WP/DeprecatedFunctionsStandard.xml
@@ -1,4 +1,8 @@
-<documentation title="Deprecated Functions">
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Deprecated Functions"
+    >
     <standard>
     <![CDATA[
     Please refrain from using deprecated WordPress functions. 

--- a/WordPress/Docs/WP/DeprecatedParameterValuesStandard.xml
+++ b/WordPress/Docs/WP/DeprecatedParameterValuesStandard.xml
@@ -1,4 +1,8 @@
-<documentation title="Deprecated Function Parameter Values">
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Deprecated Function Parameter Values"
+    >
     <standard>
     <![CDATA[
     Please refrain from using deprecated WordPress function parameter values.

--- a/WordPress/Docs/WP/DeprecatedParametersStandard.xml
+++ b/WordPress/Docs/WP/DeprecatedParametersStandard.xml
@@ -1,4 +1,8 @@
-<documentation title="Deprecated Function Parameters">
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Deprecated Function Parameters"
+    >
     <standard>
     <![CDATA[
     Please refrain from passing deprecated WordPress function parameters.

--- a/WordPress/Docs/WP/EnqueuedResourceParametersStandard.xml
+++ b/WordPress/Docs/WP/EnqueuedResourceParametersStandard.xml
@@ -1,4 +1,8 @@
-<documentation title="Enqueued Resource Parameters">
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Enqueued Resource Parameters"
+    >
     <standard>
     <![CDATA[
     The resource version must be set, to prevent the browser from using an outdated, cached version after the resource has been updated.

--- a/WordPress/Docs/WP/EnqueuedResourcesStandard.xml
+++ b/WordPress/Docs/WP/EnqueuedResourcesStandard.xml
@@ -1,4 +1,8 @@
-<documentation title="Enqueued Resources">
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Enqueued Resources"
+    >
     <standard>
     <![CDATA[
     Scripts must be registered/enqueued via wp_enqueue_script().

--- a/WordPress/Docs/WP/PostsPerPageStandard.xml
+++ b/WordPress/Docs/WP/PostsPerPageStandard.xml
@@ -1,4 +1,8 @@
-<documentation title="High Posts Per Page Limit">
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="High Posts Per Page Limit"
+    >
     <standard>
     <![CDATA[
 Using "posts_per_page" or "numberposts" with the value set to an high number opens up the potential for making requests slow if the query ends up querying thousands of posts.

--- a/WordPress/Docs/WhiteSpace/CastStructureSpacingStandard.xml
+++ b/WordPress/Docs/WhiteSpace/CastStructureSpacingStandard.xml
@@ -1,4 +1,8 @@
-<documentation title="Cast Structure Spacing">
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Cast Structure Spacing"
+    >
     <standard>
     <![CDATA[
     A type cast should be preceded by whitespace.

--- a/WordPress/Docs/WhiteSpace/OperatorSpacingStandard.xml
+++ b/WordPress/Docs/WhiteSpace/OperatorSpacingStandard.xml
@@ -1,4 +1,8 @@
-<documentation title="Operator Spacing">
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Operator Spacing"
+    >
     <standard>
     <![CDATA[
     Always put one space on both sides of logical, comparison and concatenation operators.

--- a/WordPress/Docs/WhiteSpace/PrecisionAlignmentStandard.xml
+++ b/WordPress/Docs/WhiteSpace/PrecisionAlignmentStandard.xml
@@ -1,4 +1,8 @@
-<documentation title="Precision Alignment">
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Precision Alignment"
+    >
     <standard>
     <![CDATA[
     Line indentation should only use tabs. Precision alignment with spaces after the tabs is strongly discouraged.

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
 	"require-dev": {
 		"phpcompatibility/php-compatibility": "^9.0",
 		"phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0",
-		"phpcsstandards/phpcsdevtools": "^1.0",
+		"phpcsstandards/phpcsdevtools": "^1.2.0",
 		"php-parallel-lint/php-parallel-lint": "^1.3.2",
 		"php-parallel-lint/php-console-highlighter": "^1.0.0"
 	},


### PR DESCRIPTION
### Composer/GH Actions: start using PHPCSDevTools 1.2.0

PHPCSDevTools 1.2.0 introduces an XSD for the XML docs which can accompany sniffs.

This commit:
* Updates the PHPCSDevTools to version 1.2.0.
* Adds a new check against the XSD for all sniff XML Docs files.

Ref: https://github.com/PHPCSStandards/PHPCSDevTools/releases/tag/1.2.0

#### Sniff XML docs: add schema to docs

Includes minor tweaks to some of the titles.
Includes adding the `<?xml..?>` header if it didn't exist in the file.