### PR TITLE
Sniff::is_foreach_as(): switch over to the PHPCSUtils version

### DIFF
--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -2006,41 +2006,6 @@ abstract class Sniff implements PHPCS_Sniff {
 	}
 
 	/**
-	 * Determine if a variable is in the `as $key => $value` part of a foreach condition.
-	 *
-	 * @since 1.0.0
-	 * @since 1.1.0 Moved from the PrefixAllGlobals sniff to the Sniff base class.
-	 *
-	 * @param int $stackPtr Pointer to the variable.
-	 *
-	 * @return bool True if it is. False otherwise.
-	 */
-	protected function is_foreach_as( $stackPtr ) {
-		if ( ! isset( $this->tokens[ $stackPtr ]['nested_parenthesis'] ) ) {
-			return false;
-		}
-
-		$nested_parenthesis = $this->tokens[ $stackPtr ]['nested_parenthesis'];
-		$close_parenthesis  = end( $nested_parenthesis );
-		$open_parenthesis   = key( $nested_parenthesis );
-		if ( ! isset( $this->tokens[ $close_parenthesis ]['parenthesis_owner'] ) ) {
-			return false;
-		}
-
-		if ( \T_FOREACH !== $this->tokens[ $this->tokens[ $close_parenthesis ]['parenthesis_owner'] ]['code'] ) {
-			return false;
-		}
-
-		$as_ptr = $this->phpcsFile->findNext( \T_AS, ( $open_parenthesis + 1 ), $close_parenthesis );
-		if ( false === $as_ptr ) {
-			// Should never happen.
-			return false;
-		}
-
-		return ( $stackPtr > $as_ptr );
-	}
-
-	/**
 	 * Get a list of the token pointers to the variables being assigned to in a list statement.
 	 *
 	 * @internal No need to take special measures for nested lists. Nested or not,

--- a/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
+++ b/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
@@ -11,6 +11,7 @@ namespace WordPressCS\WordPress\Sniffs\NamingConventions;
 
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\BackCompat\Helper;
+use PHPCSUtils\Utils\Context;
 use PHPCSUtils\Utils\Lists;
 use PHPCSUtils\Utils\MessageHelper;
 use PHPCSUtils\Utils\Namespaces;
@@ -629,7 +630,7 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 		 */
 		if ( false === $in_list
 			&& false === $this->is_assignment( $stackPtr )
-			&& false === $this->is_foreach_as( $stackPtr )
+			&& Context::inForeachCondition( $this->phpcsFile, $stackPtr ) !== 'afterAs'
 		) {
 			return;
 		}

--- a/WordPress/Sniffs/WP/GlobalVariablesOverrideSniff.php
+++ b/WordPress/Sniffs/WP/GlobalVariablesOverrideSniff.php
@@ -10,6 +10,7 @@
 namespace WordPressCS\WordPress\Sniffs\WP;
 
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Utils\Context;
 use PHPCSUtils\Utils\Lists;
 use PHPCSUtils\Utils\Scopes;
 use PHPCSUtils\Utils\TextStrings;
@@ -265,7 +266,7 @@ class GlobalVariablesOverrideSniff extends Sniff {
 		 */
 		if ( false === $in_list
 			&& false === $this->is_assignment( $stackPtr )
-			&& false === $this->is_foreach_as( $stackPtr )
+			&& Context::inForeachCondition( $this->phpcsFile, $stackPtr ) !== 'afterAs'
 		) {
 			return;
 		}
@@ -418,7 +419,7 @@ class GlobalVariablesOverrideSniff extends Sniff {
 			}
 
 			// Check if this is a variable assignment within a `foreach()` declaration.
-			if ( $this->is_foreach_as( $ptr ) === true ) {
+			if ( Context::inForeachCondition( $this->phpcsFile, $ptr ) === 'afterAs' ) {
 				$this->add_error( $ptr );
 			}
 		}


### PR DESCRIPTION
PHPCSUtils 1.0.0-alpha4 has a new `Context` class containing a more versatile method for the same, so we can now switch out the WPCS native method for the PHPCSUtils one.

Ref: https://phpcsutils.com/phpdoc/classes/PHPCSUtils-Utils-Context.html#method_inForeachCondition