### PR TITLE
WhiteSpace/OperatorSpacing: add extra tests with PHP 8.0+ types

### DIFF
--- a/WordPress/Tests/WhiteSpace/OperatorSpacingUnitTest.inc
+++ b/WordPress/Tests/WhiteSpace/OperatorSpacingUnitTest.inc
@@ -64,3 +64,14 @@ if ( $a === $b
 
 if ( $a === $b or
 	$b === $c ) {}
+
+// Safeguard that the "|" in PHP 8.0 union types is disregarded.
+function foo( int|float $param ) : string|false {}
+
+// Safeguard that the "&" in PHP 8.1 intersection types is disregarded.
+function foo( TypeA&namespace\TypeB $param ) : \TypeC&Partially\Qualified {}
+
+// Safeguard handling of union type separator for readonly properties.
+class Foo {
+	public readonly int|string $prop;
+}

--- a/WordPress/Tests/WhiteSpace/OperatorSpacingUnitTest.inc.fixed
+++ b/WordPress/Tests/WhiteSpace/OperatorSpacingUnitTest.inc.fixed
@@ -64,3 +64,14 @@ if ( $a === $b
 
 if ( $a === $b or
 	$b === $c ) {}
+
+// Safeguard that the "|" in PHP 8.0 union types is disregarded.
+function foo( int|float $param ) : string|false {}
+
+// Safeguard that the "&" in PHP 8.1 intersection types is disregarded.
+function foo( TypeA&namespace\TypeB $param ) : \TypeC&Partially\Qualified {}
+
+// Safeguard handling of union type separator for readonly properties.
+class Foo {
+	public readonly int|string $prop;
+}


### PR DESCRIPTION
PHP 8.0 introduced union types which use the `T_BITWISE_OR` - `|` - token to separate the types. The `|` when used in a union type will be retokenized as `T_TYPE_UNION` since PHPCS 3.6.0.

PHP 8.1 introduced intersection types which use the `T_BITWISE_AND` - `&` - token to separate the types. PHP 8.1 also changed the way the `&` is tokenized natively in PHP itself. The PHP 8.1 tokenization change was accounted for in PHPCS 3.6.1. The `&` when used in a intersection types will be retokenized as `T_TYPE_INTERSECTION` since PHPCS 3.7.0.

PHP 8.1 `readonly` properties necessitated an extra fix in PHPCS to retokenize the `T_BITWISE_OR` token to `T_TYPE_UNION` for property types. This fix was included in PHPCS 3.7.0.

The union type separator and the intersection type separator are not a "normal" operators, so the "normal" spacing rules for operators (one space either side, new line allowed), do not apply.

As without the above mentioned upstream PHPCS tokenizer fixes, the `WordPress.WhiteSpace.OperatorSpacing` would try to act on these type separators, this commit adds some extra tests to the `WordPress.WhiteSpace.OperatorSpacing` sniff to ensure that type separators are **not** touched by this sniff.