### PR TITLE
PHP/StrictInArray: prevent some false positives

### DIFF
--- a/WordPress/Sniffs/PHP/StrictInArraySniff.php
+++ b/WordPress/Sniffs/PHP/StrictInArraySniff.php
@@ -101,14 +101,14 @@ class StrictInArraySniff extends AbstractFunctionParameterSniff {
 		}
 
 		$found_parameter = PassedParameters::getParameterFromStack( $parameters, $param_info['param_position'], $param_info['param_name'] );
-		if ( false === $found_parameter || 'true' !== strtolower( $found_parameter['raw'] ) ) {
+		if ( false === $found_parameter || 'true' !== strtolower( $found_parameter['clean'] ) ) {
 			$errorcode = 'MissingTrueStrict';
 
 			/*
 			 * Use a different error code when `false` is found to allow for excluding
 			 * the warning as this will be a conscious choice made by the dev.
 			 */
-			if ( is_array( $found_parameter ) && 'false' === strtolower( $found_parameter['raw'] ) ) {
+			if ( is_array( $found_parameter ) && 'false' === strtolower( $found_parameter['clean'] ) ) {
 				$errorcode = 'FoundNonStrictFalse';
 			}
 

--- a/WordPress/Tests/PHP/StrictInArrayUnitTest.inc
+++ b/WordPress/Tests/PHP/StrictInArrayUnitTest.inc
@@ -47,3 +47,11 @@ array_keys( array: $testing ); // Ok.
 array_keys( strict: false, array: $testing ); // Ok, will cause fatal error, but that's not the concern of this sniff.
 array_keys( $testing, filter_value: 'my_key' ); // Warning.
 array_keys( $testing, strict: false, filter_value: 'my_key' ); // Warning.
+
+// Safeguard that comments in the parameter are ignored.
+in_array( 1, array( '1', 1 ), /* strict */ TRUE ); // Ok.
+array_search(
+	'needle',
+	$haystack,
+	true // Use strict typing.
+); // Ok.


### PR DESCRIPTION
The `'raw'` key in the parameter arrays returned from the `PassedParameters` class contains - as per the name - the _raw_ contents of the parameter.

Since PHPCSUtils 1.0.0-alpha4, the return array also contain a `'clean'` index, which contains the contents of the parameter cleaned of comments.

By switching to using that key, some false positives get prevented.

Includes unit tests demonstrating the issue and safeguarding the fix.