### PR TITLE
Core: add sniffs to check class/constant modifier keyword order

### DIFF
--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -391,14 +391,16 @@
 	Ref: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#visibility-and-modifier-order
 	#############################################################################
 	-->
-	<!-- Rule: When using multiple modifiers for a class declaration, the order should be as follows:
+	<!-- Covers rule: When using multiple modifiers for a class declaration, the order should be as follows:
 		 - First the optional abstract or final modifier.
 		 - Next, the optional readonly modifier. -->
+	<rule ref="Universal.Classes.ModifierKeywordOrder"/>
 
-	<!-- Rule: When using multiple modifiers for a constant declaration inside object-oriented structures,
+	<!-- Covers rule: When using multiple modifiers for a constant declaration inside object-oriented structures,
 		 the order should be as follows:
 		 - First the optional final modifier.
 		 - Next, the visibility modifier. -->
+	<rule ref="Universal.Constants.ModifierKeywordOrder"/>
 
 	<!-- Covers rule: When using multiple modifiers for a property declaration, the order should be as follows:
 		 - First a visibility modifier.


### PR DESCRIPTION
Follow up on #2102

This adds two new sniffs to the Core ruleset to cover the keyword modifier order rules for class declarations and OO constant declarations.

Refs:
* https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#visibility-and-modifier-order
* WordPress/wpcs-docs#108
* PHPCSStandards/PHPCSExtra#142
* PHPCSStandards/PHPCSExtra#143