### PR TITLE
Update for PHPCSUtils 1.0.0-alpha4

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -36,7 +36,7 @@ When you introduce new `public` sniff properties, or your sniff extends a class 
 
 ## Pre-requisites
 * WordPress-Coding-Standards
-* PHP_CodeSniffer 3.7.0 or higher
+* PHP_CodeSniffer 3.7.1 or higher
 * PHPUnit 4.x, 5.x, 6.x or 7.x
 
 The WordPress Coding Standards use the `PHP_CodeSniffer` native unit test suite for unit testing the sniffs.

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -36,9 +36,9 @@ jobs:
         phpcs_version: [ 'dev-master' ]
         include:
           - php: '7.3'
-            phpcs_version: '3.7.0'
+            phpcs_version: '3.7.1'
           - php: '5.4'
-            phpcs_version: '3.7.0'
+            phpcs_version: '3.7.1'
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/ruleset-checks-sniffs.yml
+++ b/.github/workflows/ruleset-checks-sniffs.yml
@@ -120,7 +120,7 @@ jobs:
     strategy:
       matrix:
         php: [ '7.4' ]
-        phpcs_version: [ 'dev-master', '3.7.0' ]
+        phpcs_version: [ 'dev-master', '3.7.1' ]
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       matrix:
         php: [ '8.1', '8.0', '7.4', '7.3', '7.2', '7.1', '7.0', '5.6', '5.5', '5.4' ]
-        phpcs_version: [ 'dev-master', '3.7.0' ]
+        phpcs_version: [ 'dev-master', '3.7.1' ]
         allowed_failure: [ false ]
         include:
           # Add extra build to test against PHPCS 4.

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ This project is a collection of [PHP_CodeSniffer](https://github.com/squizlabs/P
 
 ### Requirements
 
-The WordPress Coding Standards require PHP 5.4 or higher and [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) version **3.7.0** or higher.
+The WordPress Coding Standards require PHP 5.4 or higher and [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) version **3.7.1** or higher.
 
 ### Composer
 

--- a/WordPress/Sniffs/WP/CronIntervalSniff.php
+++ b/WordPress/Sniffs/WP/CronIntervalSniff.php
@@ -98,7 +98,7 @@ class CronIntervalSniff extends Sniff {
 			return;
 		}
 
-		$callback = PassedParameters::getParameter( $this->phpcsFile, $functionPtr, 2 );
+		$callback = PassedParameters::getParameter( $this->phpcsFile, $functionPtr, 2, 'callback' );
 		if ( false === $callback ) {
 			return;
 		}

--- a/WordPress/Sniffs/WP/EnqueuedResourcesSniff.php
+++ b/WordPress/Sniffs/WP/EnqueuedResourcesSniff.php
@@ -36,7 +36,7 @@ class EnqueuedResourcesSniff extends Sniff {
 	 * @return array
 	 */
 	public function register() {
-		$targets   = Collections::$textStingStartTokens;
+		$targets   = Collections::textStringStartTokens();
 		$targets[] = \T_INLINE_HTML;
 
 		return $targets;

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
 	],
 	"require": {
 		"php": ">=5.4",
-		"squizlabs/php_codesniffer": "^3.7.0",
+		"squizlabs/php_codesniffer": "^3.7.1",
 		"phpcsstandards/phpcsutils": "^1.0",
 		"phpcsstandards/phpcsextra": "^1.0"
 	},


### PR DESCRIPTION
**_Note: this is a minimal update to get rid of some deprecations and such. Once this has been merged, a lot more PRs will follow which will actually implement the new functionality from PHPCSUtils 1.0.0-alpha4._**

Ref: https://github.com/PHPCSStandards/PHPCSUtils/releases/tag/1.0.0-alpha4


### Composer: up the minimum PHPCS version to 3.7.1

Follow up on #2058

The minimum PHPCS version for PHPCSUtils 1.0.0 will be 3.7.1, so the minimum PHPCS version for WPCS should be in line with that.

The difference between 3.7.0 and 3.7.1 is very small. They were released just days apart with 3.7.1 fixing a pertinent bug in the retokenization of reserved keywords, which was updated in PHPCS 3.7.0.

Includes updating the GH Actions matrixes for this change.

### EnqueuedResourcesSniff: use Collections method instead of property

All the `Collections` class properties have been deprecated in PHPCSUtils 1.0.0-alpha4 in favour of methods with the same name, due to too many new tokens being introduced in PHP itself and the properties therefor not being a viable path for the future.

### CronInterval: add the parameter name to allow for named parameters

PHPCSUtils 1.0.0-alpha4 supports named parameters in the `PassedParameters` class, but requires for the parameter name to be passed either as a string or an array (of multiple names in case of a renamed parameter).

The `CronInterval` sniff not passing the parameter name would cause the tests to fail - even when the tests do not contain a test for named parameters yet -, so let's fix the function call.

Note: this doesn't add proper support for named parameters to the sniff yet. That will be addressed later.