### PR TITLE
Core: move rules related to include/require statements from `Extra` to `Core`

### DIFF
--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -66,6 +66,31 @@
 
 	<!--
 	#############################################################################
+	Handbook: General - Writing include/require statements.
+	Ref: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#single-and-double-quotes
+	#############################################################################
+	-->
+
+	<!-- Covers rule: include[_once] and require[_once] are language constructs, they do
+		 not need parentheses around the path, so those shouldn't be used. -->
+	<rule ref="PEAR.Files.IncludingFile.BracketsNotRequired"/>
+
+	<!-- Covers rule: There should only be one space between the path and the include/require keywords.
+		 Note: the sniff covers more language constructs than just include/require. While not in the handbook,
+		 WP Core already complies with this, so we may as well enforce it.  -->
+	<rule ref="Generic.WhiteSpace.LanguageConstructSpacing"/>
+
+	<!-- Covers rule: It is strongly recommended to use require[_once] for unconditional includes. -->
+	<rule ref="PEAR.Files.IncludingFile.UseRequire">
+		<type>warning</type>
+	</rule>
+	<rule ref="PEAR.Files.IncludingFile.UseRequireOnce">
+		<type>warning</type>
+	</rule>
+
+
+	<!--
+	#############################################################################
 	Handbook: Naming - Naming Conventions.
 	Ref: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#naming-conventions
 	#############################################################################

--- a/WordPress-Extra/ruleset.xml
+++ b/WordPress-Extra/ruleset.xml
@@ -35,23 +35,6 @@
 		 https://github.com/WordPress/WordPress-Coding-Standards/pull/809 -->
 	<rule ref="Squiz.PHP.DisallowSizeFunctionsInLoops"/>
 
-	<!-- And yet more best practices.
-		 https://github.com/WordPress/WordPress-Coding-Standards/issues/1143 -->
-	<rule ref="PEAR.Files.IncludingFile.BracketsNotRequired">
-		<type>warning</type>
-	</rule>
-	<rule ref="PEAR.Files.IncludingFile.UseRequire">
-		<type>warning</type>
-	</rule>
-	<rule ref="PEAR.Files.IncludingFile.UseRequireOnce">
-		<type>warning</type>
-	</rule>
-
-	<!-- Check correct spacing of language constructs. This also ensures that the
-		 above rule for not using brackets with require is fixed correctly.
-		 https://github.com/WordPress/WordPress-Coding-Standards/issues/1153 -->
-	<rule ref="Generic.WhiteSpace.LanguageConstructSpacing"/>
-
 	<!-- Check that functions use all parameters passed.
 		 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/pull/xxx -->
 	<rule ref="Generic.CodeAnalysis.UnusedFunctionParameter">


### PR DESCRIPTION
> 1. No parentheses shall be used for `include[_once]` and `require[_once]` statements.
>    As `include[_once]` and `require[_once]` are language constructs, they do not need parentheses around the path.
> 2. There should be exactly one space between the `include[_once]` and `require[_once]` keyword and the start of the path.
> 3. It is strongly recommended to use `require[_once]` for unconditional includes.
>    When using `include[_once]` PHP will throw a warning when the file is not found, but will continue execution which will almost certainly lead to other errors/warnings/notices being thrown if your application depends on the file being available, potentially leading to security leaks. For that reason, `require[_once]` is generally the better choice as it will throw a Fatal Error if the file cannot be found.

Refs:
* https://make.wordpress.org/core/2020/03/20/updating-the-coding-standards-for-modern-php/ - Include/Require section
* https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#writing-include-require-statements
* WordPress/wpcs-docs#111
* WordPress/WordPress-Coding-Standards#1007
* WordPress/WordPress-Coding-Standards#1143
* WordPress/WordPress-Coding-Standards#1145
* WordPress/WordPress-Coding-Standards#1153
* WordPress/WordPress-Coding-Standards#1163

Closes #1862