### PR TITLE
CS: minor tweaks/don't allow warnings

### DIFF
--- a/.github/workflows/ruleset-checks-sniffs.yml
+++ b/.github/workflows/ruleset-checks-sniffs.yml
@@ -68,13 +68,13 @@ jobs:
       # WordPress Coding Standards.
       # @link https://github.com/WordPress/WordPress-Coding-Standards
       # @link http://pear.php.net/package/PHP_CodeSniffer/
-      - name: Run PHPCS ignoring warnings
+      - name: Check the code style of the PHP files
         id: phpcs
-        run: vendor/bin/phpcs --runtime-set ignore_warnings_on_exit 1 --report-full --report-checkstyle=./phpcs-report.xml
+        run: vendor/bin/phpcs --report-full --report-checkstyle=./phpcs-report.xml
 
       - name: Show PHPCS results in PR
         if: ${{ always() && steps.phpcs.outcome == 'failure' }}
-        run: cs2pr ./phpcs-report.xml --graceful-warnings
+        run: cs2pr ./phpcs-report.xml
 
       # Validate the Ruleset XML files.
       # @link http://xmlsoft.org/xmllint.html

--- a/WordPress/AbstractFunctionParameterSniff.php
+++ b/WordPress/AbstractFunctionParameterSniff.php
@@ -106,8 +106,5 @@ abstract class AbstractFunctionParameterSniff extends AbstractFunctionRestrictio
 	 * @return int|void Integer stack pointer to skip forward or void to continue
 	 *                  normal file processing.
 	 */
-	public function process_no_parameters( $stackPtr, $group_name, $matched_content ) {
-		return;
-	}
-
+	public function process_no_parameters( $stackPtr, $group_name, $matched_content ) {}
 }

--- a/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.php
+++ b/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.php
@@ -72,15 +72,6 @@ class ControlStructureSpacingUnitTest extends AbstractSniffUnitTest {
 					267 => 1,
 				);
 
-				/*
-				Uncomment when "$blank_line_check" parameter will be "true" by default.
-
-				$ret[29] += 1;
-				$ret[33]  = 1;
-				$ret[36]  = 1;
-				$ret[38]  = 1;
-				 */
-
 				return $ret;
 
 			case 'ControlStructureSpacingUnitTest.2.inc':


### PR DESCRIPTION
This commit gets rid of the last two PHPCS warnings in the code base, which allows us to run the CS check without allowing for warnings anymore.