### PR TITLE
Core: move `BacktickOperator` sniff from `Extra` to `Core`

### DIFF
--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -561,6 +561,16 @@
 
 	<!--
 	#############################################################################
+	Handbook: Recommendations - Shell commands.
+	Ref: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#shell-commands
+	#############################################################################
+	-->
+	<!-- Covers rule: Use of the backtick operator is not allowed. -->
+	<rule ref="Generic.PHP.BacktickOperator"/>
+
+
+	<!--
+	#############################################################################
 	Not in the handbook: Generic sniffs.
 	#############################################################################
 	-->

--- a/WordPress-Extra/ruleset.xml
+++ b/WordPress-Extra/ruleset.xml
@@ -108,9 +108,6 @@
 		 https://github.com/WordPress/WordPress-Coding-Standards/issues/1146 -->
 	<rule ref="WordPress.WP.EnqueuedResourceParameters"/>
 
-	<!-- Discourage use of the backtick operator (execution of shell commands).
-		 https://github.com/WordPress/WordPress-Coding-Standards/pull/646 -->
-	<rule ref="Generic.PHP.BacktickOperator"/>
 
 	<!-- Check for PHP Parse errors.
 		 https://github.com/WordPress/WordPress-Coding-Standards/issues/522 -->


### PR DESCRIPTION
> 1. Use of the backtick operator is not allowed.

Refs:
* https://make.wordpress.org/core/2020/03/20/updating-the-coding-standards-for-modern-php/ - Shell Commands section
* https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#shell-commands
* WordPress/wpcs-docs#114
* WordPress/WordPress-Coding-Standards#646