### PR TITLE
DateTime/CurrentTimeTimestamp: add support for PHP 8.0+ named parameters + minor tweak

### DIFF
--- a/WordPress/Sniffs/DateTime/CurrentTimeTimestampSniff.php
+++ b/WordPress/Sniffs/DateTime/CurrentTimeTimestampSniff.php
@@ -9,9 +9,10 @@
 
 namespace WordPressCS\WordPress\Sniffs\DateTime;
 
-use WordPressCS\WordPress\AbstractFunctionParameterSniff;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Utils\PassedParameters;
 use PHPCSUtils\Utils\TextStrings;
+use WordPressCS\WordPress\AbstractFunctionParameterSniff;
 
 /**
  * Don't use current_time() to get a (timezone corrected) "timestamp".
@@ -74,7 +75,13 @@ class CurrentTimeTimestampSniff extends AbstractFunctionParameterSniff {
 		/*
 		 * Check whether the first parameter is a timestamp format.
 		 */
-		for ( $i = $parameters[1]['start']; $i <= $parameters[1]['end']; $i++ ) {
+		$type_param = PassedParameters::getParameterFromStack( $parameters, 1, 'type' );
+		if ( false === $type_param ) {
+			// Type parameter not found. Bow out.
+			return;
+		}
+
+		for ( $i = $type_param['start']; $i <= $type_param['end']; $i++ ) {
 			if ( isset( Tokens::$emptyTokens[ $this->tokens[ $i ]['code'] ] ) ) {
 				continue;
 			}
@@ -105,14 +112,15 @@ class CurrentTimeTimestampSniff extends AbstractFunctionParameterSniff {
 		/*
 		 * Check whether the second parameter, $gmt, is a set to `true` or `1`.
 		 */
-		if ( isset( $parameters[2] ) ) {
+		$gmt_param = PassedParameters::getParameterFromStack( $parameters, 2, 'gmt' );
+		if ( is_array( $gmt_param ) ) {
 			$content_second = '';
-			if ( 'true' === $parameters[2]['raw'] || '1' === $parameters[2]['raw'] ) {
-				$content_second = $parameters[2]['raw'];
+			if ( 'true' === $gmt_param['raw'] || '1' === $gmt_param['raw'] ) {
+				$content_second = $gmt_param['raw'];
 				$gmt_true       = true;
 			} else {
 				// Do a more extensive parameter check.
-				for ( $i = $parameters[2]['start']; $i <= $parameters[2]['end']; $i++ ) {
+				for ( $i = $gmt_param['start']; $i <= $gmt_param['end']; $i++ ) {
 					if ( isset( Tokens::$emptyTokens[ $this->tokens[ $i ]['code'] ] ) ) {
 						continue;
 					}

--- a/WordPress/Sniffs/DateTime/CurrentTimeTimestampSniff.php
+++ b/WordPress/Sniffs/DateTime/CurrentTimeTimestampSniff.php
@@ -115,22 +115,9 @@ class CurrentTimeTimestampSniff extends AbstractFunctionParameterSniff {
 		$gmt_param = PassedParameters::getParameterFromStack( $parameters, 2, 'gmt' );
 		if ( is_array( $gmt_param ) ) {
 			$content_second = '';
-			if ( 'true' === $gmt_param['raw'] || '1' === $gmt_param['raw'] ) {
-				$content_second = $gmt_param['raw'];
+			if ( 'true' === $gmt_param['clean'] || '1' === $gmt_param['clean'] ) {
+				$content_second = $gmt_param['clean'];
 				$gmt_true       = true;
-			} else {
-				// Do a more extensive parameter check.
-				for ( $i = $gmt_param['start']; $i <= $gmt_param['end']; $i++ ) {
-					if ( isset( Tokens::$emptyTokens[ $this->tokens[ $i ]['code'] ] ) ) {
-						continue;
-					}
-
-					$content_second .= $this->tokens[ $i ]['content'];
-				}
-
-				if ( 'true' === $content_second || '1' === $content_second ) {
-					$gmt_true = true;
-				}
 			}
 		}
 
@@ -163,7 +150,6 @@ class CurrentTimeTimestampSniff extends AbstractFunctionParameterSniff {
 		if ( false !== $has_comment ) {
 			// If there are comments, we don't auto-fix as it would remove those comments.
 			$this->phpcsFile->addError( $error, $stackPtr, $error_code, array( $code_snippet ) );
-
 			return;
 		}
 
@@ -179,5 +165,4 @@ class CurrentTimeTimestampSniff extends AbstractFunctionParameterSniff {
 			$this->phpcsFile->fixer->endChangeset();
 		}
 	}
-
 }

--- a/WordPress/Tests/DateTime/CurrentTimeTimestampUnitTest.inc
+++ b/WordPress/Tests/DateTime/CurrentTimeTimestampUnitTest.inc
@@ -23,3 +23,10 @@ current_time( 'timestamp', $gmt ); // Warning.
 current_time( 'timestamp', false ); // Warning.
 current_time( 'U', 0 ); // Warning.
 current_time( 'U' ); // Warning.
+
+// Safeguard support for PHP 8.0+ named parameters.
+current_time( gmt: false ); // OK. Well not really (missing required $type), but not our concern.
+current_time( gmt: true, type: 'mysql', ); // OK.
+current_time( type: 'Y-m-d' ); // OK.
+current_time( gmt: true, type: 'timestamp' ); // Error.
+current_time( gmt: 0, type : 'U' ); // Warning.

--- a/WordPress/Tests/DateTime/CurrentTimeTimestampUnitTest.inc.fixed
+++ b/WordPress/Tests/DateTime/CurrentTimeTimestampUnitTest.inc.fixed
@@ -20,3 +20,10 @@ current_time( 'timestamp', $gmt ); // Warning.
 current_time( 'timestamp', false ); // Warning.
 current_time( 'U', 0 ); // Warning.
 current_time( 'U' ); // Warning.
+
+// Safeguard support for PHP 8.0+ named parameters.
+current_time( gmt: false ); // OK. Well not really (missing required $type), but not our concern.
+current_time( gmt: true, type: 'mysql', ); // OK.
+current_time( type: 'Y-m-d' ); // OK.
+time(); // Error.
+current_time( gmt: 0, type : 'U' ); // Warning.

--- a/WordPress/Tests/DateTime/CurrentTimeTimestampUnitTest.php
+++ b/WordPress/Tests/DateTime/CurrentTimeTimestampUnitTest.php
@@ -30,6 +30,7 @@ class CurrentTimeTimestampUnitTest extends AbstractSniffUnitTest {
 			9  => 1,
 			11 => 1,
 			17 => 1,
+			31 => 1,
 		);
 	}
 
@@ -44,7 +45,7 @@ class CurrentTimeTimestampUnitTest extends AbstractSniffUnitTest {
 			23 => 1,
 			24 => 1,
 			25 => 1,
+			32 => 1,
 		);
 	}
-
 }


### PR DESCRIPTION
### DateTime/CurrentTimeTimestamp: add support for PHP 8.0+ named parameters

1. Adjusted the way the correct parameters are retrieved to use the new PHPCSUtils 1.0.0-alpha4 `PassedParameters::getParameterFromStack()` method.
2. Verified the parameter names used are in line with the name as per the WP 6.1 release.
    WP has been renaming parameters and is probably not done yet, but it doesn't look like those changes (so far) made it into changelog entries....
    For the purposes of this exercise, I've taken the _current_ parameter name as the "truth" as support for named parameters hasn't officially been announced yet, so any renames _after_ this moment are the only ones relevant.

Includes additional unit tests.

### DateTime/CurrentTimeTimestamp: minor code simplification

The `'raw'` key in the parameter arrays returned from the `PassedParameters` class contains - as per the name - the _raw_ contents of the parameter.

Since PHPCSUtils 1.0.0-alpha4, the return array also contain a `'clean'` index, which contains the contents of the parameter cleaned of comments.

By switching to using that key, some additional logic which was in place to prevent false negatives when the parameter contained comments can be removed.

Safeguarded by pre-existing unit test on line 17-20.