### PR TITLE
Core: add sniffs to check formatting of increment/decrement operators

### DIFF
--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -217,6 +217,10 @@
 		</properties>
 	</rule>
 
+	<!-- Covers rule: When using increment or decrement operators, there should be
+		 no spaces between the operator and the variable it applies to. -->
+	<rule ref="Generic.WhiteSpace.IncrementDecrementSpacing"/>
+
 
 	<!--
 	#############################################################################
@@ -466,6 +470,19 @@
 	<!-- Covers rule: This operator is often used lazily instead of doing proper error checking.
 		 Its use is highly discouraged. -->
 	<rule ref="WordPress.PHP.NoSilencedErrors"/>
+
+
+	<!--
+	#############################################################################
+	Handbook: Operators - Increment/decrement operators.
+	Ref: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#increment-decrement-operators
+	#############################################################################
+	-->
+	<!-- Covers rule: Pre-increment/decrement should be favoured over post-increment/decrement
+		 for stand-alone statements. -->
+	<rule ref="Universal.Operators.DisallowStandalonePostIncrementDecrement">
+		<type>warning</type>
+	</rule>
 
 
 	<!--

--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -928,7 +928,7 @@ abstract class Sniff implements PHPCS_Sniff {
 		$nextPtr     = ( $stackPtr + 1 );
 
 		while ( isset( $tokens[ $nextPtr ] ) && $tokens[ $nextPtr ]['line'] === $currentLine ) {
-			$nextPtr++;
+			++$nextPtr;
 			// Do nothing, we just want the last token of the line.
 		}
 

--- a/WordPress/Sniffs/Arrays/ArrayDeclarationSpacingSniff.php
+++ b/WordPress/Sniffs/Arrays/ArrayDeclarationSpacingSniff.php
@@ -405,7 +405,7 @@ class ArrayDeclarationSpacingSniff extends Sniff {
 						&& substr( rtrim( $this->tokens[ $end_of_comment ]['content'] ), -2 ) !== '*/'
 						&& ( $end_of_comment + 1 ) < $end_of_this_item
 					) {
-						$end_of_comment++;
+						++$end_of_comment;
 					}
 
 					if ( $this->tokens[ $end_of_comment ]['line'] !== $this->tokens[ $end_of_last_item ]['line'] ) {

--- a/WordPress/Sniffs/Arrays/CommaAfterArrayItemSniff.php
+++ b/WordPress/Sniffs/Arrays/CommaAfterArrayItemSniff.php
@@ -188,7 +188,7 @@ class CommaAfterArrayItemSniff extends Sniff {
 
 					if ( \T_WHITESPACE === $this->tokens[ $i ]['code'] ) {
 						if ( $this->tokens[ $i ]['content'] === $this->phpcsFile->eolChar ) {
-							$newlines++;
+							++$newlines;
 						} else {
 							$spaces += $this->tokens[ $i ]['length'];
 						}

--- a/WordPress/Sniffs/Arrays/MultipleStatementAlignmentSniff.php
+++ b/WordPress/Sniffs/Arrays/MultipleStatementAlignmentSniff.php
@@ -358,7 +358,7 @@ class MultipleStatementAlignmentSniff extends Sniff {
 				$items[ $key ]['single_line'] = true;
 			} else {
 				$items[ $key ]['single_line'] = false;
-				$multi_line_count++;
+				++$multi_line_count;
 			}
 
 			if ( ( $index_end_position + 2 ) <= $this->maxColumn ) {
@@ -368,7 +368,7 @@ class MultipleStatementAlignmentSniff extends Sniff {
 			if ( ! isset( $double_arrow_cols[ $this->tokens[ $double_arrow ]['column'] ] ) ) {
 				$double_arrow_cols[ $this->tokens[ $double_arrow ]['column'] ] = 1;
 			} else {
-				$double_arrow_cols[ $this->tokens[ $double_arrow ]['column'] ]++;
+				++$double_arrow_cols[ $this->tokens[ $double_arrow ]['column'] ];
 			}
 		}
 		unset( $key, $item, $double_arrow, $has_array_opener, $last_index_token );
@@ -413,7 +413,7 @@ class MultipleStatementAlignmentSniff extends Sniff {
 				if ( ! isset( $double_arrow_cols[ $this->tokens[ $item['operatorPtr'] ]['column'] ] ) ) {
 					$double_arrow_cols[ $this->tokens[ $item['operatorPtr'] ]['column'] ] = 1;
 				} else {
-					$double_arrow_cols[ $this->tokens[ $item['operatorPtr'] ]['column'] ]++;
+					++$double_arrow_cols[ $this->tokens[ $item['operatorPtr'] ]['column'] ];
 				}
 			}
 		}

--- a/WordPress/Sniffs/NamingConventions/ValidHookNameSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidHookNameSniff.php
@@ -178,10 +178,10 @@ class ValidHookNameSniff extends AbstractFunctionParameterSniff {
 			}
 
 			if ( $string !== $case_transform ) {
-				$case_errors++;
+				++$case_errors;
 			}
 			if ( $string !== $punct_transform ) {
-				$underscores++;
+				++$underscores;
 			}
 		}
 
@@ -270,7 +270,7 @@ class ValidHookNameSniff extends AbstractFunctionParameterSniff {
 				$is_variable = true;
 				if ( '{' === $part ) {
 					$has_braces = true;
-					$braces++;
+					++$braces;
 				}
 				continue;
 			}
@@ -278,10 +278,10 @@ class ValidHookNameSniff extends AbstractFunctionParameterSniff {
 			if ( true === $is_variable ) {
 				if ( '[' === $part ) {
 					$has_braces = true;
-					$braces++;
+					++$braces;
 				}
 				if ( \in_array( $part, array( '}', ']' ), true ) ) {
-					$braces--;
+					--$braces;
 				}
 				if ( false === $has_braces && ' ' === $part ) {
 					$is_variable  = false;

--- a/WordPress/Sniffs/Security/EscapeOutputSniff.php
+++ b/WordPress/Sniffs/Security/EscapeOutputSniff.php
@@ -263,7 +263,7 @@ class EscapeOutputSniff extends Sniff {
 		}
 
 		// Ignore the function itself.
-		$stackPtr++;
+		++$stackPtr;
 
 		$in_cast = false;
 
@@ -315,7 +315,7 @@ class EscapeOutputSniff extends Sniff {
 
 			// Handle arrays for those functions that accept them.
 			if ( \T_ARRAY === $this->tokens[ $i ]['code'] ) {
-				$i++; // Skip the opening parenthesis.
+				++$i; // Skip the opening parenthesis.
 				continue;
 			}
 

--- a/WordPress/Sniffs/WP/GlobalVariablesOverrideSniff.php
+++ b/WordPress/Sniffs/WP/GlobalVariablesOverrideSniff.php
@@ -332,7 +332,7 @@ class GlobalVariablesOverrideSniff extends Sniff {
 				}
 			}
 
-			$ptr++;
+			++$ptr;
 		}
 		unset( $var );
 

--- a/WordPress/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
@@ -561,7 +561,7 @@ class ControlStructureSpacingSniff extends Sniff {
 					$i = ( $scopeCloser + 1 );
 					while ( $this->tokens[ $i ]['line'] !== $this->tokens[ $trailingContent ]['line'] ) {
 						$this->phpcsFile->fixer->replaceToken( $i, '' );
-						$i++;
+						++$i;
 					}
 
 					// TODO: Instead a separate error should be triggered when content comes right after closing brace.


### PR DESCRIPTION
### Core: add sniffs to check formatting of increment/decrement operators

> 1. There should be no space between an increment/decrement operator and the variable it applies to.
> 2. Pre-increment/decrement should be favoured over post-increment/decrement for stand-alone statements.
>    “Pre” will in/decrement and then return, “post” will return and then in/decrement.
>    Using the “pre” version is slightly more performant and can prevent future bugs when code gets moved around.

Refs:
* https://make.wordpress.org/core/2020/03/20/updating-the-coding-standards-for-modern-php/ - Increment/decrement operators section
* https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#space-usage
* https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#increment-decrement-operators
* WordPress/wpcs-docs#112
* WordPress/WordPress-Coding-Standards#1511
* squizlabs/PHP_CodeSniffer#2172
* squizlabs/PHP_CodeSniffer#2174
* PHPCSStandards/PHPCSExtra#65

Closes #1511

### CS: clean up codebase for new rules / pre-increment