### PR TITLE
Minimum version trait fix

### DIFF
--- a/WordPress/Helpers/MinimumWPVersionTrait.php
+++ b/WordPress/Helpers/MinimumWPVersionTrait.php
@@ -9,7 +9,6 @@
 
 namespace WordPressCS\WordPress\Helpers;
 
-use PHP_CodeSniffer\Files\File;
 use PHPCSUtils\BackCompat\Helper;
 
 /**
@@ -81,12 +80,9 @@ trait MinimumWPVersionTrait {
 	 * @since 0.14.0
 	 * @since 3.0.0  - Moved from the Sniff class to this dedicated Trait.
 	 *               - Renamed from `get_wp_version_from_cl()` to `get_wp_version_from_cli()`.
-	 *               - Now requires the $phpcsFile object to be passed in.
-	 *
-	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
 	 */
-	protected function get_wp_version_from_cli( File $phpcsFile ) {
-		$cli_supported_version = Helper::getCommandLineData( $phpcsFile, 'minimum_supported_wp_version' );
+	protected function get_wp_version_from_cli() {
+		$cli_supported_version = Helper::getConfigData( 'minimum_supported_wp_version' );
 
 		if ( empty( $cli_supported_version ) ) {
 			return;

--- a/WordPress/Sniffs/WP/AlternativeFunctionsSniff.php
+++ b/WordPress/Sniffs/WP/AlternativeFunctionsSniff.php
@@ -185,7 +185,7 @@ class AlternativeFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 	 */
 	public function process_matched_token( $stackPtr, $group_name, $matched_content ) {
 
-		$this->get_wp_version_from_cli( $this->phpcsFile );
+		$this->get_wp_version_from_cli();
 
 		/*
 		 * Deal with exceptions.

--- a/WordPress/Sniffs/WP/DeprecatedClassesSniff.php
+++ b/WordPress/Sniffs/WP/DeprecatedClassesSniff.php
@@ -97,7 +97,7 @@ class DeprecatedClassesSniff extends AbstractClassRestrictionsSniff {
 	 */
 	public function process_matched_token( $stackPtr, $group_name, $matched_content ) {
 
-		$this->get_wp_version_from_cli( $this->phpcsFile );
+		$this->get_wp_version_from_cli();
 
 		$class_name = ltrim( strtolower( $matched_content ), '\\' );
 

--- a/WordPress/Sniffs/WP/DeprecatedFunctionsSniff.php
+++ b/WordPress/Sniffs/WP/DeprecatedFunctionsSniff.php
@@ -1399,7 +1399,7 @@ class DeprecatedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 	 */
 	public function process_matched_token( $stackPtr, $group_name, $matched_content ) {
 
-		$this->get_wp_version_from_cli( $this->phpcsFile );
+		$this->get_wp_version_from_cli();
 
 		$function_name = strtolower( $matched_content );
 

--- a/WordPress/Sniffs/WP/DeprecatedParameterValuesSniff.php
+++ b/WordPress/Sniffs/WP/DeprecatedParameterValuesSniff.php
@@ -155,7 +155,7 @@ class DeprecatedParameterValuesSniff extends AbstractFunctionParameterSniff {
 	 * @return void
 	 */
 	public function process_parameters( $stackPtr, $group_name, $matched_content, $parameters ) {
-		$this->get_wp_version_from_cli( $this->phpcsFile );
+		$this->get_wp_version_from_cli();
 		$param_count = \count( $parameters );
 		foreach ( $this->target_functions[ $matched_content ] as $position => $parameter_args ) {
 

--- a/WordPress/Sniffs/WP/DeprecatedParametersSniff.php
+++ b/WordPress/Sniffs/WP/DeprecatedParametersSniff.php
@@ -284,7 +284,7 @@ class DeprecatedParametersSniff extends AbstractFunctionParameterSniff {
 	 */
 	public function process_parameters( $stackPtr, $group_name, $matched_content, $parameters ) {
 
-		$this->get_wp_version_from_cli( $this->phpcsFile );
+		$this->get_wp_version_from_cli();
 
 		$paramCount = \count( $parameters );
 		foreach ( $this->target_functions[ $matched_content ] as $position => $parameter_args ) {


### PR DESCRIPTION
Discovered while working on #2112 that the command line argument wasn't being picked up by the `getCommandLineData` helper in the `get_wp_version_from_cli` method.

@jrfnl and I did all the manual tests to confirm that nothing will break with this change.



