### PR TITLE
PHP/NoSilencedErrors: implement PHPCSUtils methods

### DIFF
--- a/WordPress/Sniffs/PHP/NoSilencedErrorsSniff.php
+++ b/WordPress/Sniffs/PHP/NoSilencedErrorsSniff.php
@@ -10,6 +10,8 @@
 namespace WordPressCS\WordPress\Sniffs\PHP;
 
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\BackCompat\BCFile;
+use PHPCSUtils\Utils\GetTokensAsString;
 use WordPressCS\WordPress\Helpers\RulesetPropertyHelper;
 use WordPressCS\WordPress\Sniff;
 
@@ -216,13 +218,12 @@ class NoSilencedErrorsSniff extends Sniff {
 		}
 
 		// Prepare the "Found" string to display.
-		$end_of_statement = $this->phpcsFile->findEndOfStatement( $stackPtr, \T_COMMA );
+		$end_of_statement = BCFile::findEndOfStatement( $this->phpcsFile, $stackPtr, \T_COMMA );
 		if ( ( $end_of_statement - $stackPtr ) < $context_length ) {
 			$context_length = ( $end_of_statement - $stackPtr );
 		}
-		$found = $this->phpcsFile->getTokensAsString( $stackPtr, $context_length );
-		$found = str_replace( array( "\t", "\n", "\r" ), ' ', $found ) . '...';
 
+		$found     = GetTokensAsString::compact( $this->phpcsFile, $stackPtr, ( $stackPtr + $context_length - 1 ), true ) . '...';
 		$error_msg = 'Silencing errors is strongly discouraged. Use proper error checking instead.';
 		$data      = array();
 		if ( $this->context_length > 0 ) {
@@ -243,5 +244,4 @@ class NoSilencedErrorsSniff extends Sniff {
 			$this->phpcsFile->recordMetric( $stackPtr, 'Error silencing', $found );
 		}
 	}
-
 }

--- a/WordPress/Tests/PHP/NoSilencedErrorsUnitTest.inc
+++ b/WordPress/Tests/PHP/NoSilencedErrorsUnitTest.inc
@@ -80,3 +80,7 @@ $decoded = @hex2bin( $data );
 // phpcs:set WordPress.PHP.NoSilencedErrors customAllowedFunctionsList[]
 
 // phpcs:set WordPress.PHP.NoSilencedErrors usePHPFunctionsList true
+
+// phpcs:set WordPress.PHP.NoSilencedErrors context_length 0
+echo @some_userland_function( $param ); // Bad.
+// phpcs:set WordPress.PHP.NoSilencedErrors context_length 6

--- a/WordPress/Tests/PHP/NoSilencedErrorsUnitTest.php
+++ b/WordPress/Tests/PHP/NoSilencedErrorsUnitTest.php
@@ -60,7 +60,7 @@ class NoSilencedErrorsUnitTest extends AbstractSniffUnitTest {
 			68 => 1,
 			71 => 1,
 			78 => 1,
+			85 => 1,
 		);
 	}
-
 }


### PR DESCRIPTION
### PHP/NoSilencedErrors: add extra test

... to cover a previously uncovered condition (and ensure that the configurable `$context_length` parameter is handled correctly).


### PHP/NoSilencedErrors: implement PHPCSUtils methods

As the methods from `GetTokensAsString` work slightly differently from the PHPCS native `File::getTokensAsString()` method, this would result in a "one token longer" code snippet. The `-1` in the function call in line 225 has been added to prevent this change in behaviour without the need for people to update the `context_length` property value in their custom ruleset (which would be an unnecessary BC-break).

Functionally, using the `GetTokensAsString::compact()` method will result in the code snippet in the error message being "cleaner" as those will no longer contain comments found in the code. The PHPCSUtils method will also "compact" the whitespace, so no need for the `str_replace()` call anymore.

No additional tests added, the existing tests (line 58) already cover this.

Note: it is still the intention for a similar sniff to become available via PHPCSExtra, but that will be in a later release.

