### PR TITLE
GH Actions: harden the workflow against PHPCS ruleset errors

### DIFF
--- a/.github/workflows/ruleset-checks-sniffs.yml
+++ b/.github/workflows/ruleset-checks-sniffs.yml
@@ -66,10 +66,11 @@ jobs:
       # @link https://github.com/WordPress/WordPress-Coding-Standards
       # @link http://pear.php.net/package/PHP_CodeSniffer/
       - name: Run PHPCS ignoring warnings
-        continue-on-error: true
+        id: phpcs
         run: vendor/bin/phpcs --runtime-set ignore_warnings_on_exit 1 --report-full --report-checkstyle=./phpcs-report.xml
 
       - name: Show PHPCS results in PR
+        if: ${{ always() && steps.phpcs.outcome == 'failure' }}
         run: cs2pr ./phpcs-report.xml --graceful-warnings
 
       # Validate the Ruleset XML files.


### PR DESCRIPTION
If there is a ruleset error, the `cs2pr` action doesn't receive an `xml` report and exits with a `0` error code, even though the PHPCS run failed (though not on CS errors, but on a ruleset error).

This changes the GH Actions workflow to allow for that situation and still fail the build in that case.