### PR TITLE
WP/CronInterval: implement PHPCSUtils and support modern PHP 

### DIFF
--- a/WordPress/Sniffs/WP/CronIntervalSniff.php
+++ b/WordPress/Sniffs/WP/CronIntervalSniff.php
@@ -14,6 +14,7 @@ use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\Arrays;
 use PHPCSUtils\Utils\FunctionDeclarations;
+use PHPCSUtils\Utils\Numbers;
 use PHPCSUtils\Utils\PassedParameters;
 use PHPCSUtils\Utils\TextStrings;
 
@@ -197,6 +198,16 @@ class CronIntervalSniff extends Sniff {
 
 						if ( $j === $valueEnd && \T_COMMA === $this->tokens[ $j ]['code'] ) {
 							break;
+						}
+
+						// Make sure that PHP 7.4 numeric literals and PHP 8.1 explicit octals don't cause problems.
+						if ( \T_LNUMBER === $this->tokens[ $j ]['code']
+							|| \T_DNUMBER === $this->tokens[ $j ]['code']
+						) {
+							$number_info = Numbers::getCompleteNumber( $this->phpcsFile, $j );
+							$value      .= $number_info['decimal'];
+							$j           = $number_info['last_token'];
+							continue;
 						}
 
 						if ( \T_OPEN_PARENTHESIS === $this->tokens[ $j ]['code'] ) {

--- a/WordPress/Sniffs/WP/CronIntervalSniff.php
+++ b/WordPress/Sniffs/WP/CronIntervalSniff.php
@@ -131,6 +131,7 @@ class CronIntervalSniff extends Sniff {
 		// Search for the function in tokens.
 		$search               = Tokens::$stringTokens;
 		$search[ \T_CLOSURE ] = \T_CLOSURE;
+		$search[ \T_FN ]      = \T_FN;
 		$callbackFunctionPtr  = $this->phpcsFile->findNext( $search, $callback['start'], ( $callback['end'] + 1 ) );
 
 		if ( false === $callbackFunctionPtr ) {
@@ -138,7 +139,9 @@ class CronIntervalSniff extends Sniff {
 			return;
 		}
 
-		if ( \T_CLOSURE === $this->tokens[ $callbackFunctionPtr ]['code'] ) {
+		if ( \T_CLOSURE === $this->tokens[ $callbackFunctionPtr ]['code']
+			|| \T_FN === $this->tokens[ $callbackFunctionPtr ]['code']
+		) {
 			$functionPtr = $callbackFunctionPtr;
 		} else {
 			$functionName = TextStrings::stripQuotes( $this->tokens[ $callbackFunctionPtr ]['content'] );

--- a/WordPress/Sniffs/WP/CronIntervalSniff.php
+++ b/WordPress/Sniffs/WP/CronIntervalSniff.php
@@ -104,7 +104,7 @@ class CronIntervalSniff extends Sniff {
 			return;
 		}
 
-		if ( $stackPtr >= $callback['start'] ) {
+		if ( $stackPtr >= $callback['start'] && $stackPtr <= $callback['end'] ) {
 			// "cron_schedules" found in the second parameter, not the first.
 			return;
 		}

--- a/WordPress/Tests/WP/CronIntervalUnitTest.inc
+++ b/WordPress/Tests/WP/CronIntervalUnitTest.inc
@@ -231,3 +231,37 @@ add_filter( 'cron_schedules', function ( $schedules ) {
 // Allow for PHP 7.4+ arrow functions as callbacks.
 add_filter( 'cron_schedules', fn ( $schedules ) => $schedules + array( 'every_9_mins' => array( 'interval' => 9 * 60, ) ) ); // Warning: 9 min.
 add_filter( 'cron_schedules', fn ( $schedules ) => array_merge( $schedules, array( 'weekly' => array( 'interval' => WEEK_IN_SECONDS ) ) ) ); // OK: > 10 min.
+
+// Allow for PHP 7.4+ numeric literals with underscores.
+add_filter( 'cron_schedules', function ( $schedules ) {
+	$schedules['every_day'] = array(
+		'interval' => 86_400, // 24 hours.
+		'display' => __( 'Once every day' )
+	);
+	return $schedules;
+} ); // OK
+
+add_filter( 'cron_schedules', function ( $schedules ) {
+	$schedules['every_12_mins'] = array(
+		'interval' => 7_2_0, // 12 minutes.
+		'display' => __( 'Once every 12 minutes' )
+	);
+	return $schedules;
+} ); // Warning: 12 min.
+
+// Allow for PHP 8.1 explicit octal notation.
+add_filter( 'cron_schedules', function ( $schedules ) {
+	$schedules['every_six_hours'] = array(
+		'interval' => 0o6 * HOUR_IN_SECONDS, // 6 hours.
+		'display' => __( 'Once every six hours' )
+	);
+	return $schedules;
+} ); // OK
+
+add_filter( 'cron_schedules', function ( $schedules ) {
+	$schedules['every_83 seconds'] = array(
+		'interval' => 0O123, // 83 second.
+		'display' => __( 'Once every 83 seconds' )
+	);
+	return $schedules;
+} ); // Warning: 83 seconds.

--- a/WordPress/Tests/WP/CronIntervalUnitTest.inc
+++ b/WordPress/Tests/WP/CronIntervalUnitTest.inc
@@ -211,3 +211,19 @@ add_filter( 'cron_schedules', function ( $schedules ) {
 	];
 	return $schedules;
 } ); // Warning: time undetermined. Found 'interval', but no value.
+
+// Safeguard fix to prevent an "Parse error: Unmatched ')'" bug in the eval-ed code.
+add_filter( 'cron_schedules', function ( $schedules ) {
+	$schedules['every_8_minutes'] = array(
+		'interval' => \WEEK_IN_SECONDS
+	);
+	return $schedules;
+} ); // OK.
+
+// Safeguard fix to prevent an "Parse error: syntax error, unexpected token ";"" bug in the eval-ed code.
+add_filter( 'cron_schedules', function ( $schedules ) {
+	$schedules['every_8_minutes'] = array(
+		'interval' => ( 2 * ( \WEEK_IN_SECONDS + 4 ) )
+	);
+	return $schedules;
+} ); // OK.

--- a/WordPress/Tests/WP/CronIntervalUnitTest.inc
+++ b/WordPress/Tests/WP/CronIntervalUnitTest.inc
@@ -227,3 +227,7 @@ add_filter( 'cron_schedules', function ( $schedules ) {
 	);
 	return $schedules;
 } ); // OK.
+
+// Allow for PHP 7.4+ arrow functions as callbacks.
+add_filter( 'cron_schedules', fn ( $schedules ) => $schedules + array( 'every_9_mins' => array( 'interval' => 9 * 60, ) ) ); // Warning: 9 min.
+add_filter( 'cron_schedules', fn ( $schedules ) => array_merge( $schedules, array( 'weekly' => array( 'interval' => WEEK_IN_SECONDS ) ) ) ); // OK: > 10 min.

--- a/WordPress/Tests/WP/CronIntervalUnitTest.inc
+++ b/WordPress/Tests/WP/CronIntervalUnitTest.inc
@@ -265,3 +265,16 @@ add_filter( 'cron_schedules', function ( $schedules ) {
 	);
 	return $schedules;
 } ); // Warning: 83 seconds.
+
+// Safeguard support for PHP 8.0+ named parameters.
+add_filter( callback: array( $place, 'cron_schedules' ), hook_name: 'some_hook', ); // OK, not the hook we're looking for.
+
+function prefix_cron_schedules( $schedules ) {
+	$schedules['every_2_mins'] = array(
+		'interval' => 120,
+		'display' => __( 'Once every 2 minutes' )
+	);
+	return $schedules;
+}
+add_filter(priority: 8, callback : 'prefix_cron_schedules', hook_name : 'cron_schedules', accepted_args: 1 ); // Warning: 2 min.
+add_filter( callback: 'prefix_cron_schedules', hook_name: 'cron_schedules' ); // Warning: 2 min.

--- a/WordPress/Tests/WP/CronIntervalUnitTest.inc
+++ b/WordPress/Tests/WP/CronIntervalUnitTest.inc
@@ -202,3 +202,12 @@ class FQNConstants {
 		return $schedules;
 	}
 }
+
+// Test some edge case/invalid code situations.
+add_filter( 'cron_schedules', array() ); // Warning: time undetermined. Callback is an array, but can't determined method name.
+add_filter( 'cron_schedules', function ( $schedules ) {
+	$schedules['every_8_minutes'] = [
+		'interval',
+	];
+	return $schedules;
+} ); // Warning: time undetermined. Found 'interval', but no value.

--- a/WordPress/Tests/WP/CronIntervalUnitTest.inc
+++ b/WordPress/Tests/WP/CronIntervalUnitTest.inc
@@ -278,3 +278,51 @@ function prefix_cron_schedules( $schedules ) {
 }
 add_filter(priority: 8, callback : 'prefix_cron_schedules', hook_name : 'cron_schedules', accepted_args: 1 ); // Warning: 2 min.
 add_filter( callback: 'prefix_cron_schedules', hook_name: 'cron_schedules' ); // Warning: 2 min.
+
+// Allow for PHP 8.1+ first class callables as callbacks.
+class FirstClassCallables {
+	public function add_schedules() {
+		add_filter( 'cron_schedules', $this->cron_weekly_schedule(...) ); // Ok: > 15 min.
+		add_filter( 'cron_schedules', $this->cron_eight_minute_schedule(...) ); // Warning: 8 min.
+		add_filter( 'cron_schedules', self::cron_weekly_schedule(...) ); // Ok: > 15 min.
+		add_filter( 'cron_schedules', static::cron_eight_minute_schedule(...) ); // Warning: 8 min.
+		add_filter( 'cron_schedules', [$this, 'cron_weekly_schedule'](...) ); // Ok: > 15 min.
+		add_filter( 'cron_schedules', array($this, 'cron_eight_minute_schedule')(...) ); // Warning: 8 min.
+	}
+
+	public static function cron_weekly_schedule( $schedules ) {
+		$schedules['weekly'] = [
+			'interval' => \WEEK_IN_SECONDS,
+			'display'  => \__( 'Once Weekly', 'text-domain' ),
+		];
+		return $schedules;
+	}
+
+	public static function cron_eight_minute_schedule( $schedules ) {
+		$schedules['every_8_minutes'] = [
+			'interval' => (8 * \MINUTE_IN_SECONDS),
+			'display' => __( 'Once every 8 minutes' )
+		];
+		return $schedules;
+	}
+}
+
+function first_class_weekly_schedule( $schedules ) {
+	$schedules['weekly'] = array(
+		'interval' => WEEK_IN_SECONDS,
+		'display' => __( 'Once Weekly' )
+	);
+	return $schedules;
+}
+add_filter( 'cron_schedules', 'first_class_weekly_schedule'(...)); // Ok: > 15 min.
+add_filter( 'cron_schedules', first_class_weekly_schedule(...)); // Ok: > 15 min.
+
+function first_class_six_min_schedule( $schedules ) {
+	$schedules['every_6_mins'] = array(
+		'interval' => 360,
+		'display' => __( 'Once every 6 minutes' )
+	);
+	return $schedules;
+}
+add_filter( 'cron_schedules', first_class_six_min_schedule(...)); // Warning: 6 min.
+add_filter( 'cron_schedules', 'first_class_six_min_schedule'(...)); // Warning: 6 min.

--- a/WordPress/Tests/WP/CronIntervalUnitTest.php
+++ b/WordPress/Tests/WP/CronIntervalUnitTest.php
@@ -60,6 +60,8 @@ class CronIntervalUnitTest extends AbstractSniffUnitTest {
 			232 => 1,
 			244 => 1,
 			261 => 1,
+			279 => 1,
+			280 => 1,
 		);
 	}
 }

--- a/WordPress/Tests/WP/CronIntervalUnitTest.php
+++ b/WordPress/Tests/WP/CronIntervalUnitTest.php
@@ -58,6 +58,8 @@ class CronIntervalUnitTest extends AbstractSniffUnitTest {
 			207 => 1,
 			208 => 1,
 			232 => 1,
+			244 => 1,
+			261 => 1,
 		);
 	}
 }

--- a/WordPress/Tests/WP/CronIntervalUnitTest.php
+++ b/WordPress/Tests/WP/CronIntervalUnitTest.php
@@ -55,6 +55,8 @@ class CronIntervalUnitTest extends AbstractSniffUnitTest {
 			168 => 1,
 			169 => 1,
 			170 => 1,
+			207 => 1,
+			208 => 1,
 		);
 	}
 }

