### PR TITLE
:sparkles: New `WordPress.WP.ClassNameCase` sniff

### DIFF
--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -673,4 +673,7 @@
 	<!-- Don't use current_time() to retrieve a timestamp. -->
 	<rule ref="WordPress.DateTime.CurrentTimeTimestamp"/>
 
+	<!-- Check that class name references use the correct case. -->
+	<rule ref="WordPress.WP.ClassNameCase"/>
+
 </ruleset>

--- a/WordPress/Docs/WP/ClassNameCaseStandard.xml
+++ b/WordPress/Docs/WP/ClassNameCaseStandard.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Class Name Case"
+    >
+    <standard>
+    <![CDATA[
+    It is strongly recommended to refer to WP native classes by their properly cased name.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: reference to a WordPress native class name using the correct case.">
+        <![CDATA[
+$obj = new WP_Query;
+        ]]>
+        </code>
+        <code title="Invalid: reference to a WordPress native class name not using the correct case.">
+        <![CDATA[
+$obj = new wp_query;
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/WordPress/Sniffs/WP/ClassNameCaseSniff.php
+++ b/WordPress/Sniffs/WP/ClassNameCaseSniff.php
@@ -1,0 +1,416 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPressCS\WordPress\Sniffs\WP;
+
+use WordPressCS\WordPress\AbstractClassRestrictionsSniff;
+
+/**
+ * Verify whether references to WP native classes use the proper casing for the class name.
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since 3.0.0
+ */
+class ClassNameCaseSniff extends AbstractClassRestrictionsSniff {
+
+	/**
+	 * List of all WP native classes.
+	 *
+	 * To be updated after every major release.
+	 *
+	 * List is sorted alphabetically and based on the WIP autoloading PR.
+	 * {@link https://github.com/WordPress/wordpress-develop/pull/3470}
+	 *
+	 * Note: this list will be enhanced in the class constructor.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @var string[] The class names in their "proper" case.
+	 *               The constructor will add the lowercased class name as a key to each entry.
+	 */
+	private $wp_classes = array(
+		'_WP_Dependency',
+		'_WP_Editors',
+		'_WP_List_Table_Compat',
+		'Automatic_Upgrader_Skin',
+		'Bulk_Plugin_Upgrader_Skin',
+		'Bulk_Theme_Upgrader_Skin',
+		'Bulk_Upgrader_Skin',
+		'Core_Upgrader',
+		'Custom_Background',
+		'Custom_Image_Header',
+		'File_Upload_Upgrader',
+		'ftp_pure',
+		'ftp_sockets',
+		'Gettext_Translations',
+		'IXR_Base64',
+		'IXR_Client',
+		'IXR_ClientMulticall',
+		'IXR_Date',
+		'IXR_Error',
+		'IXR_IntrospectionServer',
+		'IXR_Message',
+		'IXR_Request',
+		'IXR_Server',
+		'IXR_Value',
+		'Language_Pack_Upgrader',
+		'Language_Pack_Upgrader_Skin',
+		'MO',
+		'NOOP_Translations',
+		'Plugin_Installer_Skin',
+		'Plugin_Upgrader',
+		'Plugin_Upgrader_Skin',
+		'Plural_Forms',
+		'PO',
+		'POMO_CachedFileReader',
+		'POMO_CachedIntFileReader',
+		'POMO_FileReader',
+		'POMO_Reader',
+		'POMO_StringReader',
+		'Theme_Installer_Skin',
+		'Theme_Upgrader',
+		'Theme_Upgrader_Skin',
+		'Translation_Entry',
+		'Translations',
+		'Walker',
+		'Walker_Category',
+		'Walker_Category_Checklist',
+		'Walker_CategoryDropdown',
+		'Walker_Comment',
+		'Walker_Nav_Menu',
+		'Walker_Nav_Menu_Checklist',
+		'Walker_Nav_Menu_Edit',
+		'Walker_Page',
+		'Walker_PageDropdown',
+		'WP',
+		'WP_Admin_Bar',
+		'WP_Ajax_Response',
+		'WP_Ajax_Upgrader_Skin',
+		'WP_Application_Passwords',
+		'WP_Application_Passwords_List_Table',
+		'WP_Automatic_Updater',
+		'WP_Block',
+		'WP_Block_Editor_Context',
+		'WP_Block_List',
+		'WP_Block_Parser',
+		'WP_Block_Parser_Block',
+		'WP_Block_Parser_Frame',
+		'WP_Block_Pattern_Categories_Registry',
+		'WP_Block_Patterns_Registry',
+		'WP_Block_Styles_Registry',
+		'WP_Block_Supports',
+		'WP_Block_Template',
+		'WP_Block_Type',
+		'WP_Block_Type_Registry',
+		'WP_Comment',
+		'WP_Comment_Query',
+		'WP_Comments_List_Table',
+		'WP_Community_Events',
+		'WP_Customize_Background_Image_Control',
+		'WP_Customize_Background_Image_Setting',
+		'WP_Customize_Background_Position_Control',
+		'WP_Customize_Code_Editor_Control',
+		'WP_Customize_Color_Control',
+		'WP_Customize_Control',
+		'WP_Customize_Cropped_Image_Control',
+		'WP_Customize_Custom_CSS_Setting',
+		'WP_Customize_Date_Time_Control',
+		'WP_Customize_Filter_Setting',
+		'WP_Customize_Header_Image_Control',
+		'WP_Customize_Header_Image_Setting',
+		'WP_Customize_Image_Control',
+		'WP_Customize_Manager',
+		'WP_Customize_Media_Control',
+		'WP_Customize_Nav_Menu_Auto_Add_Control',
+		'WP_Customize_Nav_Menu_Control',
+		'WP_Customize_Nav_Menu_Item_Control',
+		'WP_Customize_Nav_Menu_Item_Setting',
+		'WP_Customize_Nav_Menu_Location_Control',
+		'WP_Customize_Nav_Menu_Locations_Control',
+		'WP_Customize_Nav_Menu_Name_Control',
+		'WP_Customize_Nav_Menu_Section',
+		'WP_Customize_Nav_Menu_Setting',
+		'WP_Customize_Nav_Menus',
+		'WP_Customize_Nav_Menus_Panel',
+		'WP_Customize_New_Menu_Control',
+		'WP_Customize_New_Menu_Section',
+		'WP_Customize_Panel',
+		'WP_Customize_Partial',
+		'WP_Customize_Section',
+		'WP_Customize_Selective_Refresh',
+		'WP_Customize_Setting',
+		'WP_Customize_Sidebar_Section',
+		'WP_Customize_Site_Icon_Control',
+		'WP_Customize_Theme_Control',
+		'WP_Customize_Themes_Panel',
+		'WP_Customize_Themes_Section',
+		'WP_Customize_Upload_Control',
+		'WP_Customize_Widgets',
+		'WP_Date_Query',
+		'WP_Debug_Data',
+		'WP_Dependencies',
+		'WP_Embed',
+		'WP_Error',
+		'WP_Fatal_Error_Handler',
+		'WP_Feed_Cache',
+		'WP_Feed_Cache_Transient',
+		'WP_Filesystem_Base',
+		'WP_Filesystem_Direct',
+		'WP_Filesystem_FTPext',
+		'WP_Filesystem_ftpsockets',
+		'WP_Filesystem_SSH2',
+		'WP_Hook',
+		'WP_Http',
+		'WP_Http_Cookie',
+		'WP_Http_Curl',
+		'WP_Http_Encoding',
+		'WP_HTTP_Fsockopen',
+		'WP_HTTP_IXR_Client',
+		'WP_HTTP_Proxy',
+		'WP_HTTP_Requests_Hooks',
+		'WP_HTTP_Requests_Response',
+		'WP_HTTP_Response',
+		'WP_Http_Streams',
+		'WP_Image_Editor',
+		'WP_Image_Editor_GD',
+		'WP_Image_Editor_Imagick',
+		'WP_Importer',
+		'WP_Internal_Pointers',
+		'WP_Links_List_Table',
+		'WP_List_Table',
+		'WP_List_Util',
+		'WP_Locale',
+		'WP_Locale_Switcher',
+		'WP_MatchesMapRegex',
+		'WP_Media_List_Table',
+		'WP_Meta_Query',
+		'WP_Metadata_Lazyloader',
+		'WP_MS_Sites_List_Table',
+		'WP_MS_Themes_List_Table',
+		'WP_MS_Users_List_Table',
+		'WP_Nav_Menu_Widget',
+		'WP_Network',
+		'WP_Network_Query',
+		'WP_Object_Cache',
+		'WP_oEmbed',
+		'WP_oEmbed_Controller',
+		'WP_Paused_Extensions_Storage',
+		'WP_Plugin_Install_List_Table',
+		'WP_Plugins_List_Table',
+		'WP_Post',
+		'WP_Post_Comments_List_Table',
+		'WP_Post_Type',
+		'WP_Posts_List_Table',
+		'WP_Privacy_Data_Export_Requests_List_Table',
+		'WP_Privacy_Data_Export_Requests_Table',
+		'WP_Privacy_Data_Removal_Requests_List_Table',
+		'WP_Privacy_Data_Removal_Requests_Table',
+		'WP_Privacy_Policy_Content',
+		'WP_Privacy_Requests_Table',
+		'WP_Query',
+		'WP_Recovery_Mode',
+		'WP_Recovery_Mode_Cookie_Service',
+		'WP_Recovery_Mode_Email_Service',
+		'WP_Recovery_Mode_Key_Service',
+		'WP_Recovery_Mode_Link_Service',
+		'WP_REST_Application_Passwords_Controller',
+		'WP_REST_Attachments_Controller',
+		'WP_REST_Autosaves_Controller',
+		'WP_REST_Block_Directory_Controller',
+		'WP_REST_Block_Pattern_Categories_Controller',
+		'WP_REST_Block_Patterns_Controller',
+		'WP_REST_Block_Renderer_Controller',
+		'WP_REST_Block_Types_Controller',
+		'WP_REST_Blocks_Controller',
+		'WP_REST_Comment_Meta_Fields',
+		'WP_REST_Comments_Controller',
+		'WP_REST_Controller',
+		'WP_REST_Edit_Site_Export_Controller',
+		'WP_REST_Global_Styles_Controller',
+		'WP_REST_Menu_Items_Controller',
+		'WP_REST_Menu_Locations_Controller',
+		'WP_REST_Menus_Controller',
+		'WP_REST_Meta_Fields',
+		'WP_REST_Pattern_Directory_Controller',
+		'WP_REST_Plugins_Controller',
+		'WP_REST_Post_Format_Search_Handler',
+		'WP_REST_Post_Meta_Fields',
+		'WP_REST_Post_Search_Handler',
+		'WP_REST_Post_Statuses_Controller',
+		'WP_REST_Post_Types_Controller',
+		'WP_REST_Posts_Controller',
+		'WP_REST_Request',
+		'WP_REST_Response',
+		'WP_REST_Revisions_Controller',
+		'WP_REST_Search_Controller',
+		'WP_REST_Search_Handler',
+		'WP_REST_Server',
+		'WP_REST_Settings_Controller',
+		'WP_REST_Sidebars_Controller',
+		'WP_REST_Site_Health_Controller',
+		'WP_REST_Taxonomies_Controller',
+		'WP_REST_Templates_Controller',
+		'WP_REST_Term_Meta_Fields',
+		'WP_REST_Term_Search_Handler',
+		'WP_REST_Terms_Controller',
+		'WP_REST_Themes_Controller',
+		'WP_REST_URL_Details_Controller',
+		'WP_REST_User_Meta_Fields',
+		'WP_REST_Users_Controller',
+		'WP_REST_Widget_Types_Controller',
+		'WP_REST_Widgets_Controller',
+		'WP_Rewrite',
+		'WP_Role',
+		'WP_Roles',
+		'WP_Screen',
+		'WP_Scripts',
+		'WP_Session_Tokens',
+		'WP_Sidebar_Block_Editor_Control',
+		'WP_SimplePie_File',
+		'WP_SimplePie_Sanitize_KSES',
+		'WP_Site',
+		'WP_Site_Health',
+		'WP_Site_Health_Auto_Updates',
+		'WP_Site_Icon',
+		'WP_Site_Query',
+		'WP_Sitemaps',
+		'WP_Sitemaps_Index',
+		'WP_Sitemaps_Posts',
+		'WP_Sitemaps_Provider',
+		'WP_Sitemaps_Registry',
+		'WP_Sitemaps_Renderer',
+		'WP_Sitemaps_Stylesheet',
+		'WP_Sitemaps_Taxonomies',
+		'WP_Sitemaps_Users',
+		'WP_Style_Engine',
+		'WP_Style_Engine_CSS_Declarations',
+		'WP_Style_Engine_CSS_Rule',
+		'WP_Style_Engine_CSS_Rules_Store',
+		'WP_Style_Engine_Processor',
+		'WP_Styles',
+		'WP_Tax_Query',
+		'WP_Taxonomy',
+		'WP_Term',
+		'WP_Term_Query',
+		'WP_Terms_List_Table',
+		'WP_Text_Diff_Renderer_inline',
+		'WP_Text_Diff_Renderer_Table',
+		'WP_Textdomain_Registry',
+		'WP_Theme',
+		'WP_Theme_Install_List_Table',
+		'WP_Theme_JSON',
+		'WP_Theme_JSON_Data',
+		'WP_Theme_JSON_Resolver',
+		'WP_Theme_JSON_Schema',
+		'WP_Themes_List_Table',
+		'WP_Upgrader',
+		'WP_Upgrader_Skin',
+		'WP_User',
+		'WP_User_Meta_Session_Tokens',
+		'WP_User_Query',
+		'WP_User_Request',
+		'WP_User_Search',
+		'WP_Users_List_Table',
+		'WP_Widget',
+		'WP_Widget_Archives',
+		'WP_Widget_Area_Customize_Control',
+		'WP_Widget_Block',
+		'WP_Widget_Calendar',
+		'WP_Widget_Categories',
+		'WP_Widget_Custom_HTML',
+		'WP_Widget_Factory',
+		'WP_Widget_Form_Customize_Control',
+		'WP_Widget_Links',
+		'WP_Widget_Media',
+		'WP_Widget_Media_Audio',
+		'WP_Widget_Media_Gallery',
+		'WP_Widget_Media_Image',
+		'WP_Widget_Media_Video',
+		'WP_Widget_Meta',
+		'WP_Widget_Pages',
+		'WP_Widget_Recent_Comments',
+		'WP_Widget_Recent_Posts',
+		'WP_Widget_RSS',
+		'WP_Widget_Search',
+		'WP_Widget_Tag_Cloud',
+		'WP_Widget_Text',
+		'wp_xmlrpc_server',
+		'wpdb',
+	);
+
+	/**
+	 * List of all WP native classes in lowercase.
+	 *
+	 * This array is automatically generated in the class constructor based on the $wp_classes property.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @var string[] The class names in lowercase.
+	 */
+	private $wp_classes_lc = array();
+
+	/**
+	 * Constructor.
+	 *
+	 * @since 3.0.0
+	 */
+	public function __construct() {
+		// Adjust the $wp_classes property to have the lowercased version of the value as a key.
+		$this->wp_classes_lc = array_map( 'strtolower', $this->wp_classes );
+		$this->wp_classes    = array_combine( $this->wp_classes_lc, $this->wp_classes );
+	}
+
+	/**
+	 * Groups of classes to restrict.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @return array
+	 */
+	public function getGroups() {
+		return array(
+			'wp_classes' => array(
+				'classes' => $this->wp_classes_lc,
+			),
+		);
+	}
+
+	/**
+	 * Process a matched token.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @param int    $stackPtr        The position of the current token in the stack.
+	 * @param string $group_name      The name of the group which was matched. Will
+	 *                                always be 'wp_classes'.
+	 * @param string $matched_content The token content (class name) which was matched.
+	 *
+	 * @return void
+	 */
+	public function process_matched_token( $stackPtr, $group_name, $matched_content ) {
+
+		$matched_unqualified = ltrim( $matched_content, '\\' );
+		$matched_lowercase   = strtolower( $matched_unqualified );
+		$matched_proper_case = $this->wp_classes[ $matched_lowercase ];
+
+		if ( $matched_unqualified === $matched_proper_case ) {
+			// Already using proper case, nothing to do.
+			return;
+		}
+
+		$warning = 'It is strongly recommended to refer to classes by their properly cased name. Expected: %s Found: %s';
+		$data    = array(
+			$matched_proper_case,
+			$matched_unqualified,
+		);
+
+		$this->phpcsFile->addWarning( $warning, $stackPtr, 'Incorrect', $data );
+	}
+}

--- a/WordPress/Sniffs/WP/ClassNameCaseSniff.php
+++ b/WordPress/Sniffs/WP/ClassNameCaseSniff.php
@@ -346,6 +346,179 @@ class ClassNameCaseSniff extends AbstractClassRestrictionsSniff {
 	);
 
 	/**
+	 * List of all GetID3 classes include in WP Core.
+	 *
+	 * Note: this list will be enhanced in the class constructor.
+	 *
+	 * {@internal To be updated after every major release. Last updated for WordPress 6.1.1.}
+	 *
+	 * @since 3.0.0
+	 *
+	 * @var string[] The class names in their "proper" case.
+	 *               The constructor will add the lowercased class name as a key to each entry.
+	 */
+	private $getid3_classes = array(
+		'AMFReader',
+		'AMFStream',
+		'AVCSequenceParameterSetReader',
+		'getID3',
+		'getid3_ac3',
+		'getid3_apetag',
+		'getid3_asf',
+		'getid3_dts',
+		'getid3_exception',
+		'getid3_flac',
+		'getid3_flv',
+		'getid3_handler',
+		'getid3_id3v1',
+		'getid3_id3v2',
+		'getid3_lib',
+		'getid3_lyrics3',
+		'getid3_matroska',
+		'getid3_mp3',
+		'getid3_ogg',
+		'getid3_quicktime',
+		'getid3_riff',
+	);
+
+	/**
+	 * List of all PHPMailer classes include in WP Core.
+	 *
+	 * Note: this list will be enhanced in the class constructor.
+	 *
+	 * {@internal To be updated after every major release. Last updated for WordPress 6.1.1.}
+	 *
+	 * @since 3.0.0
+	 *
+	 * @var string[] The class names in their "proper" case.
+	 *               The constructor will add the lowercased class name as a key to each entry.
+	 */
+	private $phpmailer_classes = array(
+		'PHPMailer\\PHPMailer\\Exception',
+		'PHPMailer\\PHPMailer\\PHPMailer',
+		'PHPMailer\\PHPMailer\\SMTP',
+	);
+
+	/**
+	 * List of all Requests classes included in WP Core.
+	 *
+	 * Note: this list will be enhanced in the class constructor.
+	 *
+	 * {@internal To be updated after every major release. Last updated for WordPress 6.1.1.}
+	 *
+	 * @since 3.0.0
+	 *
+	 * @var string[] The class names in their "proper" case.
+	 *               The constructor will add the lowercased class name as a key to each entry.
+	 */
+	private $requests_classes = array(
+		// Interfaces.
+		'Requests_Auth',
+		'Requests_Hooker',
+		'Requests_Proxy',
+		'Requests_Transport',
+
+		// Classes.
+		'Requests',
+		'Requests_Auth_Basic',
+		'Requests_Cookie',
+		'Requests_Cookie_Jar',
+		'Requests_Exception',
+		'Requests_Exception_HTTP',
+		'Requests_Exception_Transport',
+		'Requests_Exception_Transport_cURL',
+		'Requests_Exception_HTTP_304',
+		'Requests_Exception_HTTP_305',
+		'Requests_Exception_HTTP_306',
+		'Requests_Exception_HTTP_400',
+		'Requests_Exception_HTTP_401',
+		'Requests_Exception_HTTP_402',
+		'Requests_Exception_HTTP_403',
+		'Requests_Exception_HTTP_404',
+		'Requests_Exception_HTTP_405',
+		'Requests_Exception_HTTP_406',
+		'Requests_Exception_HTTP_407',
+		'Requests_Exception_HTTP_408',
+		'Requests_Exception_HTTP_409',
+		'Requests_Exception_HTTP_410',
+		'Requests_Exception_HTTP_411',
+		'Requests_Exception_HTTP_412',
+		'Requests_Exception_HTTP_413',
+		'Requests_Exception_HTTP_414',
+		'Requests_Exception_HTTP_415',
+		'Requests_Exception_HTTP_416',
+		'Requests_Exception_HTTP_417',
+		'Requests_Exception_HTTP_418',
+		'Requests_Exception_HTTP_428',
+		'Requests_Exception_HTTP_429',
+		'Requests_Exception_HTTP_431',
+		'Requests_Exception_HTTP_500',
+		'Requests_Exception_HTTP_501',
+		'Requests_Exception_HTTP_502',
+		'Requests_Exception_HTTP_503',
+		'Requests_Exception_HTTP_504',
+		'Requests_Exception_HTTP_505',
+		'Requests_Exception_HTTP_511',
+		'Requests_Exception_HTTP_Unknown',
+		'Requests_Hooks',
+		'Requests_IDNAEncoder',
+		'Requests_IPv6',
+		'Requests_IRI',
+		'Requests_Proxy_HTTP',
+		'Requests_Response',
+		'Requests_Response_Headers',
+		'Requests_Session',
+		'Requests_SSL',
+		'Requests_Transport_cURL',
+		'Requests_Transport_fsockopen',
+		'Requests_Utility_CaseInsensitiveDictionary',
+		'Requests_Utility_FilteredIterator',
+	);
+
+	/**
+	 * List of all SimplePier classes included in WP Core.
+	 *
+	 * Note: this list will be enhanced in the class constructor.
+	 *
+	 * {@internal To be updated after every major release. Last updated for WordPress 6.1.1.}
+	 *
+	 * @since 3.0.0
+	 *
+	 * @var string[] The class names in their "proper" case.
+	 *               The constructor will add the lowercased class name as a key to each entry.
+	 */
+	private $simplepie_classes = array(
+		'SimplePie',
+		'SimplePie_Author',
+		'SimplePie_Cache',
+		'SimplePie_Caption',
+		'SimplePie_Category',
+		'SimplePie_Copyright',
+		'SimplePie_Core',
+		'SimplePie_Credit',
+		'SimplePie_Enclosure',
+		'SimplePie_Exception',
+		'SimplePie_File',
+		'SimplePie_gzdecode',
+		'SimplePie_IRI',
+		'SimplePie_Item',
+		'SimplePie_Locator',
+		'SimplePie_Misc',
+		'SimplePie_Parser',
+		'SimplePie_Rating',
+		'SimplePie_Registry',
+		'SimplePie_Restriction',
+		'SimplePie_Sanitize',
+		'SimplePie_Source',
+		'SimplePie_Content_Type_Sniffer',
+		'SimplePie_Decode_HTML_Entities',
+		'SimplePie_HTTP_Parser',
+		'SimplePie_Net_IPv6',
+		'SimplePie_Parse_Date',
+		'SimplePie_XML_Declaration_Parser',
+	);
+
+	/**
 	 * List of all WP native classes in lowercase.
 	 *
 	 * This array is automatically generated in the class constructor based on the $wp_classes property.
@@ -357,14 +530,76 @@ class ClassNameCaseSniff extends AbstractClassRestrictionsSniff {
 	private $wp_classes_lc = array();
 
 	/**
+	 * List of all GetID3 classes in lowercase.
+	 *
+	 * This array is automatically generated in the class constructor based on the $phpmailer_classes property.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @var string[] The class names in lowercase.
+	 */
+	private $getid3_classes_lc = array();
+
+	/**
+	 * List of all PHPMailer classes in lowercase.
+	 *
+	 * This array is automatically generated in the class constructor based on the $phpmailer_classes property.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @var string[] The class names in lowercase.
+	 */
+	private $phpmailer_classes_lc = array();
+
+	/**
+	 * List of all Requests classes in lowercase.
+	 *
+	 * This array is automatically generated in the class constructor based on the $requests_classes property.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @var string[] The class names in lowercase.
+	 */
+	private $requests_classes_lc = array();
+
+	/**
+	 * List of all SimplePie classes in lowercase.
+	 *
+	 * This array is automatically generated in the class constructor based on the $simplepie_classes property.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @var string[] The class names in lowercase.
+	 */
+	private $simplepie_classes_lc = array();
+
+	/**
+	 * Groups names.
+	 *
+	 * Used to dynamically fill in some of the above properties and to generate the getGroups() array.
+	 *
+	 * @var array
+	 */
+	private $class_groups = array(
+		'wp_classes',
+		'getid3_classes',
+		'phpmailer_classes',
+		'requests_classes',
+		'simplepie_classes',
+	);
+
+	/**
 	 * Constructor.
 	 *
 	 * @since 3.0.0
 	 */
 	public function __construct() {
-		// Adjust the $wp_classes property to have the lowercased version of the value as a key.
-		$this->wp_classes_lc = array_map( 'strtolower', $this->wp_classes );
-		$this->wp_classes    = array_combine( $this->wp_classes_lc, $this->wp_classes );
+		// Adjust the class list properties to have the lowercased version of the value as a key.
+		foreach ( $this->class_groups as $name ) {
+			$name_lc        = $name . '_lc';
+			$this->$name_lc = array_map( 'strtolower', $this->$name );
+			$this->$name    = array_combine( $this->$name_lc, $this->$name );
+		}
 	}
 
 	/**
@@ -375,11 +610,15 @@ class ClassNameCaseSniff extends AbstractClassRestrictionsSniff {
 	 * @return array
 	 */
 	public function getGroups() {
-		return array(
-			'wp_classes' => array(
-				'classes' => $this->wp_classes_lc,
-			),
-		);
+		$groups = array();
+		foreach ( $this->class_groups as $name ) {
+			$name_lc         = $name . '_lc';
+			$groups[ $name ] = array(
+				'classes' => $this->$name_lc,
+			);
+		}
+
+		return $groups;
 	}
 
 	/**
@@ -398,7 +637,7 @@ class ClassNameCaseSniff extends AbstractClassRestrictionsSniff {
 
 		$matched_unqualified = ltrim( $matched_content, '\\' );
 		$matched_lowercase   = strtolower( $matched_unqualified );
-		$matched_proper_case = $this->wp_classes[ $matched_lowercase ];
+		$matched_proper_case = $this->get_proper_case( $matched_lowercase );
 
 		if ( $matched_unqualified === $matched_proper_case ) {
 			// Already using proper case, nothing to do.
@@ -412,5 +651,24 @@ class ClassNameCaseSniff extends AbstractClassRestrictionsSniff {
 		);
 
 		$this->phpcsFile->addWarning( $warning, $stackPtr, 'Incorrect', $data );
+	}
+
+	/**
+	 * Match a lowercase class name to its proper cased name.
+	 *
+	 * @param string $matched_lc Lowercase class name.
+	 *
+	 * @return string
+	 */
+	private function get_proper_case( $matched_lc ) {
+		foreach ( $this->class_groups as $name ) {
+			$current = $this->$name; // Needed to prevent issues with PHP < 7.0.
+			if ( isset( $current[ $matched_lc ] ) ) {
+				return $current[ $matched_lc ];
+			}
+		}
+
+		// Shouldn't be possible.
+		return ''; // @codeCoverageIgnore
 	}
 }

--- a/WordPress/Sniffs/WP/ClassNameCaseSniff.php
+++ b/WordPress/Sniffs/WP/ClassNameCaseSniff.php
@@ -23,12 +23,12 @@ class ClassNameCaseSniff extends AbstractClassRestrictionsSniff {
 	/**
 	 * List of all WP native classes.
 	 *
-	 * To be updated after every major release.
-	 *
 	 * List is sorted alphabetically and based on the WIP autoloading PR.
 	 * {@link https://github.com/WordPress/wordpress-develop/pull/3470}
 	 *
 	 * Note: this list will be enhanced in the class constructor.
+	 *
+	 * {@internal To be updated after every major release. Last updated for WordPress 6.1.1.}
 	 *
 	 * @since 3.0.0
 	 *

--- a/WordPress/Tests/WP/ClassNameCaseUnitTest.inc
+++ b/WordPress/Tests/WP/ClassNameCaseUnitTest.inc
@@ -12,10 +12,10 @@ class Foo {
 
 $obj = new Not_A_WP_Core_Class();
 
+
 /*
  * These all use the class name in proper case.
  */
-
 $obj = new WP_Importer();
 $obj = new \WP_Query;
 
@@ -23,6 +23,13 @@ class MyList extends WP_List_Table {}
 
 echo WP_User_Search::$users_per_page;
 WP_Customize_New_Menu_Control::foo();
+
+// External libraries.
+$obj = new getID3;
+class MyMailer extends PHPMailer\PHPMailer\PHPMailer {}
+$obj = new Requests_Cookie_Jar();
+$anon = class extends SimplePie_IRI {};
+
 
 /*
  * These all use the class name in an unconventional case.
@@ -34,6 +41,13 @@ class MyList extends \WP_LIST_table {}
 
 echo wp_user_search::$users_per_page;
 WP_Customize_NEW_Menu_Control::foo();
+
+// External libraries.
+$obj = new GetID3();
+class MyMailer extends PhpMailer\PhpMailer\PhpMailer {}
+$obj = new Requests_cookie_jar();
+$anon = class extends SimplePie_Iri {};
+
 
 /*
  * These will not (yet) be detected as the abstract doesn't handle these.

--- a/WordPress/Tests/WP/ClassNameCaseUnitTest.inc
+++ b/WordPress/Tests/WP/ClassNameCaseUnitTest.inc
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * These should be disregarded by the sniff.
+ */
+class Foo {
+	function bar() {
+		$obj = new self();
+		echo static::MY_CONSTANT;
+	}
+}
+
+$obj = new Not_A_WP_Core_Class();
+
+/*
+ * These all use the class name in proper case.
+ */
+
+$obj = new WP_Importer();
+$obj = new \WP_Query;
+
+class MyList extends WP_List_Table {}
+
+echo WP_User_Search::$users_per_page;
+WP_Customize_New_Menu_Control::foo();
+
+/*
+ * These all use the class name in an unconventional case.
+ */
+$obj = new WPDB();
+$obj = new \WP_date_query;
+
+class MyList extends \WP_LIST_table {}
+
+echo wp_user_search::$users_per_page;
+WP_Customize_NEW_Menu_Control::foo();
+
+/*
+ * These will not (yet) be detected as the abstract doesn't handle these.
+ * This will be fixed in the future when the PHPCSUtils abstract will be made available.
+ */
+
+try {
+	// Do something.
+} catch ( Wp_Error ) {
+}
+
+class NotYetDetected {
+	public WalKer $property_type;
+
+	public function paramTypeDeclaration( wp_role $role ) {}
+	public function returnTypeDeclaration() : WP_TERM {}
+}

--- a/WordPress/Tests/WP/ClassNameCaseUnitTest.php
+++ b/WordPress/Tests/WP/ClassNameCaseUnitTest.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Unit test class for WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPressCS\WordPress\Tests\WP;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+/**
+ * Unit test class for the ClassNameCase sniff.
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since 3.0.0
+ */
+class ClassNameCaseUnitTest extends AbstractSniffUnitTest {
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * @return array <int line number> => <int number of errors>
+	 */
+	public function getErrorList() {
+		return array();
+	}
+
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * @return array <int line number> => <int number of warnings>
+	 */
+	public function getWarningList() {
+		return array(
+			30 => 1,
+			31 => 1,
+			33 => 1,
+			35 => 1,
+			36 => 1,
+		);
+	}
+}

--- a/WordPress/Tests/WP/ClassNameCaseUnitTest.php
+++ b/WordPress/Tests/WP/ClassNameCaseUnitTest.php
@@ -36,11 +36,15 @@ class ClassNameCaseUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getWarningList() {
 		return array(
-			30 => 1,
-			31 => 1,
-			33 => 1,
-			35 => 1,
-			36 => 1,
+			37 => 1,
+			38 => 1,
+			40 => 1,
+			42 => 1,
+			43 => 1,
+			46 => 1,
+			47 => 1,
+			48 => 1,
+			49 => 1,
 		);
 	}
 }


### PR DESCRIPTION
... to check that any class name references to WP native classes used the case of the class as per the class declaration.

As class names in PHP are case-insensitive, this is a `warning`, not an `error`.

**Open questions:**
* Should the same by checked for classes from external dependencies, like PHPMailer, SimplePie, Requests etc ? We could have separate arrays (groups) for each of these.
* Is the name of the sniff correct or should it be made more generic ? I mean, at this time, WP only contains classes, no interfaces, traits or enums, but that may change in the future and the logic for checking this is largely the same, so it would make sense to add those checks to this sniff.

I'm proposing to add this sniff to the WP Core ruleset, so both Core as well as plugins and themes will benefit from it.
FYI: I've ran the sniff over WP Core and it triggers no issues.

This sniff was inspired by a discussion I had with @aristath and @SergeyBiryukov earlier today.

----

### Future scope:

1. Expand the places where we check for the use of class/oo names.
    A new abstract class/oo-name sniff is expected to be added to PHPCSUtils in the foreseeable future which will also check for the use of class names in `catch` statements, type declarations etc.
    Once that class is available, we should consider switching.
2. As maintaining the list of classes will be a manual task which would need to be executed after each release, it would be good to create some tooling which can update the list automatically and/or generate the update which would need to be applied.
    Related #1803.