### PR TITLE
WPCS-Extra: enable the `Generic.CodeAnalysis.UnusedFunctionParameter` sniff

### DIFF
--- a/WordPress-Extra/ruleset.xml
+++ b/WordPress-Extra/ruleset.xml
@@ -48,13 +48,23 @@
 	</rule>
 
 	<!-- Check correct spacing of language constructs. This also ensures that the
-	     above rule for not using brackets with require is fixed correctly.
+		 above rule for not using brackets with require is fixed correctly.
 		 https://github.com/WordPress/WordPress-Coding-Standards/issues/1153 -->
 	<rule ref="Generic.WhiteSpace.LanguageConstructSpacing"/>
 
-	<!-- Hook callbacks may not use all params -->
-	<!-- https://github.com/WordPress/WordPress-Coding-Standards/pull/382#discussion_r29981655 -->
-	<!--<rule ref="Generic.CodeAnalysis.UnusedFunctionParameter"/>-->
+	<!-- Check that functions use all parameters passed.
+		 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/pull/xxx -->
+	<rule ref="Generic.CodeAnalysis.UnusedFunctionParameter">
+		<!-- Allow for callback functions which may not need all parameters passed. -->
+		<exclude name="Generic.CodeAnalysis.UnusedFunctionParameter.FoundBeforeLastUsed"/>
+		<!-- Allow for functions in extended classes/implemented interfaces. -->
+		<exclude name="Generic.CodeAnalysis.UnusedFunctionParameter.FoundInExtentedClass"/>
+		<exclude name="Generic.CodeAnalysis.UnusedFunctionParameter.FoundInExtentedClassBeforeLastUsed"/>
+		<exclude name="Generic.CodeAnalysis.UnusedFunctionParameter.FoundInExtentedClassAfterLastUsed"/>
+		<exclude name="Generic.CodeAnalysis.UnusedFunctionParameter.FoundInImplementedInterface"/>
+		<exclude name="Generic.CodeAnalysis.UnusedFunctionParameter.FoundInImplementedInterfaceBeforeLastUsed"/>
+		<exclude name="Generic.CodeAnalysis.UnusedFunctionParameter.FoundInImplementedInterfaceAfterLastUsed"/>
+	</rule>
 
 	<!-- Verify modifier keywords for declared methods and properties in classes.
 		 https://github.com/WordPress/WordPress-Coding-Standards/issues/1101 -->


### PR DESCRIPTION
The reason why the sniff was disabled up to now was that WP uses callbacks a lot and the hooked in functions may not use all parameters passed to them.

This concern was previously raised in https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/pull/382#discussion_r29981655, also see https://github.com/WordPress/WordPress-Coding-Standards/pull/382/commits/522b35f3ebac915d6eebb92624fc703c193aee60

To this end, I've send in a [PR upstream](https://github.com/squizlabs/PHP_CodeSniffer/pull/1318) to address these concerns, which has subsequently been merged. The adjusted version of the sniff was released in PHPCS 3.4.0, which means the sniff can now be added.

Note: the sniff has since then also been adjusted to handle arrow functions correctly, as well as constructor property promotion.

Fixes #1510