### PR TITLE
GH Actions: tweak label management workflow

### DIFF
--- a/.github/workflows/manage-labels.yml
+++ b/.github/workflows/manage-labels.yml
@@ -21,8 +21,8 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           labels: |
-            "Status: Awaiting Feedback"
-            "Status: Review Ready"
+            Status: Awaiting Feedback
+            Status: Review Ready
 
   on-pr-close:
     runs-on: ubuntu-latest
@@ -35,9 +35,9 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           labels: |
-            "Status: Awaiting Feedback"
-            "Status: close candidate"
-            "Status: Review Ready"
+            Status: Awaiting Feedback
+            Status: close candidate
+            Status: Review Ready
 
   on-issue-close:
     runs-on: ubuntu-latest
@@ -50,8 +50,8 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           labels: |
-            "Status: Awaiting Feedback"
-            "Status: close candidate"
-            "Status: help wanted"
-            "Status: good first issue"
-            "Status: PR Exists"
+            Status: Awaiting Feedback
+            Status: close candidate
+            Status: help wanted
+            Status: good first issue
+            Status: PR Exists


### PR DESCRIPTION
Follow up on #2127

Let's try this without the quotes around the labels. The example in the action runners' readme didn't contain quotes, I added them as the labels we use have a `:` in it, which has special meaning in YAML workflows, but clearly that's not working.

If this doesn't work either, I may need to report it as a bug to the action runner (or find another action runner for the same).