### PR TITLE
Security/PluginMenuSlug: implement PHPCSUtils and support modern PHP

### DIFF
--- a/WordPress/Sniffs/Security/PluginMenuSlugSniff.php
+++ b/WordPress/Sniffs/Security/PluginMenuSlugSniff.php
@@ -9,6 +9,7 @@
 
 namespace WordPressCS\WordPress\Sniffs\Security;
 
+use PHPCSUtils\Utils\PassedParameters;
 use WordPressCS\WordPress\AbstractFunctionParameterSniff;
 
 /**
@@ -41,25 +42,61 @@ class PluginMenuSlugSniff extends AbstractFunctionParameterSniff {
 	 * @since 0.3.0
 	 * @since 0.11.0 Renamed from $add_menu_functions to $target_functions
 	 *               and changed visibility to protected.
+	 * @since 3.0.0  The format of the value has changed from a numerically indexed
+	 *               array containing parameter positions to an array with the parameter
+	 *               position as the index and the parameter name as value.
 	 *
-	 * @var array <string function name> => <array target parameter positions>
+	 * @var array<string, <int, string|array>> Key is the name of the functions being targetted.
+	 *                                         Value is an array with parameter positions as the
+	 *                                         keys and parameter names as the values
 	 */
 	protected $target_functions = array(
-		'add_menu_page'       => array( 4 ),
-		'add_object_page'     => array( 4 ),
-		'add_utility_page'    => array( 4 ),
-		'add_submenu_page'    => array( 1, 5 ),
-		'add_dashboard_page'  => array( 4 ),
-		'add_posts_page'      => array( 4 ),
-		'add_media_page'      => array( 4 ),
-		'add_links_page'      => array( 4 ),
-		'add_pages_page'      => array( 4 ),
-		'add_comments_page'   => array( 4 ),
-		'add_theme_page'      => array( 4 ),
-		'add_plugins_page'    => array( 4 ),
-		'add_users_page'      => array( 4 ),
-		'add_management_page' => array( 4 ),
-		'add_options_page'    => array( 4 ),
+		'add_menu_page'       => array(
+			4 => 'menu_slug',
+		),
+		'add_object_page'     => array(
+			4 => 'menu_slug',
+		),
+		'add_utility_page'    => array(
+			4 => 'menu_slug',
+		),
+		'add_submenu_page'    => array(
+			1 => 'parent_slug',
+			5 => 'menu_slug',
+		),
+		'add_dashboard_page'  => array(
+			4 => 'menu_slug',
+		),
+		'add_posts_page'      => array(
+			4 => 'menu_slug',
+		),
+		'add_media_page'      => array(
+			4 => 'menu_slug',
+		),
+		'add_links_page'      => array(
+			4 => 'menu_slug',
+		),
+		'add_pages_page'      => array(
+			4 => 'menu_slug',
+		),
+		'add_comments_page'   => array(
+			4 => 'menu_slug',
+		),
+		'add_theme_page'      => array(
+			4 => 'menu_slug',
+		),
+		'add_plugins_page'    => array(
+			4 => 'menu_slug',
+		),
+		'add_users_page'      => array(
+			4 => 'menu_slug',
+		),
+		'add_management_page' => array(
+			4 => 'menu_slug',
+		),
+		'add_options_page'    => array(
+			4 => 'menu_slug',
+		),
 	);
 
 	/**
@@ -75,13 +112,15 @@ class PluginMenuSlugSniff extends AbstractFunctionParameterSniff {
 	 * @return void
 	 */
 	public function process_parameters( $stackPtr, $group_name, $matched_content, $parameters ) {
-		foreach ( $this->target_functions[ $matched_content ] as $position ) {
-			if ( isset( $parameters[ $position ] ) ) {
-				$file_constant = $this->phpcsFile->findNext( \T_FILE, $parameters[ $position ]['start'], ( $parameters[ $position ]['end'] + 1 ) );
+		foreach ( $this->target_functions[ $matched_content ] as $position => $param_name ) {
+			$found_param = PassedParameters::getParameterFromStack( $parameters, $position, $param_name );
+			if ( false === $found_param ) {
+				continue;
+			}
 
-				if ( false !== $file_constant ) {
-					$this->phpcsFile->addWarning( 'Using __FILE__ for menu slugs risks exposing filesystem structure.', $stackPtr, 'Using__FILE__' );
-				}
+			$file_constant = $this->phpcsFile->findNext( \T_FILE, $found_param['start'], ( $found_param['end'] + 1 ) );
+			if ( false !== $file_constant ) {
+				$this->phpcsFile->addWarning( 'Using __FILE__ for menu slugs risks exposing filesystem structure.', $stackPtr, 'Using__FILE__' );
 			}
 		}
 	}

--- a/WordPress/Sniffs/Security/PluginMenuSlugSniff.php
+++ b/WordPress/Sniffs/Security/PluginMenuSlugSniff.php
@@ -120,7 +120,7 @@ class PluginMenuSlugSniff extends AbstractFunctionParameterSniff {
 
 			$file_constant = $this->phpcsFile->findNext( \T_FILE, $found_param['start'], ( $found_param['end'] + 1 ) );
 			if ( false !== $file_constant ) {
-				$this->phpcsFile->addWarning( 'Using __FILE__ for menu slugs risks exposing filesystem structure.', $stackPtr, 'Using__FILE__' );
+				$this->phpcsFile->addWarning( 'Using __FILE__ for menu slugs risks exposing filesystem structure.', $file_constant, 'Using__FILE__' );
 			}
 		}
 	}

--- a/WordPress/Tests/Security/PluginMenuSlugUnitTest.inc
+++ b/WordPress/Tests/Security/PluginMenuSlugUnitTest.inc
@@ -12,3 +12,11 @@ add_submenu_page( __FILE__ . 'parent', $page_title, $menu_title, $capability, __
 $my_class->add_dashboard_page( $page_title, $menu_title, $capability, __FILE__, $function); // Ok.
 Some_Class::add_dashboard_page( $page_title, $menu_title, $capability, __FILE__, $function); // Ok.
 \My_Namespace\add_dashboard_page( $page_title, $menu_title, $capability, __FILE__, $function); // Ok.
+
+// Safeguard support for PHP 8.0+ named parameters.
+add_submenu_page(
+	page_title: $page_title,
+	menu_title: $menu_title,
+	parent_slug: __FILE__, // Bad.
+	capability: $capability,
+);

--- a/WordPress/Tests/Security/PluginMenuSlugUnitTest.inc
+++ b/WordPress/Tests/Security/PluginMenuSlugUnitTest.inc
@@ -2,7 +2,7 @@
 
 add_menu_page( $page_title, $menu_title, $capability, __FILE__, $function, $icon_url, $position ); // Bad.
 
-add_dashboard_page( $page_title, $menu_title, $capability, __FILE__, $function); // Bad.
+add_dashboard_page( $page_title, $menu_title, $capability, __file__, $function); // Bad.
 
 add_submenu_page( $parent_slug, $page_title, $menu_title, $capability, 'awesome-submenu-page', $function ); // Ok.
 

--- a/WordPress/Tests/Security/PluginMenuSlugUnitTest.php
+++ b/WordPress/Tests/Security/PluginMenuSlugUnitTest.php
@@ -38,10 +38,10 @@ class PluginMenuSlugUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getWarningList() {
 		return array(
-			3 => 1,
-			5 => 1,
-			9 => 2,
+			3  => 1,
+			5  => 1,
+			9  => 2,
+			17 => 1,
 		);
 	}
-
 }

--- a/WordPress/Tests/Security/PluginMenuSlugUnitTest.php
+++ b/WordPress/Tests/Security/PluginMenuSlugUnitTest.php
@@ -41,7 +41,7 @@ class PluginMenuSlugUnitTest extends AbstractSniffUnitTest {
 			3  => 1,
 			5  => 1,
 			9  => 2,
-			17 => 1,
+			20 => 1,
 		);
 	}
 }


### PR DESCRIPTION
### Security/PluginMenuSlug: add support for PHP 8.0+ named parameters

1. Adjusted the way the correct parameters are retrieved to use the new PHPCSUtils 1.0.0-alpha4 `PassedParameters::getParameterFromStack()` method.
2. Verified the parameter names used are in line with the name as per the WP 6.1 release.
    WP has been renaming parameters and is probably not done yet, but it doesn't look like those changes (so far) made it into changelog entries....
    For the purposes of this exercise, I've taken the _current_ parameter name as the "truth" as support for named parameters hasn't officially been announced yet, so any renames _after_ this moment are the only ones relevant.

Includes additional unit tests.

### Security/PluginMenuSlug: minor test tweak

Adjust one test to use lowercase `__file__` to safeguard that the sniff correctly recognizes that these magic constants are case insensitive.

### Security/PluginMenuSlug: improve error position precision

Throw the error on the token containing the `__FILE__` magic constant instead of on the function call token.