### PR TITLE
Core: add sniffs to check the formatting of `::class` class resolution

### DIFF
--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -222,6 +222,13 @@
 		 no spaces between the operator and the variable it applies to. -->
 	<rule ref="Generic.WhiteSpace.IncrementDecrementSpacing"/>
 
+	<!-- Implied through the examples: Object operators should not have whitespace around them unless they are multi-line. -->
+	<rule ref="WordPress.WhiteSpace.ObjectOperatorSpacing">
+		<properties>
+			<property name="ignoreNewlines" value="true"/>
+		</properties>
+	</rule>
+
 
 	<!--
 	#############################################################################
@@ -382,9 +389,11 @@
 	<!-- Covers rule: The PHP native __*__ magic constants should be written in uppercase. -->
 	<rule ref="Universal.Constants.UppercaseMagicConstants"/>
 
-	<!-- Rule: When using the ::class constant for class name resolution, the class keyword should be in lowercase... -->
+	<!-- Covers rule: When using the ::class constant for class name resolution, the class keyword should be in lowercase... -->
+	<rule ref="Universal.Constants.LowercaseClassResolutionKeyword"/>
 
-	<!-- Rule: ... and there should be no spaces around the :: operator. -->
+	<!-- Covers rule: ... and there should be no spaces around the :: operator. -->
+	<!-- Covered by the WordPress.WhiteSpace.ObjectOperatorSpacing sniff. -->
 
 
 	<!--
@@ -717,13 +726,6 @@
 
 	<!-- Class opening braces should be on the same line as the statement. -->
 	<rule ref="Generic.Classes.OpeningBraceSameLine"/>
-
-	<!-- Object operators should not have whitespace around them unless they are multi-line. -->
-	<rule ref="WordPress.WhiteSpace.ObjectOperatorSpacing">
-		<properties>
-			<property name="ignoreNewlines" value="true"/>
-		</properties>
-	</rule>
 
 	<!-- References to self in a class should be lower-case and not have extraneous spaces,
 		 per implicit conventions in the core codebase; the NotUsed code refers to using the


### PR DESCRIPTION
> 1. There should be no space between `::class` and the preceding class name it applies to.
> 2. There should be no space between the double colon and the `class` keyword.
> 3. The `class` keyword should be in lowercase.

The first two rules are covered via the new `WordPress.WhiteSpace.ObjectOperatorSpacing` sniff. The last rule via a new sniff from PHPCSExtra.

Refs:
* https://make.wordpress.org/core/2020/03/20/updating-the-coding-standards-for-modern-php/ - `::class` constant section
* https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#magic-constants
* WordPress/wpcs-docs#113
* WordPress/WordPress-Coding-Standards#1115
* WordPress/WordPress-Coding-Standards#1116
* WordPress/WordPress-Coding-Standards#2095
* PHPCSStandards/PHPCSExtra#72