### PR TITLE
TextStringHelper: remove the strip_interpolated_variables() method

### DIFF
--- a/WordPress/Helpers/TextStringHelper.php
+++ b/WordPress/Helpers/TextStringHelper.php
@@ -21,20 +21,10 @@ namespace WordPressCS\WordPress\Helpers;
  * the future by functions from PHPCSUtils.}
  *
  * @package WPCS\WordPressCodingStandards
- * @since   3.0.0 The constant and methods in this class were previously contained in the
- *                `WordPressCS\WordPress\Sniff` class and have been moved here.
+ * @since   3.0.0 The method in this class was previously contained in the
+ *                `WordPressCS\WordPress\Sniff` class and has been moved here.
  */
 final class TextStringHelper {
-
-	/**
-	 * Regex to get complex variables from T_DOUBLE_QUOTED_STRING or T_HEREDOC.
-	 *
-	 * @since 0.14.0
-	 * @since 3.0.0  Moved from the Sniff class to this class.
-	 *
-	 * @var string
-	 */
-	const REGEX_COMPLEX_VARS = '`(?:(\{)?(?<!\\\\)\$)?(\{)?(?<!\\\\)\$(\{)?(?P<varname>[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*)(?:->\$?(?P>varname)|\[[^\]]+\]|::\$?(?P>varname)|\([^\)]*\))*(?(3)\}|)(?(2)\}|)(?(1)\}|)`';
 
 	/**
 	 * Get the interpolated variable names from a string.
@@ -59,26 +49,5 @@ final class TextStringHelper {
 			}
 		}
 		return $variables;
-	}
-
-	/**
-	 * Strip variables from an arbitrary double quoted/heredoc string.
-	 *
-	 * Intended for use with the contents of a T_DOUBLE_QUOTED_STRING or T_HEREDOC token.
-	 *
-	 * @since 0.14.0
-	 * @since 3.0.0 - Moved from the Sniff class to this class.
-	 *              - The method was made `static`.
-	 *
-	 * @param string $string The raw string.
-	 *
-	 * @return string String without variables in it.
-	 */
-	public static function strip_interpolated_variables( $string ) {
-		if ( strpos( $string, '$' ) === false ) {
-			return $string;
-		}
-
-		return preg_replace( self::REGEX_COMPLEX_VARS, '', $string );
 	}
 }

--- a/WordPress/Sniffs/DB/PreparedSQLPlaceholdersSniff.php
+++ b/WordPress/Sniffs/DB/PreparedSQLPlaceholdersSniff.php
@@ -275,7 +275,7 @@ class PreparedSQLPlaceholdersSniff extends Sniff {
 				|| \T_HEREDOC === $this->tokens[ $i ]['code']
 			) {
 				// Only interested in actual query text, so strip out variables.
-				$stripped_content = TextStringHelper::strip_interpolated_variables( $content );
+				$stripped_content = TextStrings::stripEmbeds( $content );
 				if ( $stripped_content !== $content ) {
 					$interpolated_vars = TextStringHelper::get_interpolated_variables( $content );
 					$vars_without_wpdb = array_diff( $interpolated_vars, array( 'wpdb' ) );

--- a/WordPress/Sniffs/NamingConventions/ValidPostTypeSlugSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidPostTypeSlugSniff.php
@@ -12,7 +12,6 @@ namespace WordPressCS\WordPress\Sniffs\NamingConventions;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\Utils\TextStrings;
 use WordPressCS\WordPress\AbstractFunctionParameterSniff;
-use WordPressCS\WordPress\Helpers\TextStringHelper;
 
 /**
  * Validates post type names.
@@ -163,7 +162,7 @@ class ValidPostTypeSlugSniff extends AbstractFunctionParameterSniff {
 				'PartiallyDynamic',
 				$data
 			);
-			$post_type = TextStringHelper::strip_interpolated_variables( $post_type );
+			$post_type = TextStrings::stripEmbeds( $post_type );
 		}
 
 		if ( preg_match( self::VALID_POST_TYPE_CHARACTERS, $post_type ) === 0 ) {

--- a/WordPress/Tests/NamingConventions/ValidPostTypeSlugUnitTest.inc
+++ b/WordPress/Tests/NamingConventions/ValidPostTypeSlugUnitTest.inc
@@ -50,3 +50,7 @@ register_post_type( "my-own-post-type-too-long-{$i}" ); // 1x Error, Too long. 1
 register_post_type( 'my/own/post/type/too/long', array() ); // Bad. Invalid chars: "/" and too long.
 
 register_post_type( 'wp_block', array() ); // Bad. Must only error on reserved keyword, not invalid prefix.
+
+// Test handling of more complex embedded variables and expressions.
+register_post_type("testing123-${(foo)}-test");
+register_post_type("testing123-${foo["${bar['baz']}"]}-test");

--- a/WordPress/Tests/NamingConventions/ValidPostTypeSlugUnitTest.php
+++ b/WordPress/Tests/NamingConventions/ValidPostTypeSlugUnitTest.php
@@ -71,6 +71,8 @@ class ValidPostTypeSlugUnitTest extends AbstractSniffUnitTest {
 			40 => 1,
 			45 => 1,
 			49 => 1,
+			55 => 1,
+			56 => 1,
 		);
 	}
 }


### PR DESCRIPTION
... in favour of the significantly more comprehensive PHPCSUtils `TextStrings::stripEmbeds()` method.

This improves the handling of embedded variables in double quoted strings (and consequently fixes some bugs).

Bug confirmed via the tests added to the `ValidPostTypeSlug` sniff.

Without this fix, the "text stripped of embeds" for these test cases would look like this:
```
string(24) "testing123-${(foo)}-test"
string(19) "testing123-"]}-test"
```

I.e. the embeds wouldn't be, or wouldn't be completely, stripped.

With the fix, the embeds in both texts are correctly stripped, resulting in:
```
string(16) "testing123--test"
```

As for the sniff, for the `ValidPostTypeSlug` sniff, the bug meant that the sniff would report three false positives:
```
 55 | ERROR   | register_post_type() called with invalid post type "testing123-${(foo)}-test". Post type contains invalid characters. Only lowercase
    |         | alphanumeric characters, dashes, and underscores are allowed.
 55 | ERROR   | A post type slug must not exceed 20 characters. Found: "testing123-${(foo)}-test" (24 characters).
 56 | ERROR   | register_post_type() called with invalid post type "testing123-${foo["${bar['baz']}"]}-test". Post type contains invalid characters.
    |         | Only lowercase alphanumeric characters, dashes, and underscores are allowed.
```

These are all fixed now.