### PR TITLE
Core: add sniff to check magic constants are in uppercase

### DIFF
--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -375,6 +375,20 @@
 
 	<!--
 	#############################################################################
+	Handbook: Formatting - Magic constants.
+	Ref: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#magic-constants
+	#############################################################################
+	-->
+	<!-- Covers rule: The PHP native __*__ magic constants should be written in uppercase. -->
+	<rule ref="Universal.Constants.UppercaseMagicConstants"/>
+
+	<!-- Rule: When using the ::class constant for class name resolution, the class keyword should be in lowercase... -->
+
+	<!-- Rule: ... and there should be no spaces around the :: operator. -->
+
+
+	<!--
+	#############################################################################
 	Handbook: Formatting - Spread operator.
 	Ref: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#spread-operator
 	#############################################################################


### PR DESCRIPTION
> 1. The PHP native `__...__` magic constants should be in uppercase when used.

Refs:
* https://make.wordpress.org/core/2020/03/20/updating-the-coding-standards-for-modern-php/ - Magic Constants section
* https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#magic-constants
* WordPress/wpcs-docs#113
* PHPCSStandards/PHPCSExtra#64