--- a/WordPress/Tests/WP/CronIntervalUnitTest.php
+++ b/WordPress/Tests/WP/CronIntervalUnitTest.php
@@ -62,6 +62,11 @@ class CronIntervalUnitTest extends AbstractSniffUnitTest {
 			261 => 1,
 			279 => 1,
 			280 => 1,
+			286 => 1,
+			288 => 1,
+			290 => 1,
+			327 => 1,
+			328 => 1,
 		);
 	}
 }

--- a/WordPress/Tests/WP/CronIntervalUnitTest.php
+++ b/WordPress/Tests/WP/CronIntervalUnitTest.php
@@ -57,6 +57,7 @@ class CronIntervalUnitTest extends AbstractSniffUnitTest {
 			170 => 1,
 			207 => 1,
 			208 => 1,
+			232 => 1,
 		);
 	}
 }


### PR DESCRIPTION
### WP/CronInterval: implement PHPCSUtils and other minor tweaks

This commit contains no functional changes.

### WP/CronInterval: add some tests for edge cases

... to add code coverage for some edge cases already accounted for in the code.

### WP/CronInterval: bug fix / prevent parse errors in eval-ed code

Follow up on #2026 (not yet released) which added handling of time calculations wrapped in parentheses to the sniff.

This improves on the initial fix by making the code more stable and preventing parse errors in the code (which will eventually be eval-ed) due to unmatched parentheses.

