### PR TITLE
Group all the checks in one place and add script descriptions

### DIFF
--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -73,7 +73,7 @@ jobs:
 
       - name: Lint PHP files against parse errors
         if: ${{ matrix.phpcs_version == 'dev-master' }}
-        run: composer lint-ci
+        run: composer lint -- --checkstyle
 
       - name: Run unit tests
         run: composer run-tests

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -95,7 +95,7 @@ jobs:
 
       - name: Lint PHP files against parse errors
         if: ${{ matrix.phpcs_version == 'dev-master' }}
-        run: composer lint-ci | cs2pr
+        run: composer lint -- --checkstyle | cs2pr
 
       - name: Run the unit tests - PHP 5.4 - 8.0
         if: ${{ matrix.php < '8.1' }}

--- a/composer.json
+++ b/composer.json
@@ -39,17 +39,11 @@
 		"lint": [
 			"@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --show-deprecated --exclude vendor --exclude .git"
 		],
-		"lint-ci": [
-			"@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --show-deprecated --exclude vendor --exclude .git --checkstyle"
-		],
 		"check-cs": [
 			"@php ./vendor/squizlabs/php_codesniffer/bin/phpcs"
 		],
 		"fix-cs": [
 			"@php ./vendor/squizlabs/php_codesniffer/bin/phpcbf"
-		],
-		"install-codestandards": [
-			"Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin::run"
 		],
 		"run-tests": [
 			"@php ./vendor/phpunit/phpunit/phpunit --filter WordPress ./vendor/squizlabs/php_codesniffer/tests/AllTests.php"
@@ -59,7 +53,22 @@
 		],
 		"check-complete-strict": [
 			"@php ./vendor/phpcsstandards/phpcsdevtools/bin/phpcs-check-feature-completeness ./WordPress"
+		],
+		"check-all": [
+			"@lint",
+			"@check-cs",
+			"@run-tests",
+			"@check-complete-strict"
 		]
+	},
+	"scripts-descriptions": {
+		"lint": "Lint PHP files against parse errors.",
+		"check-cs": "Run the PHPCS script against the entire codebase.",
+		"fix-cs": "Run the PHPCBF script to fix all the autofixable violations on the codebase.",
+		"run-tests": "Run all the unit tests for the WordPress Coding Standards sniffs.",
+		"check-complete": "Check if all the sniffs have tests.",
+		"check-complete-strict": "Check if all the sniffs have unit tests and XML documentation.",
+		"check-all": "Run all checks (lint, phpcs, feature completeness) and tests."
 	},
 	"support": {
 		"issues": "https://github.com/WordPress/WordPress-Coding-Standards/issues",


### PR DESCRIPTION
Closes #2115.

The PR groups the checks that are useful to pass before the sniff is pushed to the repo for a PR.

It also adds a description of all the custom commands defined in the `scripts` section.

I'm not too happy about the `check-complete` description, as it's a bit long so I need to split it into two lines, which doesn't look too nice.

But I couldn't omit all the necessary information about what this command is doing 🤷🏼‍♂️ 

<img width="1160" alt="image" src="https://user-images.githubusercontent.com/8638515/204126907-997ceb14-e0ee-4da7-b082-442552cb6f36.png">
