### PR TITLE
MinimumWPVersionTrait: add new `wp_version_compare()` method (bug fix)

### DIFF
--- a/WordPress/Helpers/MinimumWPVersionTrait.php
+++ b/WordPress/Helpers/MinimumWPVersionTrait.php
@@ -97,4 +97,27 @@ trait MinimumWPVersionTrait {
 		}
 	}
 
+	/**
+	 * Compares two version numbers.
+	 *
+	 * Ensures that the version numbers are comparable via the PHP version_compare() function
+	 * by making sure they comply with the minimum "PHP-standardized" version number requirements.
+	 *
+	 * @param string $version1 First version number.
+	 * @param string $version2 Second version number.
+	 * @param string $operator Comparison operator.
+	 *
+	 * @return bool
+	 */
+	protected function wp_version_compare( $version1, $version2, $operator ) {
+		if ( preg_match( '`^\d+\.\d+$`', $version1 ) ) {
+			$version1 .= '.0';
+		}
+
+		if ( preg_match( '`^\d+\.\d+$`', $version2 ) ) {
+			$version2 .= '.0';
+		}
+
+		return version_compare( $version1, $version2, $operator );
+	}
 }

--- a/WordPress/Sniffs/WP/AlternativeFunctionsSniff.php
+++ b/WordPress/Sniffs/WP/AlternativeFunctionsSniff.php
@@ -210,7 +210,7 @@ class AlternativeFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 				 * @see https://developer.wordpress.org/reference/functions/wp_parse_url/#changelog
 				 */
 				if ( PassedParameters::getParameterCount( $this->phpcsFile, $stackPtr ) !== 1
-					&& version_compare( $this->minimum_wp_version, '4.7.0', '<' )
+					&& $this->wp_version_compare( $this->minimum_wp_version, '4.7.0', '<' )
 				) {
 					return;
 				}
@@ -288,7 +288,7 @@ class AlternativeFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 		}
 
 		// Verify if the alternative is available in the minimum supported WP version.
-		if ( version_compare( $this->groups[ $group_name ]['since'], $this->minimum_wp_version, '<=' ) ) {
+		if ( $this->wp_version_compare( $this->groups[ $group_name ]['since'], $this->minimum_wp_version, '<=' ) ) {
 			return parent::process_matched_token( $stackPtr, $group_name, $matched_content );
 		}
 	}

--- a/WordPress/Sniffs/WP/CapabilitiesSniff.php
+++ b/WordPress/Sniffs/WP/CapabilitiesSniff.php
@@ -434,7 +434,7 @@ class CapabilitiesSniff extends AbstractFunctionParameterSniff {
 
 		if ( isset( $this->deprecated_capabilities[ $matched_parameter ] ) ) {
 			$this->get_wp_version_from_cli( $this->phpcsFile );
-			$is_error = version_compare( $this->deprecated_capabilities[ $matched_parameter ], $this->minimum_wp_version, '<' );
+			$is_error = $this->wp_version_compare( $this->deprecated_capabilities[ $matched_parameter ], $this->minimum_wp_version, '<' );
 
 			$data = array(
 				$matched_parameter,

--- a/WordPress/Sniffs/WP/DeprecatedClassesSniff.php
+++ b/WordPress/Sniffs/WP/DeprecatedClassesSniff.php
@@ -116,7 +116,7 @@ class DeprecatedClassesSniff extends AbstractClassRestrictionsSniff {
 			$this->phpcsFile,
 			$message,
 			$stackPtr,
-			( version_compare( $this->deprecated_classes[ $class_name ]['version'], $this->minimum_wp_version, '<' ) ),
+			( $this->wp_version_compare( $this->deprecated_classes[ $class_name ]['version'], $this->minimum_wp_version, '<' ) ),
 			MessageHelper::stringToErrorcode( $class_name . 'Found' ),
 			$data
 		);

--- a/WordPress/Sniffs/WP/DeprecatedFunctionsSniff.php
+++ b/WordPress/Sniffs/WP/DeprecatedFunctionsSniff.php
@@ -1545,7 +1545,7 @@ class DeprecatedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 			$this->phpcsFile,
 			$message,
 			$stackPtr,
-			( version_compare( $this->deprecated_functions[ $function_name ]['version'], $this->minimum_wp_version, '<' ) ),
+			( $this->wp_version_compare( $this->deprecated_functions[ $function_name ]['version'], $this->minimum_wp_version, '<' ) ),
 			MessageHelper::stringToErrorcode( $matched_content . 'Found' ),
 			$data
 		);

--- a/WordPress/Sniffs/WP/DeprecatedParameterValuesSniff.php
+++ b/WordPress/Sniffs/WP/DeprecatedParameterValuesSniff.php
@@ -208,7 +208,7 @@ class DeprecatedParameterValuesSniff extends AbstractFunctionParameterSniff {
 			$data[]   = $parameter_args[ $matched_parameter ]['alt'];
 		}
 
-		$is_error = version_compare( $parameter_args[ $matched_parameter ]['version'], $this->minimum_wp_version, '<' );
+		$is_error = $this->wp_version_compare( $parameter_args[ $matched_parameter ]['version'], $this->minimum_wp_version, '<' );
 		MessageHelper::addMessage(
 			$this->phpcsFile,
 			$message,

--- a/WordPress/Sniffs/WP/DeprecatedParametersSniff.php
+++ b/WordPress/Sniffs/WP/DeprecatedParametersSniff.php
@@ -345,7 +345,7 @@ class DeprecatedParametersSniff extends AbstractFunctionParameterSniff {
 			}
 
 			$message  = 'The parameter "%s" at position #%s of %s() has been deprecated since WordPress version %s.';
-			$is_error = version_compare( $parameter_args['version'], $this->minimum_wp_version, '<' );
+			$is_error = $this->wp_version_compare( $parameter_args['version'], $this->minimum_wp_version, '<' );
 			$code     = MessageHelper::stringToErrorcode( ucfirst( $matched_content ) . 'Param' . $position . 'Found' );
 
 			$data = array(


### PR DESCRIPTION
... and implement it in the relevant places.

The PHP native `version_compare()` function expects two "PHP-standardized" version number strings and has some quirks if the numbers are not "PHP-standardized", i.e. one of the two numbers is a `#.#`-style version number, while the other is a `#.#.#`-style version number.
See: https://3v4l.org/OUMWE

This helper method works round those quirks and will ensure that the version comparisons done with the `$this->minimum_wp_version` are correct.

This fixes some subtle (and unreported) bugs with the version comparisons.