### PR TITLE
NamingConventions/ValidHookName: implement PHPCSUtils and support modern PHP

### DIFF
--- a/WordPress/Sniffs/NamingConventions/ValidHookNameSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidHookNameSniff.php
@@ -94,6 +94,11 @@ class ValidHookNameSniff extends AbstractFunctionParameterSniff {
 	 */
 	public function process_parameters( $stackPtr, $group_name, $matched_content, $parameters ) {
 
+		$hook_name_param = WPHookHelper::get_hook_name_param( $matched_content, $parameters );
+		if ( false === $hook_name_param ) {
+			return;
+		}
+
 		$regex = $this->prepare_regex();
 
 		$case_errors    = 0;
@@ -102,7 +107,7 @@ class ValidHookNameSniff extends AbstractFunctionParameterSniff {
 		$expected       = array();
 		$last_non_empty = null;
 
-		for ( $i = $parameters[1]['start']; $i <= $parameters[1]['end']; $i++ ) {
+		for ( $i = $hook_name_param['start']; $i <= $hook_name_param['end']; $i++ ) {
 			// Skip past comment tokens.
 			if ( isset( Tokens::$commentTokens[ $this->tokens[ $i ]['code'] ] ) ) {
 				continue;
@@ -125,7 +130,7 @@ class ValidHookNameSniff extends AbstractFunctionParameterSniff {
 
 					$i = $this->tokens[ $open_bracket ]['bracket_closer'];
 
-				} while ( isset( $this->tokens[ $i ] ) && $i <= $parameters[1]['end'] );
+				} while ( isset( $this->tokens[ $i ] ) && $i <= $hook_name_param['end'] );
 
 				$last_non_empty = $i;
 				continue;
@@ -185,8 +190,8 @@ class ValidHookNameSniff extends AbstractFunctionParameterSniff {
 
 		$first_non_empty = $this->phpcsFile->findNext(
 			Tokens::$emptyTokens,
-			$parameters[1]['start'],
-			( $parameters[1]['end'] + 1 ),
+			$hook_name_param['start'],
+			( $hook_name_param['end'] + 1 ),
 			true
 		);
 

--- a/WordPress/Sniffs/NamingConventions/ValidHookNameSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidHookNameSniff.php
@@ -133,7 +133,8 @@ class ValidHookNameSniff extends AbstractFunctionParameterSniff {
 
 			// Skip over parameters passed to function calls.
 			if ( \T_OPEN_PARENTHESIS === $this->tokens[ $i ]['code']
-				&& \T_STRING === $this->tokens[ $last_non_empty ]['code']
+				&& ( \T_STRING === $this->tokens[ $last_non_empty ]['code']
+				|| \T_VARIABLE === $this->tokens[ $last_non_empty ]['code'] )
 				&& isset( $this->tokens[ $i ]['parenthesis_closer'] )
 			) {
 				$i              = $this->tokens[ $i ]['parenthesis_closer'];

--- a/WordPress/Sniffs/NamingConventions/ValidHookNameSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidHookNameSniff.php
@@ -104,14 +104,14 @@ class ValidHookNameSniff extends AbstractFunctionParameterSniff {
 
 		for ( $i = $parameters[1]['start']; $i <= $parameters[1]['end']; $i++ ) {
 			// Skip past comment tokens.
-			if ( isset( Tokens::$commentTokens[ $this->tokens[ $i ]['code'] ] ) !== false ) {
+			if ( isset( Tokens::$commentTokens[ $this->tokens[ $i ]['code'] ] ) ) {
 				continue;
 			}
 
 			$content[ $i ]  = $this->tokens[ $i ]['content'];
 			$expected[ $i ] = $this->tokens[ $i ]['content'];
 
-			// Skip past potential variable array access: $var['Key'].
+			// Skip past potential variable array access: `$var['key']`.
 			if ( \T_VARIABLE === $this->tokens[ $i ]['code'] ) {
 				do {
 					$open_bracket = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $i + 1 ), null, true );
@@ -119,6 +119,7 @@ class ValidHookNameSniff extends AbstractFunctionParameterSniff {
 						|| \T_OPEN_SQUARE_BRACKET !== $this->tokens[ $open_bracket ]['code']
 						|| ! isset( $this->tokens[ $open_bracket ]['bracket_closer'] )
 					) {
+						$last_non_empty = $i;
 						continue 2;
 					}
 
@@ -140,7 +141,7 @@ class ValidHookNameSniff extends AbstractFunctionParameterSniff {
 				continue;
 			}
 
-			// Skip past non-string tokens.
+			// Skip past non text string tokens.
 			if ( isset( Tokens::$stringTokens[ $this->tokens[ $i ]['code'] ] ) === false ) {
 				$last_non_empty = $i;
 				continue;
@@ -197,6 +198,7 @@ class ValidHookNameSniff extends AbstractFunctionParameterSniff {
 			$error = 'Hook names should be lowercase. Expected: %s, but found: %s.';
 			$this->phpcsFile->addError( $error, $first_non_empty, 'NotLowercase', $data );
 		}
+
 		if ( $underscores > 0 ) {
 			$error = 'Words in hook names should be separated using underscores. Expected: %s, but found: %s.';
 			$this->phpcsFile->addWarning( $error, $first_non_empty, 'UseUnderscores', $data );

--- a/WordPress/Tests/NamingConventions/ValidHookNameUnitTest.1.inc
+++ b/WordPress/Tests/NamingConventions/ValidHookNameUnitTest.1.inc
@@ -108,3 +108,8 @@ $value = apply_filters(
 	$value,
 	$attributes
 );
+
+// Test handling of more complex embedded variables and expressions.
+do_action( "admin_head_${Foo->{$Baz}}_action_$Post->ID" ); // OK.
+do_action( "admin_Head_${Foo?->{$Baz}}_Action_{$Post?->ID}_Bla" ); // Error - use lowercase.
+do_action( "admin_Head_${Foo->{"${'A'}"}}-Action_$Post[A]_Bla" ); // Error - use lowercase + warning about dash.

--- a/WordPress/Tests/NamingConventions/ValidHookNameUnitTest.1.inc
+++ b/WordPress/Tests/NamingConventions/ValidHookNameUnitTest.1.inc
@@ -113,3 +113,6 @@ $value = apply_filters(
 do_action( "admin_head_${Foo->{$Baz}}_action_$Post->ID" ); // OK.
 do_action( "admin_Head_${Foo?->{$Baz}}_Action_{$Post?->ID}_Bla" ); // Error - use lowercase.
 do_action( "admin_Head_${Foo->{"${'A'}"}}-Action_$Post[A]_Bla" ); // Error - use lowercase + warning about dash.
+
+// Safeguard that variable function calls are handled correctly.
+do_action( 'admin_head_' .  $fn( 'UPPERCASE', 'wrong-delimiter' ) . '_action' ); // Ok.

--- a/WordPress/Tests/NamingConventions/ValidHookNameUnitTest.1.inc
+++ b/WordPress/Tests/NamingConventions/ValidHookNameUnitTest.1.inc
@@ -116,3 +116,8 @@ do_action( "admin_Head_${Foo->{"${'A'}"}}-Action_$Post[A]_Bla" ); // Error - use
 
 // Safeguard that variable function calls are handled correctly.
 do_action( 'admin_head_' .  $fn( 'UPPERCASE', 'wrong-delimiter' ) . '_action' ); // Ok.
+
+// Safeguard support for PHP 8.0+ named parameters.
+do_action_ref_array( hook: 'My-Hook', args: $args ); // OK. Well, not really, but using the wrong parameter name, so not our concern.
+do_action_ref_array( args: $args, hook_name: 'my_hook', ); // OK.
+do_action_ref_array( args: $args, hook_name: 'My-Hook', ); // Error - use lowercase + warning about dash.

--- a/WordPress/Tests/NamingConventions/ValidHookNameUnitTest.php
+++ b/WordPress/Tests/NamingConventions/ValidHookNameUnitTest.php
@@ -70,6 +70,8 @@ class ValidHookNameUnitTest extends AbstractSniffUnitTest {
 					81  => 1,
 					89  => 1,
 					107 => 1,
+					114 => 1,
+					115 => 1,
 				);
 
 			case 'ValidHookNameUnitTest.2.inc':
@@ -99,6 +101,7 @@ class ValidHookNameUnitTest extends AbstractSniffUnitTest {
 					77  => 1,
 					95  => 1,
 					107 => 1,
+					115 => 1,
 				);
 
 			case 'ValidHookNameUnitTest.2.inc':
@@ -114,5 +117,4 @@ class ValidHookNameUnitTest extends AbstractSniffUnitTest {
 				return array();
 		}
 	}
-
 }

--- a/WordPress/Tests/NamingConventions/ValidHookNameUnitTest.php
+++ b/WordPress/Tests/NamingConventions/ValidHookNameUnitTest.php
@@ -72,6 +72,7 @@ class ValidHookNameUnitTest extends AbstractSniffUnitTest {
 					107 => 1,
 					114 => 1,
 					115 => 1,
+					123 => 1,
 				);
 
 			case 'ValidHookNameUnitTest.2.inc':
@@ -102,6 +103,7 @@ class ValidHookNameUnitTest extends AbstractSniffUnitTest {
 					95  => 1,
 					107 => 1,
 					115 => 1,
+					123 => 1,
 				);
 
 			case 'ValidHookNameUnitTest.2.inc':


### PR DESCRIPTION
### NamingConventions/ValidHookName: various minor code and comment tweaks

### NamingConventions/ValidHookName::transform_complex_string(): simplify with PHPCSUtils

Simplify the `transform_complex_string()` method by using the PHPCSUtils utilities to split a text string containing interpolated variables or expressions, instead of using custom logic to do this in the sniff.

Functionally this has no impact. The "old" code already handled complex expressions correctly.
Performance-wise, this could (should) have a small, positive impact as PHPCSUtils caches the results of the splitting of the text string and using the Utils functions allows for simplifying the logic in the function itself, which is called three times for each double quoted teẋt string.

Includes a few extra tests with some more complex variables/expressions.

### NamingConventions/ValidHookName: bug fix - disregard variable function calls

Iterates on previously pulled PR #2056.

As function calls via closure callbacks are getting more common, probably a good idea to make the sniff ignore parameters passed to variable function calls as well.

Includes a test which would previously result in false positives from the sniff.

### NamingConventions/ValidHookName: add support for PHP 8.0+ named parameters

1. Adjusted the way the correct parameter is retrieved to use the new `WPHookHelper::get_hook_name_param()` method, which uses the PHPCSUtils 1.0.0-alpha4 `PassedParameters::getParameterFromStack()` method under the hood.
2. Verified the parameter names used are in line with the name as per the WP 6.1 release.
    WP has been renaming parameters and is probably not done yet, but it doesn't look like those changes (so far) made it into changelog entries....
    For the purposes of this exercise, I've taken the _current_ parameter name as the "truth" as support for named parameters hasn't officially been announced yet, so any renames _after_ this moment are the only ones relevant.

Includes additional unit tests.

Note: function calls with named arguments are not supported for the `do_action()` or `apply_filters()` functions as those have a parameter with a spread operator (but that's irrelevant for the sniff).