### PR TITLE
WP/Capabilities: tests - prevent CLI value leaking

### DIFF
--- a/WordPress/Tests/WP/CapabilitiesUnitTest.4.inc
+++ b/WordPress/Tests/WP/CapabilitiesUnitTest.4.inc
@@ -1,0 +1,12 @@
+<?php
+
+if ( author_can( $post, 'read' ) ) { } // OK.
+
+/*
+ * Deprecated capabilities - just making sure the CLI option is reset to the default.
+ */
+if ( author_can( $post, 'level_3' ) ) { } // Error.
+
+if ( author_can( $post, 'level_5' ) ) { } // Error.
+
+add_options_page( 'page_title', 'menu_title', 'level_10', 'menu_slug', 'function' ); // Error.

--- a/WordPress/Tests/WP/CapabilitiesUnitTest.php
+++ b/WordPress/Tests/WP/CapabilitiesUnitTest.php
@@ -19,8 +19,9 @@ use PHPCSUtils\BackCompat\Helper;
  * @since   3.0.0
  */
 class CapabilitiesUnitTest extends AbstractSniffUnitTest {
+
 	/**
-	 * Set warnings level to 3 to trigger suggestions as warnings.
+	 * Adjust the config to allow for testing with specific CLI arguments.
 	 *
 	 * @param string                  $filename The name of the file being tested.
 	 * @param \PHP_CodeSniffer\Config $config   The config data for the run.
@@ -30,7 +31,11 @@ class CapabilitiesUnitTest extends AbstractSniffUnitTest {
 	public function setCliValues( $filename, $config ) {
 		if ( 'CapabilitiesUnitTest.1.inc' === $filename ) {
 			$config->warningSeverity = 3;
-		} elseif ( 'CapabilitiesUnitTest.2.inc' === $filename ) {
+		} else {
+			$config->warningSeverity = 5;
+		}
+
+		if ( 'CapabilitiesUnitTest.2.inc' === $filename ) {
 			Helper::setConfigData( 'minimum_wp_version', '2.9', true, $config );
 		} elseif ( 'CapabilitiesUnitTest.3.inc' === $filename ) {
 			Helper::setConfigData( 'minimum_wp_version', '6.1', true, $config );
@@ -74,6 +79,13 @@ class CapabilitiesUnitTest extends AbstractSniffUnitTest {
 					10 => 1,
 					12 => 1,
 					14 => 1,
+				);
+
+			case 'CapabilitiesUnitTest.4.inc':
+				return array(
+					8  => 1,
+					10 => 1,
+					12 => 1,
 				);
 
 			default:


### PR DESCRIPTION
In the `CapabilitiesUnitTest::setCliValues()` method, the config value for `'minimum_wp_version'` is set for two test case files, but as the sniff did not have a test case file which would be run _after_ that, it would never get _unset_ again, which means it could negatively influence other tests as the value will persist and the value from the CLI will overrule "ruleset" passed values (including the values passed using `phpcs:set`).

This fixes this issue by adding an extra test case file, which makes sure that the CLI value gets reset/deleted.

Notes:
* The "proper" way to do this would be to use the test `tear_down()`, but unfortunately, the `tear_down()` doesn't have access to the `$config`, so resetting the value won't work.
* This is a known bug in the test framework for which I have had a PR open in PHPCS since March 2020. squizlabs/PHP_CodeSniffer#2899
* There are a couple of other tests in WPCS in which the same should probably be applied, however, those (currently) don't negatively affect other tests.