### PR TITLE
Move "is assignment" related utility to dedicated `VariableHelper`

### DIFF
--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -533,63 +533,6 @@ abstract class Sniff implements PHPCS_Sniff {
 	}
 
 	/**
-	 * Check if this variable is being assigned a value.
-	 *
-	 * E.g., $var = 'foo';
-	 *
-	 * Also handles array assignments to arbitrary depth:
-	 *
-	 * $array['key'][ $foo ][ something() ] = $bar;
-	 *
-	 * @since 0.5.0
-	 *
-	 * @param int $stackPtr The index of the token in the stack. This must point to
-	 *                      either a T_VARIABLE or T_CLOSE_SQUARE_BRACKET token.
-	 *
-	 * @return bool Whether the token is a variable being assigned a value.
-	 */
-	protected function is_assignment( $stackPtr ) {
-
-		static $valid = array(
-			\T_VARIABLE             => true,
-			\T_CLOSE_SQUARE_BRACKET => true,
-		);
-
-		// Must be a variable, constant or closing square bracket (see below).
-		if ( ! isset( $valid[ $this->tokens[ $stackPtr ]['code'] ] ) ) {
-			return false;
-		}
-
-		$next_non_empty = $this->phpcsFile->findNext(
-			Tokens::$emptyTokens,
-			( $stackPtr + 1 ),
-			null,
-			true,
-			null,
-			true
-		);
-
-		// No token found.
-		if ( false === $next_non_empty ) {
-			return false;
-		}
-
-		// If the next token is an assignment, that's all we need to know.
-		if ( isset( Tokens::$assignmentTokens[ $this->tokens[ $next_non_empty ]['code'] ] ) ) {
-			return true;
-		}
-
-		// Check if this is an array assignment, e.g., `$var['key'] = 'val';` .
-		if ( \T_OPEN_SQUARE_BRACKET === $this->tokens[ $next_non_empty ]['code']
-			&& isset( $this->tokens[ $next_non_empty ]['bracket_closer'] )
-		) {
-			return $this->is_assignment( $this->tokens[ $next_non_empty ]['bracket_closer'] );
-		}
-
-		return false;
-	}
-
-	/**
 	 * Check if a token is inside of an isset(), empty() or array_key_exists() statement.
 	 *
 	 * @since 0.5.0

--- a/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
+++ b/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
@@ -21,6 +21,7 @@ use WordPressCS\WordPress\AbstractFunctionParameterSniff;
 use WordPressCS\WordPress\Helpers\DeprecationHelper;
 use WordPressCS\WordPress\Helpers\IsUnitTestTrait;
 use WordPressCS\WordPress\Helpers\RulesetPropertyHelper;
+use WordPressCS\WordPress\Helpers\VariableHelper;
 use WordPressCS\WordPress\Helpers\WPGlobalVariablesHelper;
 use WordPressCS\WordPress\Helpers\WPHookHelper;
 
@@ -628,7 +629,7 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 		 * we need a separate check for that.
 		 */
 		if ( false === $in_list
-			&& false === $this->is_assignment( $stackPtr )
+			&& false === VariableHelper::is_assignment( $this->phpcsFile, $stackPtr )
 			&& Context::inForeachCondition( $this->phpcsFile, $stackPtr ) !== 'afterAs'
 		) {
 			return;

--- a/WordPress/Sniffs/Security/NonceVerificationSniff.php
+++ b/WordPress/Sniffs/Security/NonceVerificationSniff.php
@@ -130,7 +130,7 @@ class NonceVerificationSniff extends Sniff {
 			return;
 		}
 
-		if ( $this->is_assignment( $stackPtr ) ) {
+		if ( VariableHelper::is_assignment( $this->phpcsFile, $stackPtr ) ) {
 			return;
 		}
 

--- a/WordPress/Sniffs/Security/ValidatedSanitizedInputSniff.php
+++ b/WordPress/Sniffs/Security/ValidatedSanitizedInputSniff.php
@@ -120,7 +120,7 @@ class ValidatedSanitizedInputSniff extends Sniff {
 		}
 
 		// If we're overriding a superglobal with an assignment, no need to test.
-		if ( $this->is_assignment( $stackPtr ) ) {
+		if ( VariableHelper::is_assignment( $this->phpcsFile, $stackPtr ) ) {
 			return;
 		}
 

--- a/WordPress/Sniffs/WP/GlobalVariablesOverrideSniff.php
+++ b/WordPress/Sniffs/WP/GlobalVariablesOverrideSniff.php
@@ -266,7 +266,7 @@ class GlobalVariablesOverrideSniff extends Sniff {
 		 * Check if the variable value is being changed.
 		 */
 		if ( false === $in_list
-			&& false === $this->is_assignment( $stackPtr )
+			&& false === VariableHelper::is_assignment( $this->phpcsFile, $stackPtr )
 			&& Context::inForeachCondition( $this->phpcsFile, $stackPtr ) !== 'afterAs'
 		) {
 			return;
@@ -414,7 +414,7 @@ class GlobalVariablesOverrideSniff extends Sniff {
 				continue;
 			}
 
-			if ( true === $this->is_assignment( $ptr ) ) {
+			if ( true === VariableHelper::is_assignment( $this->phpcsFile, $ptr ) ) {
 				$this->add_error( $ptr );
 				continue;
 			}


### PR DESCRIPTION
The "is assignment" related utility method is only used by a small set of sniffs, so is better placed in a dedicated class.

As this method also primarily expects a `T_VARIABLE` token as input, the `VariableHelper` class seems appropriate.

This commit moves the `is_assignment()` method to the new `WordPressCS\WordPress\Helpers\VariableHelper` and starts using that class in the relevant sniffs.

Related to #1465