### PR TITLE
Arrays/ArrayKeySpacingRestrictions: small bug fix

### DIFF
--- a/WordPress/Sniffs/Arrays/ArrayKeySpacingRestrictionsSniff.php
+++ b/WordPress/Sniffs/Arrays/ArrayKeySpacingRestrictionsSniff.php
@@ -99,6 +99,8 @@ class ArrayKeySpacingRestrictionsSniff extends Sniff {
 			$error = 'Array keys must be surrounded by spaces unless they contain a string or an integer.';
 			$fix   = $this->phpcsFile->addFixableError( $error, $stackPtr, 'NoSpacesAroundArrayKeys' );
 			if ( true === $fix ) {
+				$this->phpcsFile->fixer->beginChangeset();
+
 				if ( false === $has_space_after_opener ) {
 					$this->phpcsFile->fixer->addContent( $stackPtr, ' ' );
 				}
@@ -106,6 +108,8 @@ class ArrayKeySpacingRestrictionsSniff extends Sniff {
 				if ( false === $has_space_before_close ) {
 					$this->phpcsFile->fixer->addContentBefore( $token['bracket_closer'], ' ' );
 				}
+
+				$this->phpcsFile->fixer->endChangeset();
 			}
 		} elseif ( false === $needs_spaces && ( $has_space_after_opener || $has_space_before_close ) ) {
 			$error = 'Array keys must NOT be surrounded by spaces if they only contain a string or an integer.';


### PR DESCRIPTION
If an auto-fix contains more than one instruction, it should be wrapped in `beginChangeset()`/`endChangeset()` function calls.

This auto-fix code could potentially touch two tokens, so should included the changeset wrapper function calls.

FYI: the wrapper calls are used to potentially revert changes if they would conflict with changes made by another sniff in the same fixer loop. In that case, the changes are attempted again in the next fixer loop, with the fixer trying up to 50 loops before giving up.