### PR TITLE
Core: add sniff to enforce the use of __DIR__ instead of dirname(__FILE__)

### DIFF
--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -744,4 +744,8 @@
 	<!-- Check that class name references use the correct case. -->
 	<rule ref="WordPress.WP.ClassNameCase"/>
 
+	<!-- Check that __DIR__ is favoured over dirname(__FILE__).
+		 See: https://core.trac.wordpress.org/ticket/48082 -->
+	<rule ref="Modernize.FunctionCalls.Dirname.FileConstant"/>
+
 </ruleset>


### PR DESCRIPTION
Related to previous efforts which already fixed all instances of this in WP Core.

The sniff from PHPCSExtra includes an auto-fixer for the issue.

Note: the sniff from PHPCSExtra also contains a check for nested `dirname()` function calls. This check is not (yet) enabled as the fix for this requires PHP 7.0+.

Fixes #1954

Refs:
* PHPCSStandards/PHPCSExtra#172
* PHPCSStandards/PHPCSExtra#187

Related to WP Core tickets:
* https://core.trac.wordpress.org/ticket/48082
* https://core.trac.wordpress.org/changeset/47198