### PR TITLE
Core: add initial sniffs for modifier keyword ordering rules

### DIFF
--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -417,6 +417,9 @@
 		<severity>0</severity>
 	</rule>
 
+	<!-- Implied through the examples: Single space after each modifier keyword. -->
+	<rule ref="Squiz.WhiteSpace.ScopeKeywordSpacing"/>
+
 
 	<!--
 	#############################################################################

--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -389,6 +389,37 @@
 
 	<!--
 	#############################################################################
+	Handbook: Object-Oriented Programming - Visibility and modifier order.
+	Ref: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#visibility-and-modifier-order
+	#############################################################################
+	-->
+	<!-- Rule: When using multiple modifiers for a class declaration, the order should be as follows:
+		 - First the optional abstract or final modifier.
+		 - Next, the optional readonly modifier. -->
+
+	<!-- Rule: When using multiple modifiers for a constant declaration inside object-oriented structures,
+		 the order should be as follows:
+		 - First the optional final modifier.
+		 - Next, the visibility modifier. -->
+
+	<!-- Covers rule: When using multiple modifiers for a property declaration, the order should be as follows:
+		 - First a visibility modifier.
+		 - Next, the optional static or readonly modifier (these keywords are mutually exclusive).
+		 - Finally, the optional type declaration. -->
+	<!-- Covered by the PSR2.Classes.PropertyDeclaration sniff. -->
+
+	<!-- Covers rule: When using multiple modifiers for a method declaration, the order should be as follows:
+		 - First the optional abstract or final modifier.
+		 - Then, a visibility modifier.
+		 - Finally, the optional static modifier. -->
+	<rule ref="PSR2.Methods.MethodDeclaration"/>
+	<rule ref="PSR2.Methods.MethodDeclaration.Underscore">
+		<severity>0</severity>
+	</rule>
+
+
+	<!--
+	#############################################################################
 	Handbook: Control Structures - Use elseif, not else if.
 	Ref: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#use-elseif-not-else-if
 	#############################################################################

--- a/WordPress-Extra/ruleset.xml
+++ b/WordPress-Extra/ruleset.xml
@@ -49,10 +49,6 @@
 		<exclude name="Generic.CodeAnalysis.UnusedFunctionParameter.FoundInImplementedInterfaceAfterLastUsed"/>
 	</rule>
 
-	<!-- Verify modifier keywords for declared methods and properties in classes.
-		 https://github.com/WordPress/WordPress-Coding-Standards/issues/1101 -->
-	<rule ref="Squiz.WhiteSpace.ScopeKeywordSpacing"/>
-
 	<!-- Do not allow leading underscores in property or method names. Visibility should be used instead.
 		 https://github.com/WordPress/WordPress-Coding-Standards/issues/1101 -->
 	<rule ref="PSR2.Classes.PropertyDeclaration.Underscore">

--- a/WordPress-Extra/ruleset.xml
+++ b/WordPress-Extra/ruleset.xml
@@ -52,11 +52,13 @@
 	<!-- Verify modifier keywords for declared methods and properties in classes.
 		 https://github.com/WordPress/WordPress-Coding-Standards/issues/1101 -->
 	<rule ref="Squiz.WhiteSpace.ScopeKeywordSpacing"/>
-	<rule ref="PSR2.Methods.MethodDeclaration"/>
 
 	<!-- Do not allow leading underscores in property or method names. Visibility should be used instead.
 		 https://github.com/WordPress/WordPress-Coding-Standards/issues/1101 -->
 	<rule ref="PSR2.Classes.PropertyDeclaration.Underscore">
+		<severity>5</severity>
+	</rule>
+	<rule ref="PSR2.Methods.MethodDeclaration.Underscore">
 		<severity>5</severity>
 	</rule>
 


### PR DESCRIPTION
### Core: move rules related to property/method modifier order from `Extra` to `Core`

> 1. When using multiple modifiers for a property or method declaration, the order should be as follows:
>     1. First the optional `abstract` or `final` keyword.
>     2. Next a visibility keyword.
>     3. Lastly, the optional `static` [red: or `readonly`] keyword.

For property declarations, this is already covered by the `PSR2.Classes.PropertyDeclaration` sniff.
For method declarations, the `PSR2.Methods.MethodDeclaration` sniff has now been moved from `Extra` to `Core`.

The `PSR2.Methods.MethodDeclaration` sniff contains one additional error code, which IMO should probably not (yet) go into the `Core` ruleset.
* `Underscore` - which warns against prefixing a method name with an underscore, advising to use visibility instead.
    While I'm 100% in favour of this, introducing this for WP Core would be problematic as renaming (`public`/`protected`) methods would be a BC-break.

As this rule was previously already included in the `Extra` ruleset, the error code which is being silenced for `Core`, will be "unsilenced" again for `Extra`.

The `PSR2.Classes.PropertyDeclaration` sniff does not yet account for ordering the visibility vs readonly keywords.
I have opened a PR upstream - squizlabs/PHP_CodeSniffer#3637 - proposing to add a check for this to the `PSR2.Classes.PropertyDeclaration` sniff.
* If that PR would be accepted, WPCS will automatically inherit the check and we'd be good.
* If that PR would be rejected, I propose to create a dedicated sniff in PHPCSExtra to handle property modifier keywords with configuration options for the preferred order.

Refs:
* https://make.wordpress.org/core/2020/03/20/updating-the-coding-standards-for-modern-php/ - Visibility should always be declared section
* https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#visibility-and-modifier-order
* WordPress/wpcs-docs#108
* WordPress/WordPress-Coding-Standards#1101
* WordPress/WordPress-Coding-Standards#1103
* squizlabs/PHP_CodeSniffer#3637

### Core: move last modifier keyword sniff from Extra to Core

While this was not explicitly mentioned in the Make post, it is implied (via the code samples) that there should be exactly one space after each modifier keyword for properties and methods.

This was already being checked for in `Extra`. I'm proposing to move this sniff to the `Core` ruleset.

Note: I've checked and introducing this sniff to the `Core` ruleset does not yield any issues for WP Core as is, so it would be a silent introduction.

Refs:
* WordPress/WordPress-Coding-Standards#1101