Includes additional unit tests.

### WP/CronInterval: add support for PHP 7.4+ arrow function callbacks

PHP 7.4 introduced arrow functions.

While these may not be the first choice for returning an adjusted array value, like is required for adjusting the `cron_schedules`, it is still perfectly possible to do so, so the sniff should handle callbacks declared via arrow functions correctly.

Includes unit tests.

### WP/CronInterval: add support for PHP 7.4/8.1 numbers

PHP 7.4 introduced numeric literals with underscores.
PHP 8.1 introduced explicit octal notation.

While PHPCS backfills the tokens for this, this sniff uses an `eval()` call and if either of these PHP 7.4/8.1 syntaxes would be passed to this `eval()` while PHPCS is being run on PHP < 7.4, this will result in a parse error on the code passed to `eval()`.

Luckily the sniff already contains protection against that, but that means, the sniff would throw the "Detected changing of cron_schedules, but could not detect the interval value." warning, instead of okay-ing correct values/throwing an error for incorrect values when either of those syntaxes is used.

By using the PHPCSUtils `Numbers::getCompleteNumber()` method, we can get access to the decimal value of the encountered number, which allows us to bypass the issue by using that in the code string passed to `eval()`.

Includes unit tests.

### WP/CronInterval: (properly) add support for PHP 8.0+ named parameters

Follow up to PR #2090 which already added preliminary support for named parameters to the sniff.

This commit now adds tests with named arguments in the `add_filter()` function calls and safeguards the prevention for false positives on callbacks containing a "cron_schedules" text string.

### WP/CronInterval: add support for PHP 8.1 first class callables

PHP 8.1 introduced a first class callables syntax, which can be used to express callbacks.

This commit adds support for callbacks passed to the `add_filter()` function expressed using this new syntax.

This prevents some false positives as well as prevents the "interval undetermined" warning being displayed for first class callables, where the interval _is_ actually determinable.

Note: there are more flaws in this sniff, like the scoping of the function search not being limited to the class/global scope depending on how the callback is defined, but that is outside the scope of this commit.

Includes unit tests.

Ref: https://wiki.php.net/rfc/first_class_callable_syntax