### PR TITLE
PHP/PregQuoteDelimiter: add support for PHP 8.0+ named parameters

### DIFF
--- a/WordPress/Sniffs/PHP/PregQuoteDelimiterSniff.php
+++ b/WordPress/Sniffs/PHP/PregQuoteDelimiterSniff.php
@@ -9,6 +9,7 @@
 
 namespace WordPressCS\WordPress\Sniffs\PHP;
 
+use PHPCSUtils\Utils\PassedParameters;
 use WordPressCS\WordPress\AbstractFunctionParameterSniff;
 
 /**
@@ -55,15 +56,16 @@ class PregQuoteDelimiterSniff extends AbstractFunctionParameterSniff {
 	 * @return void
 	 */
 	public function process_parameters( $stackPtr, $group_name, $matched_content, $parameters ) {
-		if ( \count( $parameters ) > 1 ) {
+
+		$delimiter = PassedParameters::getParameterFromStack( $parameters, 2, 'delimiter' );
+		if ( false !== $delimiter ) {
 			return;
 		}
 
 		$this->phpcsFile->addWarning(
-			'Passing the $delimiter as the second parameter to preg_quote() is strongly recommended.',
+			'Passing the $delimiter to preg_quote() is strongly recommended.',
 			$stackPtr,
 			'Missing'
 		);
 	}
-
 }

--- a/WordPress/Tests/PHP/PregQuoteDelimiterUnitTest.inc
+++ b/WordPress/Tests/PHP/PregQuoteDelimiterUnitTest.inc
@@ -7,3 +7,9 @@ preg_quote($keywords); // Warning.
 $textbody = preg_replace ( "/" . preg_quote($word) . "/", // Warning
                           "<i>" . $word . "</i>",
                           $textbody );
+
+// Safeguard support for PHP 8.0+ named parameters.
+preg_quote(delimiter: '#', str: $keywords); // OK.
+preg_quote(str: $keywords); // Warning.
+preg_quote(str: $keywords, delimitter: '#'); // Warning (typo in param name).
+preg_quote(delimiter: '#'); // OK. Invalid function call, but that's not the concern of this sniff.

--- a/WordPress/Tests/PHP/PregQuoteDelimiterUnitTest.php
+++ b/WordPress/Tests/PHP/PregQuoteDelimiterUnitTest.php
@@ -36,9 +36,10 @@ class PregQuoteDelimiterUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getWarningList() {
 		return array(
-			6 => 1,
-			7 => 1,
+			6  => 1,
+			7  => 1,
+			13 => 1,
+			14 => 1,
 		);
 	}
-
 }


### PR DESCRIPTION
1. Adjusted the way the correct parameter is retrieved to use the new PHPCSUtils 1.0.0-alpha4 `PassedParameters::getParameterFromStack()` method.
2. Verified the parameter name used is in line with the name as per the PHP 8.0 release.
    PHP itself renamed a lot of parameters in PHP 8.0. As named parameters did not exist before PHP 8.0, the parameter name as per PHP 8.0 (or above) is the only relevant name.

Includes minor tweak to the warning message to remove mention of the parameter position.

Includes additional unit tests.