### PR TITLE
PHP/IniSet: add support for PHP 8.0+ named parameters + bug fix

### DIFF
--- a/WordPress/Sniffs/PHP/IniSetSniff.php
+++ b/WordPress/Sniffs/PHP/IniSetSniff.php
@@ -151,8 +151,8 @@ class IniSetSniff extends AbstractFunctionParameterSniff {
 			return;
 		}
 
-		$option_name  = TextStrings::stripQuotes( $option_param['raw'] );
-		$option_value = TextStrings::stripQuotes( $value_param['raw'] );
+		$option_name  = TextStrings::stripQuotes( $option_param['clean'] );
+		$option_value = TextStrings::stripQuotes( $value_param['clean'] );
 		if ( isset( $this->safe_options[ $option_name ] ) ) {
 			$safe_option = $this->safe_options[ $option_name ];
 			if ( ! isset( $safe_option['valid_values'] ) || in_array( strtolower( $option_value ), $safe_option['valid_values'], true ) ) {
@@ -169,8 +169,8 @@ class IniSetSniff extends AbstractFunctionParameterSniff {
 					MessageHelper::stringToErrorcode( $option_name . '_Disallowed' ),
 					array(
 						$matched_content,
-						$option_param['raw'],
-						$value_param['raw'],
+						$option_param['clean'],
+						$value_param['clean'],
 						$disallowed_option['message'],
 					)
 				);
@@ -184,8 +184,8 @@ class IniSetSniff extends AbstractFunctionParameterSniff {
 			'Risky',
 			array(
 				$matched_content,
-				$option_param['raw'],
-				$value_param['raw'],
+				$option_param['clean'],
+				$value_param['clean'],
 			)
 		);
 	}

--- a/WordPress/Sniffs/PHP/IniSetSniff.php
+++ b/WordPress/Sniffs/PHP/IniSetSniff.php
@@ -101,13 +101,13 @@ class IniSetSniff extends AbstractFunctionParameterSniff {
 			'message' => 'Changing the option value can break other plugins. Use the filter flag constants when calling the Filter functions instead.',
 		),
 		'iconv.input_encoding' => array(
-			'message' => 'PHP < 5.6 only - use `iconv_set_encoding()` instead.',
+			'message' => 'This option is not supported since PHP 5.6 - use `iconv_set_encoding()` instead.',
 		),
 		'iconv.internal_encoding' => array(
-			'message' => 'PHP < 5.6 only - use `iconv_set_encoding()` instead.',
+			'message' => 'This option is not supported since PHP 5.6 - use `iconv_set_encoding()` instead.',
 		),
 		'iconv.output_encoding' => array(
-			'message' => 'PHP < 5.6 only - use `iconv_set_encoding()` instead.',
+			'message' => 'This option is not supported since PHP 5.6 - use `iconv_set_encoding()` instead.',
 		),
 		'ignore_user_abort' => array(
 			'message' => 'Use `ignore_user_abort()` instead.',
@@ -166,7 +166,7 @@ class IniSetSniff extends AbstractFunctionParameterSniff {
 				|| in_array( strtolower( $option_value ), $disallowed_option['invalid_values'], true )
 			) {
 				$this->phpcsFile->addError(
-					'%s(%s, %s) found. %s',
+					'Found: %s(%s, %s). %s',
 					$stackPtr,
 					MessageHelper::stringToErrorcode( $option_name . '_Disallowed' ),
 					array(
@@ -181,7 +181,7 @@ class IniSetSniff extends AbstractFunctionParameterSniff {
 		}
 
 		$this->phpcsFile->addWarning(
-			'%s(%s, %s) found. Changing configuration values at runtime is strongly discouraged.',
+			'Changing configuration values at runtime is strongly discouraged. Found: %s(%s, %s)',
 			$stackPtr,
 			'Risky',
 			array(

--- a/WordPress/Sniffs/PHP/IniSetSniff.php
+++ b/WordPress/Sniffs/PHP/IniSetSniff.php
@@ -155,14 +155,16 @@ class IniSetSniff extends AbstractFunctionParameterSniff {
 		$option_value = TextStrings::stripQuotes( $value_param['clean'] );
 		if ( isset( $this->safe_options[ $option_name ] ) ) {
 			$safe_option = $this->safe_options[ $option_name ];
-			if ( ! isset( $safe_option['valid_values'] ) || in_array( strtolower( $option_value ), $safe_option['valid_values'], true ) ) {
+			if ( empty( $safe_option['valid_values'] ) || in_array( strtolower( $option_value ), $safe_option['valid_values'], true ) ) {
 				return;
 			}
 		}
 
 		if ( isset( $this->disallowed_options[ $option_name ] ) ) {
 			$disallowed_option = $this->disallowed_options[ $option_name ];
-			if ( ! isset( $disallowed_option['invalid_values'] ) || in_array( strtolower( $option_value ), $disallowed_option['invalid_values'], true ) ) {
+			if ( empty( $disallowed_option['invalid_values'] )
+				|| in_array( strtolower( $option_value ), $disallowed_option['invalid_values'], true )
+			) {
 				$this->phpcsFile->addError(
 					'%s(%s, %s) found. %s',
 					$stackPtr,

--- a/WordPress/Tests/PHP/IniSetUnitTest.inc
+++ b/WordPress/Tests/PHP/IniSetUnitTest.inc
@@ -41,3 +41,11 @@ ini_set($test, 1230); // Warning.
 ini_alter('auto_detect_line_endings', true); // Ok.
 ini_alter('display_errors', false); // Error.
 ini_alter('report_memleaks', 1230); // Warning.
+
+// Ignore missing required parameters.
+ini_set('short_open_tag', ); // Ok. Well not really, missing value param, but that's not the concern of this sniff.
+
+// Safeguard support for PHP 8.0+ named parameters.
+ini_set(new_value: 0, option: 'short_open_tag', ); // Ok. Well not really, unrecognized param name, but that's not the concern of this sniff.
+ini_set(value: 1, option: 'short_open_tag', ); // Ok.
+ini_set(value: 0, option: 'short_open_tag', ); // Error.

--- a/WordPress/Tests/PHP/IniSetUnitTest.inc
+++ b/WordPress/Tests/PHP/IniSetUnitTest.inc
@@ -49,3 +49,12 @@ ini_set('short_open_tag', ); // Ok. Well not really, missing value param, but th
 ini_set(new_value: 0, option: 'short_open_tag', ); // Ok. Well not really, unrecognized param name, but that's not the concern of this sniff.
 ini_set(value: 1, option: 'short_open_tag', ); // Ok.
 ini_set(value: 0, option: 'short_open_tag', ); // Error.
+
+// Safeguard that comments in the parameters are ignored.
+ini_set('short_open_tag', /* allowed*/ 'on'); // Ok.
+ini_set(
+	// This affects all function calls to the BCMath extension.
+	'bcmath.scale',
+	// Set the number of decimals.
+	0
+); // Error.

--- a/WordPress/Tests/PHP/IniSetUnitTest.php
+++ b/WordPress/Tests/PHP/IniSetUnitTest.php
@@ -47,6 +47,7 @@ class IniSetUnitTest extends AbstractSniffUnitTest {
 			33 => 1,
 			34 => 1,
 			42 => 1,
+			51 => 1,
 		);
 	}
 
@@ -64,5 +65,4 @@ class IniSetUnitTest extends AbstractSniffUnitTest {
 			43 => 1,
 		);
 	}
-
 }

--- a/WordPress/Tests/PHP/IniSetUnitTest.php
+++ b/WordPress/Tests/PHP/IniSetUnitTest.php
@@ -48,6 +48,7 @@ class IniSetUnitTest extends AbstractSniffUnitTest {
 			34 => 1,
 			42 => 1,
 			51 => 1,
+			55 => 1,
 		);
 	}
 


### PR DESCRIPTION
### PHP/IniSet: add support for PHP 8.0+ named parameters

1. Adjusted the way the correct parameters are retrieved to use the new PHPCSUtils 1.0.0-alpha4 `PassedParameters::getParameterFromStack()` method.
2. Verified the parameter names used are in line with the names as per the PHP 8.0 release.
    PHP itself renamed a lot of parameters in PHP 8.0. As named parameters did not exist before PHP 8.0, the parameter name as per PHP 8.0 (or above) is the only relevant name.
    Ref: https://www.php.net/manual/en/function.ini-set.php

Includes additional unit tests.

### PHP/IniSet: prevent some false positives

The `'raw'` key in the parameter arrays returned from the `PassedParameters` class contains - as per the name - the _raw_ contents of the parameter.

Since PHPCSUtils 1.0.0-alpha4, the return array also contain a `'clean'` index, which contains the contents of the parameter cleaned of comments.

By switching to using that key, some false positives/incorrect error message being thrown situations get prevented.

Includes unit tests demonstrating the issue and safeguarding the fix.

Includes ensuring that the information displayed in the error message will also no longer contain comments.

### PHP/IniSet: minor code simplification

Check using `empty()` instead `! isset()` for efficiency as it will prevent a potentially unncessary call to `in_array()`.

### PHP/IniSet: minor message tweak for clarity 