### PR TITLE
Core: add sniff to discourage using reserved keywords as param names

### DIFF
--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -101,6 +101,9 @@
 	<rule ref="WordPress.NamingConventions.ValidHookName"/>
 	<rule ref="WordPress.NamingConventions.ValidVariableName"/>
 
+	<!-- Covers rule: It is _strongly recommended_ to avoid reserved keywords as function parameter names. -->
+	<rule ref="Universal.NamingConventions.NoReservedKeywordParameterNames"/>
+
 	<!-- Covers rule: Class names should use capitalized words separated by underscores. -->
 	<rule ref="PEAR.NamingConventions.ValidClassName"/>
 

--- a/WordPress/AbstractFunctionRestrictionsSniff.php
+++ b/WordPress/AbstractFunctionRestrictionsSniff.php
@@ -330,15 +330,15 @@ abstract class AbstractFunctionRestrictionsSniff extends Sniff {
 	 *
 	 * @since 0.10.0
 	 *
-	 * @param string $function Function name.
+	 * @param string $function_name Function name.
 	 * @return string Regex escaped function name.
 	 */
-	protected function prepare_name_for_regex( $function ) {
-		$function = str_replace( array( '.*', '*' ), '@@', $function ); // Replace wildcards with placeholder.
-		$function = preg_quote( $function, '`' );
-		$function = str_replace( '@@', '.*', $function ); // Replace placeholder with regex wildcard.
+	protected function prepare_name_for_regex( $function_name ) {
+		$function_name = str_replace( array( '.*', '*' ), '@@', $function_name ); // Replace wildcards with placeholder.
+		$function_name = preg_quote( $function_name, '`' );
+		$function_name = str_replace( '@@', '.*', $function_name ); // Replace placeholder with regex wildcard.
 
-		return $function;
+		return $function_name;
 	}
 
 }

--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -1256,7 +1256,7 @@ abstract class Sniff implements PHPCS_Sniff {
 	 * @param array $valid_functions List of valid function names.
 	 *                               Note: The keys to this array should be the function names
 	 *                               in lowercase. Values are irrelevant.
-	 * @param bool  $global          Optional. Whether to make sure that the function call is
+	 * @param bool  $global_function Optional. Whether to make sure that the function call is
 	 *                               to a global function. If `false`, calls to methods, be it static
 	 *                               `Class::method()` or via an object `$obj->method()`, and
 	 *                               namespaced function calls, like `MyNS\function_name()` will
@@ -1271,7 +1271,7 @@ abstract class Sniff implements PHPCS_Sniff {
 	 *
 	 * @return int|bool Stack pointer to the function call T_STRING token or false otherwise.
 	 */
-	protected function is_in_function_call( $stackPtr, $valid_functions, $global = true, $allow_nested = false ) {
+	protected function is_in_function_call( $stackPtr, $valid_functions, $global_function = true, $allow_nested = false ) {
 		if ( ! isset( $this->tokens[ $stackPtr ]['nested_parenthesis'] ) ) {
 			return false;
 		}
@@ -1297,7 +1297,7 @@ abstract class Sniff implements PHPCS_Sniff {
 				continue;
 			}
 
-			if ( false === $global ) {
+			if ( false === $global_function ) {
 				return $prev_non_empty;
 			}
 

--- a/WordPress/Sniffs/NamingConventions/ValidHookNameSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidHookNameSniff.php
@@ -228,38 +228,38 @@ class ValidHookNameSniff extends AbstractFunctionParameterSniff {
 	/**
 	 * Transform an arbitrary string to lowercase and replace punctuation and spaces with underscores.
 	 *
-	 * @param string $string         The target string.
+	 * @param string $text_string    The target string.
 	 * @param string $regex          The punctuation regular expression to use.
 	 * @param string $transform_type Whether to a partial or complete transform.
 	 *                               Valid values are: 'full', 'case', 'punctuation'.
 	 * @return string
 	 */
-	protected function transform( $string, $regex, $transform_type = 'full' ) {
+	protected function transform( $text_string, $regex, $transform_type = 'full' ) {
 
 		switch ( $transform_type ) {
 			case 'case':
-				return strtolower( $string );
+				return strtolower( $text_string );
 
 			case 'punctuation':
-				return preg_replace( $regex, '_', $string );
+				return preg_replace( $regex, '_', $text_string );
 
 			case 'full':
 			default:
-				return preg_replace( $regex, '_', strtolower( $string ) );
+				return preg_replace( $regex, '_', strtolower( $text_string ) );
 		}
 	}
 
 	/**
 	 * Transform a complex string which may contain variable extrapolation.
 	 *
-	 * @param string $string         The target string.
+	 * @param string $text_string    The target string.
 	 * @param string $regex          The punctuation regular expression to use.
 	 * @param string $transform_type Whether to a partial or complete transform.
 	 *                               Valid values are: 'full', 'case', 'punctuation'.
 	 * @return string
 	 */
-	protected function transform_complex_string( $string, $regex, $transform_type = 'full' ) {
-		$output = preg_split( '`([\{\}\$\[\] ])`', $string, -1, \PREG_SPLIT_DELIM_CAPTURE );
+	protected function transform_complex_string( $text_string, $regex, $transform_type = 'full' ) {
+		$output = preg_split( '`([\{\}\$\[\] ])`', $text_string, -1, \PREG_SPLIT_DELIM_CAPTURE );
 
 		$is_variable = false;
 		$has_braces  = false;


### PR DESCRIPTION
The sniff in PHPCSExtra throws a `warning`. This is in line with the wording now used in the WP Core CS handbook.

All the same, as warnings for the `src` directory are currently ignored in CI for WP Core, we could consider making this an `error` once all known instances have been fixed, which should be soon as the fixes are all lined up to be committed, and we _really_ don't want new ones being introduced (as renaming the parameter after introduction would be a BC-break). For `Extra` we could then choose to make this less opinionated and revert it to a `warning`.

Refs:
* WordPress/wpcs-docs#120
* PHPCSStandards/PHPCSExtra#80

Related to WP Core tickets:
* https://core.trac.wordpress.org/ticket/51553
* https://core.trac.wordpress.org/ticket/55327
* https://core.trac.wordpress.org/ticket/55650
* https://core.trac.wordpress.org/ticket/56788