### PR TITLE
New `WPHookHelper` utility class, incl PHP 8.0+ named param helper

### DIFF
--- a/WordPress/Helpers/WPHookHelper.php
+++ b/WordPress/Helpers/WPHookHelper.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPressCS\WordPress\Helpers;
+
+/**
+ * Helper utilities for recognizing functions related to the WP Hook mechanism.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @since   3.0.0 The property in this class was previously contained in the
+ *                `WordPressCS\WordPress\Sniff` class and has been moved here.
+ */
+final class WPHookHelper {
+
+	/**
+	 * A list of functions that invoke WP hooks (filters/actions).
+	 *
+	 * @since 0.10.0
+	 * @since 0.11.0 Changed from public static to protected non-static.
+	 * @since 3.0.0  - Moved from the Sniff class to this class.
+	 *               - The property visibility has changed from `protected` to `private static`.
+	 *                 Use the `get_function_names()` method for access.
+	 *
+	 * @var array<string, bool>
+	 */
+	private static $hookInvokeFunctions = array(
+		'do_action'                => true,
+		'do_action_ref_array'      => true,
+		'do_action_deprecated'     => true,
+		'apply_filters'            => true,
+		'apply_filters_ref_array'  => true,
+		'apply_filters_deprecated' => true,
+	);
+
+	/**
+	 * Retrieve a list of the WordPress functions which invoke hooks.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @param bool $include_deprecated Whether to include the names of functions
+	 *                                 which are used to invoke deprecated hooks.
+	 *                                 Defaults to `true`.
+	 *
+	 * @return array<string, bool> Array with the function names as keys. The value is irrelevant.
+	 */
+	public static function get_functions( $include_deprecated = true ) {
+		$hooks = self::$hookInvokeFunctions;
+		if ( false === $include_deprecated ) {
+			unset(
+				$hooks['do_action_deprecated'],
+				$hooks['apply_filters_deprecated']
+			);
+		}
+
+		return $hooks;
+	}
+}

--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -471,23 +471,6 @@ abstract class Sniff implements PHPCS_Sniff {
 	);
 
 	/**
-	 * A list of functions that invoke WP hooks (filters/actions).
-	 *
-	 * @since 0.10.0
-	 * @since 0.11.0 Changed from public static to protected non-static.
-	 *
-	 * @var array
-	 */
-	protected $hookInvokeFunctions = array(
-		'do_action'                => true,
-		'do_action_ref_array'      => true,
-		'do_action_deprecated'     => true,
-		'apply_filters'            => true,
-		'apply_filters_ref_array'  => true,
-		'apply_filters_deprecated' => true,
-	);
-
-	/**
 	 * List of global WP variables.
 	 *
 	 * @since 0.3.0

--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -488,29 +488,6 @@ abstract class Sniff implements PHPCS_Sniff {
 	);
 
 	/**
-	 * A list of functions that are used to interact with the WP plugins API.
-	 *
-	 * @since 0.10.0
-	 * @since 0.11.0 Changed from public static to protected non-static.
-	 *
-	 * @var array <string function name> => <int position of the hook name argument in function signature>
-	 */
-	protected $hookFunctions = array(
-		'has_filter'         => 1,
-		'add_filter'         => 1,
-		'remove_filter'      => 1,
-		'remove_all_filters' => 1,
-		'doing_filter'       => 1, // Hook name optional.
-		'has_action'         => 1,
-		'add_action'         => 1,
-		'doing_action'       => 1, // Hook name optional.
-		'did_action'         => 1,
-		'remove_action'      => 1,
-		'remove_all_actions' => 1,
-		'current_filter'     => 0, // No hook name argument.
-	);
-
-	/**
 	 * List of global WP variables.
 	 *
 	 * @since 0.3.0

--- a/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
+++ b/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
@@ -20,6 +20,7 @@ use PHPCSUtils\Utils\TextStrings;
 use WordPressCS\WordPress\AbstractFunctionParameterSniff;
 use WordPressCS\WordPress\Helpers\DeprecationHelper;
 use WordPressCS\WordPress\Helpers\IsUnitTestTrait;
+use WordPressCS\WordPress\Helpers\WPHookHelper;
 
 /**
  * Verify that everything defined in the global namespace is prefixed with a theme/plugin specific prefix.
@@ -254,12 +255,8 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 	 * @return array
 	 */
 	public function getGroups() {
-		$this->target_functions = $this->hookInvokeFunctions;
-		unset(
-			$this->target_functions['do_action_deprecated'],
-			$this->target_functions['apply_filters_deprecated']
-		);
-
+		// Only retrieve functions which are not used for deprecated hooks.
+		$this->target_functions           = WPHookHelper::get_functions( false );
 		$this->target_functions['define'] = true;
 
 		return parent::getGroups();

--- a/WordPress/Sniffs/NamingConventions/ValidHookNameSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidHookNameSniff.php
@@ -9,9 +9,10 @@
 
 namespace WordPressCS\WordPress\Sniffs\NamingConventions;
 
-use WordPressCS\WordPress\AbstractFunctionParameterSniff;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\Utils\TextStrings;
+use WordPressCS\WordPress\AbstractFunctionParameterSniff;
+use WordPressCS\WordPress\Helpers\WPHookHelper;
 
 /**
  * Use lowercase letters in action and filter names. Separate words via underscores.
@@ -73,13 +74,8 @@ class ValidHookNameSniff extends AbstractFunctionParameterSniff {
 	 * @return array
 	 */
 	public function getGroups() {
-		$this->target_functions = $this->hookInvokeFunctions;
-
-		// No need to examine the names of deprecated hooks.
-		unset(
-			$this->target_functions['do_action_deprecated'],
-			$this->target_functions['apply_filters_deprecated']
-		);
+		// Only retrieve functions which are not used for deprecated hooks.
+		$this->target_functions = WPHookHelper::get_functions( false );
 
 		return parent::getGroups();
 	}


### PR DESCRIPTION
### Sniff: remove the $hookFunctions property

... as it is not currently used anywhere in the WPCS codebase.

### Move "hook" related utilities to dedicated WPHookHelper

The "hook" related property is only used by a small set of sniffs, so are better placed in a dedicated class.

This commit moves the `$hookInvokeFunctions` property to a new `WordPressCS\WordPress\Helpers\WPHookHelper` class and starts using that class in the relevant sniffs.

Note:
* The property is now `private` (and `static`).
* Access to the property can be obtained via the new `WPHookHelper::get_functions()` method.
* This new method can also pre-filter the list to only return thos functions which are not specifically to invoke deprecated hooks.

Related to #1465

### WPHookHelper: add new get_hook_name_param() method

... to support retrieving the hook name parameters from a stack of parameters, while supporting PHP 8.0+ function calls using named arguments.

This new method will be tested via the implementations in the `ValidHookName` and the `PrefixAllGlobals` sniffs (upcoming).