### PR TITLE
Core: ensure more keywords are lowercase

### DIFF
--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -699,6 +699,7 @@
 
 	<!-- Lowercase PHP keywords, like class, function and case. -->
 	<rule ref="Generic.PHP.LowerCaseKeyword"/>
+	<rule ref="Universal.UseStatements.LowercaseFunctionConst"/>
 
 	<!-- Class opening braces should be on the same line as the statement. -->
 	<rule ref="Generic.Classes.OpeningBraceSameLine"/>


### PR DESCRIPTION
The `function` and `const` keywords when used in import `use` statements are tokenized as `T_STRING`, not their keyword token, which means that the `Generic.PHP.LowerCaseKeyword` overlooks these.

This adds an additional sniff, which specifically checks that the `function` and `const` keywords in import `use` statements are in lowercase.