### PR TITLE
Extra: add additional rules

### DIFF
--- a/WordPress-Extra/ruleset.xml
+++ b/WordPress-Extra/ruleset.xml
@@ -147,11 +147,29 @@
 		</properties>
 	</rule>
 
-
 	<!-- Prevent some typical mistakes people make accidentally.
-	     https://github.com/WordPress/WordPress-Coding-Standards/pull/1777 -->
+		 https://github.com/WordPress/WordPress-Coding-Standards/pull/1777 -->
 	<rule ref="WordPress.CodeAnalysis.EscapedNotTranslated"/>
 
+	<!-- Detects duplicate array keys in array declarations. -->
+	<rule ref="Universal.Arrays.DuplicateArrayKey"/>
+
+	<!-- Disallows return type declarations on constructor/destructor methods,
+		and constructor/destructor methods returning a value. -->
+	<rule ref="Universal.CodeAnalysis.ConstructorDestructorReturn"/>
+
+	<!-- Detects foreach control structures using the same variable for both key and value. -->
+	<rule ref="Universal.CodeAnalysis.ForeachUniqueAssignment"/>
+
+	<!-- Detects using static instead of self in object-oriented constructs which are final. -->
+	<rule ref="Universal.CodeAnalysis.StaticInFinalClass"/>
+
+	<!-- Disallow if statements, if they are the only statement in an else block. -->
+	<rule ref="Universal.ControlStructures.DisallowLonelyIf"/>
+
+	<!-- Enforce for a file to either declare (global/namespaced) functions
+		or declare object-oriented structures, but not both. -->
+	<rule ref="Universal.Files.SeparateFunctionsFromOO"/>
 
 	<!--
 	#############################################################################

--- a/WordPress/Sniffs/Arrays/MultipleStatementAlignmentSniff.php
+++ b/WordPress/Sniffs/Arrays/MultipleStatementAlignmentSniff.php
@@ -465,12 +465,10 @@ class MultipleStatementAlignmentSniff extends Sniff {
 
 			if ( \T_WHITESPACE !== $this->tokens[ ( $item['operatorPtr'] - 1 ) ]['code'] ) {
 				$before = 0;
+			} elseif ( $this->tokens[ $item['last_index_token'] ]['line'] !== $this->tokens[ $item['operatorPtr'] ]['line'] ) {
+				$before = 'newline';
 			} else {
-				if ( $this->tokens[ $item['last_index_token'] ]['line'] !== $this->tokens[ $item['operatorPtr'] ]['line'] ) {
-					$before = 'newline';
-				} else {
-					$before = $this->tokens[ ( $item['operatorPtr'] - 1 ) ]['length'];
-				}
+				$before = $this->tokens[ ( $item['operatorPtr'] - 1 ) ]['length'];
 			}
 
 			/*

--- a/WordPress/Sniffs/Security/EscapeOutputSniff.php
+++ b/WordPress/Sniffs/Security/EscapeOutputSniff.php
@@ -425,13 +425,11 @@ class EscapeOutputSniff extends Sniff {
 					if ( $is_formatting_function ) {
 						$i     = ( $function_opener + 1 );
 						$watch = true;
+					} elseif ( isset( $this->tokens[ $function_opener ]['parenthesis_closer'] ) ) {
+						$i = $this->tokens[ $function_opener ]['parenthesis_closer'];
 					} else {
-						if ( isset( $this->tokens[ $function_opener ]['parenthesis_closer'] ) ) {
-							$i = $this->tokens[ $function_opener ]['parenthesis_closer'];
-						} else {
-							// Live coding or parse error.
-							break;
-						}
+						// Live coding or parse error.
+						break;
 					}
 				}
 

--- a/WordPress/Sniffs/WP/EnqueuedResourceParametersSniff.php
+++ b/WordPress/Sniffs/WP/EnqueuedResourceParametersSniff.php
@@ -140,17 +140,15 @@ class EnqueuedResourceParametersSniff extends AbstractFunctionParameterSniff {
 				'MissingVersion',
 				array( $matched_content, $type )
 			);
-		} else {
 			// The version argument should have a non-false value.
-			if ( $this->is_falsy( $parameters[4]['start'], $parameters[4]['end'] ) ) {
-				$this->phpcsFile->addError(
-					'Version parameter is not explicitly set or has been set to an equivalent of "false" for %s; ' .
-					'This means that the WordPress core version will be used which is not recommended for plugin or theme development.',
-					$stackPtr,
-					'NoExplicitVersion',
-					array( $matched_content )
-				);
-			}
+		} elseif ( $this->is_falsy( $parameters[4]['start'], $parameters[4]['end'] ) ) {
+			$this->phpcsFile->addError(
+				'Version parameter is not explicitly set or has been set to an equivalent of "false" for %s; ' .
+				'This means that the WordPress core version will be used which is not recommended for plugin or theme development.',
+				$stackPtr,
+				'NoExplicitVersion',
+				array( $matched_content )
+			);
 		}
 
 		/*


### PR DESCRIPTION
This PR will add the following useful rules to the WordPress-Extra ruleset from the PHPCSExtra ruleset:

- `Universal.Arrays.DuplicateArrayKey`
- `Universal.CodeAnalysis.ConstructorDestructorReturn`
- `Universal.CodeAnalysis.ForeachUniqueAssignment`
- `Universal.CodeAnalysis.StaticInFinalClass`
- `Universal.ControlStructures.DisallowLonelyIf`
- `Universal.Files.SeparateFunctionsFromOO`

For the entire documentation of the added sniffs check the [documentation](https://github.com/PHPCSStandards/PHPCSExtra).

The PR also fixes the violations of the newly added sniffs and does a small cleanup of the spaces in the ruleset file.