### PR TITLE
Core: move rules related to explicit property/method visibility from `Extra` to `Core`

### DIFF
--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -348,6 +348,27 @@
 
 	<!--
 	#############################################################################
+	Handbook: Object-Oriented Programming - Visibility should always be declared.
+	Ref: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#visibility-should-always-be-declared
+	#############################################################################
+	-->
+	<!-- Covers rule: For all constructs that allow it (properties, methods, class constants since PHP 7.1),
+		 visibility should be explicitly declared. -->
+	<rule ref="PSR2.Classes.PropertyDeclaration"/>
+	<rule ref="PSR2.Classes.PropertyDeclaration.Underscore">
+		<severity>0</severity>
+	</rule>
+	<rule ref="PSR2.Classes.PropertyDeclaration.Multiple">
+		<severity>0</severity>
+	</rule>
+	<rule ref="Squiz.Scope.MethodScope"/>
+
+	<!-- Covers rule: Using the var keyword for property declarations is not allowed. -->
+	<!-- Covered by the PSR2.Classes.PropertyDeclaration sniff. -->
+
+
+	<!--
+	#############################################################################
 	Handbook: Control Structures - Use elseif, not else if.
 	Ref: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#use-elseif-not-else-if
 	#############################################################################

--- a/WordPress-Extra/ruleset.xml
+++ b/WordPress-Extra/ruleset.xml
@@ -51,10 +51,20 @@
 
 	<!-- Verify modifier keywords for declared methods and properties in classes.
 		 https://github.com/WordPress/WordPress-Coding-Standards/issues/1101 -->
-	<rule ref="Squiz.Scope.MethodScope"/>
-	<rule ref="PSR2.Classes.PropertyDeclaration"/>
 	<rule ref="Squiz.WhiteSpace.ScopeKeywordSpacing"/>
 	<rule ref="PSR2.Methods.MethodDeclaration"/>
+
+	<!-- Do not allow leading underscores in property or method names. Visibility should be used instead.
+		 https://github.com/WordPress/WordPress-Coding-Standards/issues/1101 -->
+	<rule ref="PSR2.Classes.PropertyDeclaration.Underscore">
+		<severity>5</severity>
+	</rule>
+
+	<!-- Do not allow multi-property declarations.
+		 https://github.com/WordPress/WordPress-Coding-Standards/issues/1101 -->
+	<rule ref="PSR2.Classes.PropertyDeclaration.Multiple">
+		<severity>5</severity>
+	</rule>
 
 	<!-- Warn against using fully-qualified class names instead of the self keyword. -->
 	<rule ref="Squiz.Classes.SelfMemberReference.NotUsed">


### PR DESCRIPTION
> 1. For all constructs which allow it (properties, methods), visibility should be explicitly declared.
> 2. Using the var keyword for property declarations is not allowed.

The `PSR2.Classes.PropertyDeclaration` sniff contains a multitude of checks, amongst which two error codes which IMO should probably not (yet) go into the `Core` ruleset.
* `Underscore` - which warns against prefixing a property name with an underscore, advising to use visibility instead. While I'm 100% in favour of this, introducing this for WP Core would be problematic as renaming (`public`/`protected`) properties would be a BC-break.
* `Multiple` - which throws an error for multi-property declarations. I have excluded it as it is not something which is explicitly forbidden in the handbook, nor was it mentioned in the Make post. Having said that, I have scanned WP Core with this check in place and it would not yield any issues, so "silently" introducing it should not be a problem.

As these rules were previously already included in the `Extra` ruleset, those error code which are being silenced for `Core`, will be "unsilenced" again for `Extra`.

Refs:
* https://make.wordpress.org/core/2020/03/20/updating-the-coding-standards-for-modern-php/ - Visibility should always be declared section
* https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#visibility-should-always-be-declared
* WordPress/wpcs-docs#107
* WordPress/WordPress-Coding-Standards#1101
* WordPress/WordPress-Coding-Standards#1103