### PR TITLE
Core: add sniff to check spacing around spread operators

### DIFF
--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -170,6 +170,9 @@
 	<rule ref="Squiz.Functions.FunctionDeclarationArgumentSpacing.SpacingBeforeClose">
 		<severity>0</severity>
 	</rule>
+	<rule ref="Squiz.Functions.FunctionDeclarationArgumentSpacing.SpacingAfterVariadic">
+		<severity>0</severity>
+	</rule>
 
 
 	<!-- Covers rule: Call a function, like so: my_function( $param1, func_param( $param2 ) ); -->
@@ -334,6 +337,23 @@
 	<!-- Rule: Each parameter must take up no more than a single line. Multi-line parameter
 		 values must be assigned to a variable and then that variable should be passed to the function call.
 		 https://github.com/WordPress/WordPress-Coding-Standards/issues/1330 -->
+
+
+	<!--
+	#############################################################################
+	Handbook: Formatting - Spread operator.
+	Ref: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#spread-operator
+	#############################################################################
+	-->
+	<!-- Covers rule: When using the spread operator, there should be one space or a new line
+		 with the appropriate indentation before the spread operator. -->
+	<!-- Covered by a variety of sniffs which deal with function calls, function declarations, array declarations. -->
+
+	<!-- Covers rule: There should be no spaces between the spread operator and the variable/function call it applies to. -->
+	<rule ref="Generic.WhiteSpace.SpreadOperatorSpacingAfter"/>
+
+	<!-- Covers rule: When combining the spread operator with the reference operator (&), there should be no spaces between them.. -->
+	<!-- Covered by the Squiz.Functions.FunctionDeclarationArgumentSpacing.SpacingAfterReference error code. -->
 
 
 	<!--


### PR DESCRIPTION
> 1. There should be one space, or a new line + appropriate indentation, before the spread operator.
> 2. There should be no space between the spread operator and the variable/function call it applies to.
> 3. When combining the spread operator with the reference operator, there should be no space between them.

Includes excluding a particular error code from the `Squiz.Functions.FunctionDeclarationArgumentSpacing` sniff to prevent duplicate messages about the same thing.

Refs:
* https://make.wordpress.org/core/2020/03/20/updating-the-coding-standards-for-modern-php/ - Operators section
* https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#spread-operator
* WordPress/wpcs-docs#105
* WordPress/WordPress-Coding-Standards#1762
* squizlabs/PHP_CodeSniffer#2548

Fixes #1762

Also note: there are currently two PRs open in PHPCS upstream for the `Generic.WhiteSpace.SpreadOperatorSpacingAfter` sniff:
* The first -  squizlabs/PHP_CodeSniffer#3647 - is inconsequential as it only involves a message tweak.
* The second - squizlabs/PHP_CodeSniffer#3694 - is related to PHP 8.1 first class callables and will prevent the sniff from triggering on those.