### PR TITLE
GH Actions: various tweaks / add PHP 8.3

### DIFF
--- a/.github/workflows/basic-qa.yml
+++ b/.github/workflows/basic-qa.yml
@@ -44,8 +44,8 @@ jobs:
       - name: Install Composer dependencies
         uses: ramsey/composer-install@v2
         with:
-          # Bust the cache at least once a month - output format: YYYY-MM-DD.
-          custom-cache-suffix: $(date -u -d "-0 month -$(($(date +%d)-1)) days" "+%F")
+          # Bust the cache at least once a month - output format: YYYY-MM.
+          custom-cache-suffix: $(date -u "+%Y-%m")
 
       - name: Install xmllint
         run: |
@@ -120,8 +120,8 @@ jobs:
       - name: Install Composer dependencies
         uses: ramsey/composer-install@v2
         with:
-          # Bust the cache at least once a month - output format: YYYY-MM-DD.
-          custom-cache-suffix: $(date -u -d "-0 month -$(($(date +%d)-1)) days" "+%F")
+          # Bust the cache at least once a month - output format: YYYY-MM.
+          custom-cache-suffix: $(date -u "+%Y-%m")
 
       - name: Test the WordPress-Core ruleset
         run: $(pwd)/vendor/bin/phpcs -ps ./Tests/RulesetCheck/class-ruleset-test.inc --standard=WordPress-Core

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -62,15 +62,15 @@ jobs:
         if: ${{ matrix.php < 8.0 && matrix.php != 'latest' }}
         uses: ramsey/composer-install@v2
         with:
-          # Bust the cache at least once a month - output format: YYYY-MM-DD.
-          custom-cache-suffix: $(date -u -d "-0 month -$(($(date +%d)-1)) days" "+%F")
+          # Bust the cache at least once a month - output format: YYYY-MM.
+          custom-cache-suffix: $(date -u "+%Y-%m")
 
       - name: Install Composer dependencies (PHP >= 8.0)
         if: ${{ matrix.php >= 8.0 || matrix.php == 'latest' }}
         uses: ramsey/composer-install@v2
         with:
           composer-options: --ignore-platform-reqs
-          custom-cache-suffix: $(date -u -d "-0 month -$(($(date +%d)-1)) days" "+%F")
+          custom-cache-suffix: $(date -u "+%Y-%m")
 
       - name: Lint PHP files against parse errors
         if: ${{ matrix.phpcs_version == 'dev-master' }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -60,15 +60,15 @@ jobs:
         if: ${{ matrix.php < 8.0 }}
         uses: ramsey/composer-install@v2
         with:
-          # Bust the cache at least once a month - output format: YYYY-MM-DD.
-          custom-cache-suffix: $(date -u -d "-0 month -$(($(date +%d)-1)) days" "+%F")
+          # Bust the cache at least once a month - output format: YYYY-MM.
+          custom-cache-suffix: $(date -u "+%Y-%m")
 
       - name: Install Composer dependencies (PHP >= 8.0)
         if: ${{ matrix.php >= 8.0 }}
         uses: ramsey/composer-install@v2
         with:
           composer-options: --ignore-platform-reqs
-          custom-cache-suffix: $(date -u -d "-0 month -$(($(date +%d)-1)) days" "+%F")
+          custom-cache-suffix: $(date -u "+%Y-%m")
 
       - name: Lint PHP files against parse errors
         if: ${{ matrix.phpcs_version == 'dev-master' }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [ '5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2' ]
+        php: [ '5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3' ]
         phpcs_version: [ '3.7.1', 'dev-master' ]
         #include:
           # Add extra build to test against PHPCS 4.
@@ -29,6 +29,8 @@ jobs:
           #  phpcs_version: '4.0.x-dev as 3.9.99'
 
     name: PHP ${{ matrix.php }} on PHPCS ${{ matrix.phpcs_version }}
+
+    continue-on-error: ${{ matrix.php == '8.3' }}
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
### GH Actions: minor simplification

... of the bash `date` command in the earlier pulled cache busting.

### GH Actions: update PHP versions in workflows

PHP 8.2 has been released today 🎉 and the `setup-php` action has announced support for PHP 8.3, so adding PHP 8.3 to the matrix.

Note: PHPCS does not (yet) have full syntax support for PHP 8.2, but it does have runtime support (for the most part, see squizlabs/PHP_CodeSniffer#3629).

Builds against PHP 8.3 are still allowed to fail for now.