### PR TITLE
Sniff: move the `$cache*Functions` properties to the `DB/DirectDatabaseQuery` Sniff

### DIFF
--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -423,54 +423,6 @@ abstract class Sniff implements PHPCS_Sniff {
 	);
 
 	/**
-	 * A list of functions that get data from the cache.
-	 *
-	 * @since 0.6.0
-	 * @since 0.11.0 Changed from public static to protected non-static.
-	 *
-	 * @var array
-	 */
-	protected $cacheGetFunctions = array(
-		'wp_cache_get' => true,
-	);
-
-	/**
-	 * A list of functions that set data in the cache.
-	 *
-	 * @since 0.6.0
-	 * @since 0.11.0 Changed from public static to protected non-static.
-	 *
-	 * @var array
-	 */
-	protected $cacheSetFunctions = array(
-		'wp_cache_set' => true,
-		'wp_cache_add' => true,
-	);
-
-	/**
-	 * A list of functions that delete data from the cache.
-	 *
-	 * @since 0.6.0
-	 * @since 0.11.0 Changed from public static to protected non-static.
-	 *
-	 * @var array
-	 */
-	protected $cacheDeleteFunctions = array(
-		'wp_cache_delete'         => true,
-		'clean_attachment_cache'  => true,
-		'clean_blog_cache'        => true,
-		'clean_bookmark_cache'    => true,
-		'clean_category_cache'    => true,
-		'clean_comment_cache'     => true,
-		'clean_network_cache'     => true,
-		'clean_object_term_cache' => true,
-		'clean_page_cache'        => true,
-		'clean_post_cache'        => true,
-		'clean_term_cache'        => true,
-		'clean_user_cache'        => true,
-	);
-
-	/**
 	 * List of global WP variables.
 	 *
 	 * @since 0.3.0

--- a/WordPress/Sniffs/DB/DirectDatabaseQuerySniff.php
+++ b/WordPress/Sniffs/DB/DirectDatabaseQuerySniff.php
@@ -71,6 +71,57 @@ class DirectDatabaseQuerySniff extends Sniff {
 	);
 
 	/**
+	 * A list of functions that get data from the cache.
+	 *
+	 * @since 0.6.0
+	 * @since 0.11.0 Changed from public static to protected non-static.
+	 * @since 3.0.0  Moved from the generic `Sniff` class to this class.
+	 *
+	 * @var array
+	 */
+	protected $cacheGetFunctions = array(
+		'wp_cache_get' => true,
+	);
+
+	/**
+	 * A list of functions that set data in the cache.
+	 *
+	 * @since 0.6.0
+	 * @since 0.11.0 Changed from public static to protected non-static.
+	 * @since 3.0.0  Moved from the generic `Sniff` class to this class.
+	 *
+	 * @var array
+	 */
+	protected $cacheSetFunctions = array(
+		'wp_cache_set' => true,
+		'wp_cache_add' => true,
+	);
+
+	/**
+	 * A list of functions that delete data from the cache.
+	 *
+	 * @since 0.6.0
+	 * @since 0.11.0 Changed from public static to protected non-static.
+	 * @since 3.0.0  Moved from the generic `Sniff` class to this class.
+	 *
+	 * @var array
+	 */
+	protected $cacheDeleteFunctions = array(
+		'wp_cache_delete'         => true,
+		'clean_attachment_cache'  => true,
+		'clean_blog_cache'        => true,
+		'clean_bookmark_cache'    => true,
+		'clean_category_cache'    => true,
+		'clean_comment_cache'     => true,
+		'clean_network_cache'     => true,
+		'clean_object_term_cache' => true,
+		'clean_page_cache'        => true,
+		'clean_post_cache'        => true,
+		'clean_term_cache'        => true,
+		'clean_user_cache'        => true,
+	);
+
+	/**
 	 * The lists of $wpdb methods.
 	 *
 	 * @since 0.6.0


### PR DESCRIPTION
The `Sniff::$cacheGetFunctions`, `Sniff::$cacheSetFunctions` and `Sniff::$cacheDeleteFunctions` properties are _only_ used by the `WordPress.DB.DirectDatabaseQuerySniff` sniff, so these don't belong in the generic base `Sniff` class.

A [code search](https://sourcegraph.com/search?q=context:global+-%3Ecache%28Get%7CSet%7CDelete%29Functions+-file:%5E%28.*/%29%3Fvendor/wp-coding-standards/.*%24&patternType=regexp&case=yes&sm=0) also shows these properties are not used by sniffs from external standards, so this change should have no noticeable impact.