### PR TITLE
PHP/StrictInArray: add support for PHP 8.0+ named parameters

### DIFF
--- a/WordPress/Sniffs/PHP/StrictInArraySniff.php
+++ b/WordPress/Sniffs/PHP/StrictInArraySniff.php
@@ -9,6 +9,7 @@
 
 namespace WordPressCS\WordPress\Sniffs\PHP;
 
+use PHPCSUtils\Utils\PassedParameters;
 use WordPressCS\WordPress\AbstractFunctionParameterSniff;
 
 /**
@@ -40,10 +41,8 @@ class StrictInArraySniff extends AbstractFunctionParameterSniff {
 	/**
 	 * List of array functions to which a $strict parameter can be passed.
 	 *
-	 * The $strict parameter is the third and last parameter for each of these functions.
-	 *
 	 * The array_keys() function only requires the $strict parameter when the optional
-	 * second parameter $search has been set.
+	 * second parameter $filter_value has been set.
 	 *
 	 * @link http://php.net/in-array
 	 * @link http://php.net/array-search
@@ -51,13 +50,26 @@ class StrictInArraySniff extends AbstractFunctionParameterSniff {
 	 *
 	 * @since 0.10.0
 	 * @since 0.11.0 Renamed from $array_functions to $target_functions.
+	 * @since 3.0.0  The format of the array value has changed from boolean to array.
 	 *
-	 * @var array <string function_name> => <bool always needed ?>
+	 * @var array<string, array{param_position: int, param_name: string, always_needed: bool}> Key is the function name.
 	 */
 	protected $target_functions = array(
-		'in_array'     => true,
-		'array_search' => true,
-		'array_keys'   => false,
+		'in_array'     => array(
+			'param_position' => 3,
+			'param_name'     => 'strict',
+			'always_needed'  => true,
+		),
+		'array_search' => array(
+			'param_position' => 3,
+			'param_name'     => 'strict',
+			'always_needed'  => true,
+		),
+		'array_keys'   => array(
+			'param_position' => 3,
+			'param_name'     => 'strict',
+			'always_needed'  => false,
+		),
 	);
 
 	/**
@@ -73,33 +85,41 @@ class StrictInArraySniff extends AbstractFunctionParameterSniff {
 	 * @return void
 	 */
 	public function process_parameters( $stackPtr, $group_name, $matched_content, $parameters ) {
-		// Check if the strict check is actually needed.
-		if ( false === $this->target_functions[ $matched_content ] ) {
-			if ( \count( $parameters ) === 1 ) {
+		$param_info = $this->target_functions[ $matched_content ];
+
+		/*
+		 * Check if the strict check is actually needed.
+		 *
+		 * Important! This check only applies to array_keys() in the current form of the sniff
+		 * and has been written to be specific to that function.
+		 * If more functions would be added with 'always_needed' set to `false`,
+		 * this code will need to be adjusted to handle those.
+		 */
+		if ( false === $param_info['always_needed'] ) {
+			$has_search = PassedParameters::getParameterFromStack( $parameters, 2, 'filter_value' );
+			if ( false === $has_search ) {
 				return;
 			}
 		}
 
-		// We're only interested in the third parameter.
-		if ( false === isset( $parameters[3] ) || 'true' !== strtolower( $parameters[3]['raw'] ) ) {
+		$found_parameter = PassedParameters::getParameterFromStack( $parameters, $param_info['param_position'], $param_info['param_name'] );
+		if ( false === $found_parameter || 'true' !== strtolower( $found_parameter['raw'] ) ) {
 			$errorcode = 'MissingTrueStrict';
 
 			/*
 			 * Use a different error code when `false` is found to allow for excluding
 			 * the warning as this will be a conscious choice made by the dev.
 			 */
-			if ( isset( $parameters[3] ) && 'false' === strtolower( $parameters[3]['raw'] ) ) {
+			if ( is_array( $found_parameter ) && 'false' === strtolower( $found_parameter['raw'] ) ) {
 				$errorcode = 'FoundNonStrictFalse';
 			}
 
 			$this->phpcsFile->addWarning(
-				'Not using strict comparison for %s; supply true for third argument.',
-				( isset( $parameters[3]['start'] ) ? $parameters[3]['start'] : $parameters[1]['start'] ),
+				'Not using strict comparison for %s; supply true for $%s argument.',
+				( isset( $found_parameter['start'] ) ? $found_parameter['start'] : $stackPtr ),
 				$errorcode,
-				array( $matched_content )
+				array( $matched_content, $param_info['param_name'] )
 			);
-			return;
 		}
 	}
-
 }

--- a/WordPress/Tests/PHP/StrictInArrayUnitTest.inc
+++ b/WordPress/Tests/PHP/StrictInArrayUnitTest.inc
@@ -14,7 +14,7 @@ $bar->in_array( 1, array( '1', 1, true ) ); // Ok.
 $bar->
 	in_array( 1, array( '1', 1, true ) ); // Ok.
 
-in_array(); // Error.
+in_array(); // Warning.
 
 
 array_search( 1, $array, true ); // Ok.
@@ -38,3 +38,12 @@ array_keys( array( '1', 1, true ), 'my_key', false ); // Warning
 in_array( 1, array( '1', 1 ), TRUE ); // Ok.
 
 use function in_array; // OK.
+
+// Safeguard support for PHP 8.0+ named parameters.
+in_array( strict: true, haystack: $haystack1, needle: 1, ); // Ok.
+in_array( needle: 1, haystack: $haystack ); // Warning.
+
+array_keys( array: $testing ); // Ok.
+array_keys( strict: false, array: $testing ); // Ok, will cause fatal error, but that's not the concern of this sniff.
+array_keys( $testing, filter_value: 'my_key' ); // Warning.
+array_keys( $testing, strict: false, filter_value: 'my_key' ); // Warning.

--- a/WordPress/Tests/PHP/StrictInArrayUnitTest.php
+++ b/WordPress/Tests/PHP/StrictInArrayUnitTest.php
@@ -48,7 +48,9 @@ class StrictInArrayUnitTest extends AbstractSniffUnitTest {
 			35 => 1,
 			36 => 1,
 			37 => 1,
+			44 => 1,
+			48 => 1,
+			49 => 1,
 		);
 	}
-
 }


### PR DESCRIPTION
1. Changed the `$target_functions` property to not only contain information about "always needed", but also about the target parameter name and position.
2. Adjusted the logic in the sniff to allow for named parameters using the new PHPCSUtils 1.0.0-alpha4 `PassedParameters::getParameterFromStack()` method..
3. The parameter names used are in line with the name as per the PHP 8.0 release.
    PHP itself renamed a lot of parameters in PHP 8.0. As named parameters did not exist before PHP 8.0, the parameter name as per PHP 8.0 (or above) is the only relevant name.
    Also see: https://github.com/php/doc-en/pull/2044

Includes additional unit tests.