### PR TITLE
Core: add sniffs to check there is no blank line before a function close brace

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -30,8 +30,6 @@
 		</properties>
 	</rule>
 
-	<rule ref="PSR2.Methods.FunctionClosingBrace"/>
-
 	<!-- Check code for cross-version PHP compatibility. -->
 	<config name="testVersion" value="5.4-"/>
 	<rule ref="PHPCompatibility">

--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -294,6 +294,10 @@
 	<!-- Covers rule: Omitting the closing PHP tag at the end of a file is preferred. -->
 	<rule ref="PSR2.Files.ClosingTag"/>
 
+	<!-- Covers rule: There should be no trailing blank lines at the end of a function body. -->
+	<rule ref="PSR2.Methods.FunctionClosingBrace"/>
+
+
 	<!--
 	#############################################################################
 	Handbook: Formatting - Brace Style.


### PR DESCRIPTION
> 1. There should be no blank line between the content of a function and the function’s closing brace.

Includes removing this rule from the WPCS native ruleset in which we already enforced it (as it will now be inherited from the `WordPress` ruleset).

Refs:
* https://make.wordpress.org/core/2020/03/20/updating-the-coding-standards-for-modern-php/ - Function closing brace section
* https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#remove-trailing-spaces
* https://github.com/WordPress/wpcs-docs/pull/110

Loosely related to #1101