### PR TITLE
WP/DeprecatedParameters: verify against WP Core

### DIFF
--- a/WordPress/Sniffs/WP/DeprecatedParametersSniff.php
+++ b/WordPress/Sniffs/WP/DeprecatedParametersSniff.php
@@ -73,7 +73,20 @@ class DeprecatedParametersSniff extends AbstractFunctionParameterSniff {
 	 *    );
 	 */
 	protected $target_functions = array(
-
+		'_future_post_hook' => array(
+			1 => array(
+				'name'    => 'deprecated',
+				'value'   => null,
+				'version' => '2.3.0',
+			),
+		),
+		'_load_remote_block_patterns' => array(
+			1 => array(
+				'name'    => 'deprecated',
+				'value'   => null,
+				'version' => '5.9.0',
+			),
+		),
 		'add_option' => array(
 			3 => array(
 				'name'    => 'deprecated',
@@ -139,7 +152,7 @@ class DeprecatedParametersSniff extends AbstractFunctionParameterSniff {
 			3 => array(
 				'name'    => 'deprecated',
 				'value'   => '',
-				'version' => '2.3.0',
+				'version' => '3.0.0',
 			),
 		),
 		'get_wp_title_rss' => array(
@@ -232,7 +245,7 @@ class DeprecatedParametersSniff extends AbstractFunctionParameterSniff {
 			),
 		),
 		'unregister_setting' => array(
-			4 => array(
+			3 => array(
 				'name'    => 'deprecated',
 				'value'   => '',
 				'version' => '4.7.0',

--- a/WordPress/Tests/WP/DeprecatedParametersUnitTest.inc
+++ b/WordPress/Tests/WP/DeprecatedParametersUnitTest.inc
@@ -62,7 +62,7 @@ the_author( 'deprecated', 'deprecated' );
 the_author_posts_link( 'deprecated' );
 trackback_rdf( 'deprecated' );
 trackback_url( 'deprecated' );
-unregister_setting( '', '', '', 'deprecated' );
+unregister_setting( '', '', 'deprecated' );
 update_blog_option( '', '', '', 'deprecated' );
 update_user_status( '', '', '', 'deprecated' );
 wp_get_http_headers( '', 'deprecated' );
@@ -74,6 +74,7 @@ wp_notify_postauthor( '', 'null' ); // Null as a string not null.
 wp_title_rss( 'deprecated' );
 wp_upload_bits( '', 'deprecated' );
 xfn_check( '', '', 'deprecated' );
+_future_post_hook( 10, $post );
 
-// All will give an WARNING as they have been deprecated after WP 4.9.
-// Nothing yet.
+// All will give an WARNING as they have been deprecated after WP 5.8.
+_load_remote_block_patterns( $value );

--- a/WordPress/Tests/WP/DeprecatedParametersUnitTest.php
+++ b/WordPress/Tests/WP/DeprecatedParametersUnitTest.php
@@ -28,7 +28,7 @@ class DeprecatedParametersUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getErrorList() {
 		$start_line = 42;
-		$end_line   = 76;
+		$end_line   = 77;
 		$errors     = array_fill( $start_line, ( ( $end_line - $start_line ) + 1 ), 1 );
 
 		$errors[22] = 1;
@@ -51,6 +51,10 @@ class DeprecatedParametersUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of warnings>
 	 */
 	public function getWarningList() {
-		return array();
+		$start_line = 80;
+		$end_line   = 80;
+		$errors     = array_fill( $start_line, ( ( $end_line - $start_line ) + 1 ), 1 );
+
+		return $errors;
 	}
 }


### PR DESCRIPTION
Updated the array of parameters to search for based on a review of all calls to the `_deprecated_argument()` function in WP Core.

Findings:
* `get_user_option()` was listing the wrong WP version for its deprecation.
    Ref: https://developer.wordpress.org/reference/functions/get_user_option/
* `unregister_setting()` was looking for the wrong (positional) parameter. Includes updating the unit test.
    Ref: https://developer.wordpress.org/reference/functions/unregister_setting/
* The `_future_post_hook()` function contains a _soft_ deprecated parameter. Should still be detected by WPCS. As per the function docblock, I've set the expected value to `null`.
    Ref: https://developer.wordpress.org/reference/functions/_future_post_hook/
* The `_load_remote_block_patterns()` is a newly deprecated function (per WP 5.9.0).
    Ref: https://developer.wordpress.org/reference/functions/_load_remote_block_patterns/

Includes additional unit tests for the two newly listed functions.