### PR TITLE
Core: remove custom message for `OneObjectStructurePerFile` sniff

### DIFF
--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -339,9 +339,7 @@
 	#############################################################################
 	-->
 	<!-- Covers rule: Only One Object Structure (Class/Interface/Trait) per file. -->
-	<rule ref="Generic.Files.OneObjectStructurePerFile">
-		<message>Best practices: Declare only one class/interface/trait in a file.</message>
-	</rule>
+	<rule ref="Generic.Files.OneObjectStructurePerFile"/>
 
 
 	<!--


### PR DESCRIPTION
As this rule is now in the handbook and has been explicitly listed in the Make post from March 2020, the error message should not look like a recommendation, but like the error which it is.

The standard message from the upstream sniff reads: "Only one object structure is allowed in a file".

Note: the upstream sniff we're using has been updated already to include PHP 8.1 `enum`s.

Refs:
* https://make.wordpress.org/core/2020/03/20/updating-the-coding-standards-for-modern-php/ - One class-like definition per file section
* https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#only-one-object-structure-class-interface-trait-per-file
* WordPress/WordPress-Coding-Standards#1802
* WordPress/wpcs-docs#52