### PR TITLE
WP/DeprecatedParameterValues: support modern PHP + update for WP 6.1

### DIFF
--- a/WordPress/Sniffs/WP/DeprecatedParameterValuesSniff.php
+++ b/WordPress/Sniffs/WP/DeprecatedParameterValuesSniff.php
@@ -66,6 +66,21 @@ class DeprecatedParameterValuesSniff extends AbstractFunctionParameterSniff {
 	 *     );
 	 */
 	protected $target_functions = array(
+		'add_option' => array(
+			1 => array(
+				'name'   => 'option',
+				'values' => array(
+					'blacklist_keys' => array(
+						'alt'     => 'disallowed_keys',
+						'version' => '5.5.0',
+					),
+					'comment_whitelist' => array(
+						'alt'     => 'comment_previously_approved',
+						'version' => '5.5.0',
+					),
+				),
+			),
+		),
 		'add_settings_field' => array(
 			4 => array(
 				'name'   => 'page',
@@ -134,6 +149,21 @@ class DeprecatedParameterValuesSniff extends AbstractFunctionParameterSniff {
 				),
 			),
 		),
+		'get_option' => array(
+			1 => array(
+				'name'   => 'option',
+				'values' => array(
+					'blacklist_keys' => array(
+						'alt'     => 'disallowed_keys',
+						'version' => '5.5.0',
+					),
+					'comment_whitelist' => array(
+						'alt'     => 'comment_previously_approved',
+						'version' => '5.5.0',
+					),
+				),
+			),
+		),
 		'register_setting' => array(
 			1 => array(
 				'name'   => 'option_group',
@@ -160,6 +190,21 @@ class DeprecatedParameterValuesSniff extends AbstractFunctionParameterSniff {
 					'privacy' => array(
 						'alt'     => 'another settings group',
 						'version' => '3.5.0',
+					),
+				),
+			),
+		),
+		'update_option' => array(
+			1 => array(
+				'name'   => 'option',
+				'values' => array(
+					'blacklist_keys' => array(
+						'alt'     => 'disallowed_keys',
+						'version' => '5.5.0',
+					),
+					'comment_whitelist' => array(
+						'alt'     => 'comment_previously_approved',
+						'version' => '5.5.0',
 					),
 				),
 			),

--- a/WordPress/Sniffs/WP/DeprecatedParameterValuesSniff.php
+++ b/WordPress/Sniffs/WP/DeprecatedParameterValuesSniff.php
@@ -11,6 +11,7 @@ namespace WordPressCS\WordPress\Sniffs\WP;
 
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\Utils\MessageHelper;
+use PHPCSUtils\Utils\PassedParameters;
 use PHPCSUtils\Utils\TextStrings;
 use WordPressCS\WordPress\AbstractFunctionParameterSniff;
 use WordPressCS\WordPress\Helpers\MinimumWPVersionTrait;
@@ -46,14 +47,19 @@ class DeprecatedParameterValuesSniff extends AbstractFunctionParameterSniff {
 	 * Last updated for WordPress 4.9.6.
 	 *
 	 * @since 1.0.0
+	 * @since 3.0.0 The format of the value has changed to support function calls
+	 *              using named parameters.
 	 *
 	 * @var array Multidimensional array with parameter details.
 	 *     $target_functions = array(
 	 *         (string) Function name. => array(
 	 *             (int) Target parameter position, 1-based. => array(
-	 *                 (string) Parameter value. => array(
-	 *                     'alt'     => (string) Suggested alternative.
-	 *                     'version' => (int) The WordPress version when deprecated.
+	 *                 (string) 'name'   => (string|array) Parameter name(s),
+	 *                 (string) 'values' => array(
+	 *                     (string) Parameter value. => array(
+	 *                         'alt'     => (string) Suggested alternative.
+	 *                         'version' => (int) The WordPress version when deprecated.
+	 *                     )
 	 *                 )
 	 *             )
 	 *         )
@@ -62,81 +68,99 @@ class DeprecatedParameterValuesSniff extends AbstractFunctionParameterSniff {
 	protected $target_functions = array(
 		'add_settings_field' => array(
 			4 => array(
-				'misc' => array(
-					'alt'     => 'another settings group',
-					'version' => '3.0.0',
-				),
-				'privacy' => array(
-					'alt'     => 'another settings group',
-					'version' => '3.5.0',
+				'name'   => 'page',
+				'values' => array(
+					'misc' => array(
+						'alt'     => 'another settings group',
+						'version' => '3.0.0',
+					),
+					'privacy' => array(
+						'alt'     => 'another settings group',
+						'version' => '3.5.0',
+					),
 				),
 			),
 		),
 		'add_settings_section' => array(
 			4 => array(
-				'misc' => array(
-					'alt'     => 'another settings group',
-					'version' => '3.0.0',
-				),
-				'privacy' => array(
-					'alt'     => 'another settings group',
-					'version' => '3.5.0',
+				'name'   => 'page',
+				'values' => array(
+					'misc' => array(
+						'alt'     => 'another settings group',
+						'version' => '3.0.0',
+					),
+					'privacy' => array(
+						'alt'     => 'another settings group',
+						'version' => '3.5.0',
+					),
 				),
 			),
 		),
 		'bloginfo' => array(
 			1 => array(
-				'home' => array(
-					'alt'     => 'the "url" argument',
-					'version' => '2.2.0',
-				),
-				'siteurl' => array(
-					'alt'     => 'the "url" argument',
-					'version' => '2.2.0',
-				),
-				'text_direction' => array(
-					'alt'     => 'is_rtl()',
-					'version' => '2.2.0',
+				'name'   => 'show',
+				'values' => array(
+					'home' => array(
+						'alt'     => 'the "url" argument',
+						'version' => '2.2.0',
+					),
+					'siteurl' => array(
+						'alt'     => 'the "url" argument',
+						'version' => '2.2.0',
+					),
+					'text_direction' => array(
+						'alt'     => 'is_rtl()',
+						'version' => '2.2.0',
+					),
 				),
 			),
 		),
 		'get_bloginfo' => array(
 			1 => array(
-				'home' => array(
-					'alt'     => 'the "url" argument',
-					'version' => '2.2.0',
-				),
-				'siteurl' => array(
-					'alt'     => 'the "url" argument',
-					'version' => '2.2.0',
-				),
-				'text_direction' => array(
-					'alt'     => 'is_rtl()',
-					'version' => '2.2.0',
+				'name'   => 'show',
+				'values' => array(
+					'home' => array(
+						'alt'     => 'the "url" argument',
+						'version' => '2.2.0',
+					),
+					'siteurl' => array(
+						'alt'     => 'the "url" argument',
+						'version' => '2.2.0',
+					),
+					'text_direction' => array(
+						'alt'     => 'is_rtl()',
+						'version' => '2.2.0',
+					),
 				),
 			),
 		),
 		'register_setting' => array(
 			1 => array(
-				'misc' => array(
-					'alt'     => 'another settings group',
-					'version' => '3.0.0',
-				),
-				'privacy' => array(
-					'alt'     => 'another settings group',
-					'version' => '3.5.0',
+				'name'   => 'option_group',
+				'values' => array(
+					'misc' => array(
+						'alt'     => 'another settings group',
+						'version' => '3.0.0',
+					),
+					'privacy' => array(
+						'alt'     => 'another settings group',
+						'version' => '3.5.0',
+					),
 				),
 			),
 		),
 		'unregister_setting' => array(
 			1 => array(
-				'misc' => array(
-					'alt'     => 'another settings group',
-					'version' => '3.0.0',
-				),
-				'privacy' => array(
-					'alt'     => 'another settings group',
-					'version' => '3.5.0',
+				'name'   => 'option_group',
+				'values' => array(
+					'misc' => array(
+						'alt'     => 'another settings group',
+						'version' => '3.0.0',
+					),
+					'privacy' => array(
+						'alt'     => 'another settings group',
+						'version' => '3.5.0',
+					),
 				),
 			),
 		),
@@ -156,15 +180,16 @@ class DeprecatedParameterValuesSniff extends AbstractFunctionParameterSniff {
 	 */
 	public function process_parameters( $stackPtr, $group_name, $matched_content, $parameters ) {
 		$this->get_wp_version_from_cli();
-		$param_count = \count( $parameters );
-		foreach ( $this->target_functions[ $matched_content ] as $position => $parameter_args ) {
 
-			// Stop if the position is higher then the total number of parameters.
-			if ( $position > $param_count ) {
-				break;
+		foreach ( $this->target_functions[ $matched_content ] as $position => $parameter_args ) {
+			$found_param = PassedParameters::getParameterFromStack( $parameters, $position, $parameter_args['name'] );
+
+			// Skip if the parameter was not found.
+			if ( false === $found_param ) {
+				continue;
 			}
 
-			$this->process_parameter( $matched_content, $parameters[ $position ], $parameter_args );
+			$this->process_parameter( $matched_content, $found_param, $parameter_args['values'] );
 		}
 	}
 

--- a/WordPress/Tests/WP/DeprecatedParameterValuesUnitTest.inc
+++ b/WordPress/Tests/WP/DeprecatedParameterValuesUnitTest.inc
@@ -38,3 +38,14 @@ get_bloginfo( filter: $filter ); // OK, optional parameter skipped.
 get_bloginfo( filter: $filter, show: $show, ); // OK, undetermined.
 get_bloginfo( filter: $filter, show: 'admin_email', ); // OK, not the deprecated value.
 get_bloginfo( filter: $filter, show: 'text_direction', ); // Error.
+
+// Parameter values which have been deprecated in WP 5.5. All will give an error as the `minimum_wp_version` > 5.5.
+add_option('blacklist_keys');
+add_option('comment_whitelist', $value);
+add_option(value: $value, option: 'blacklist_keys');
+get_option('blacklist_keys');
+get_option('comment_whitelist', $default);
+get_option(default: $default, option: 'comment_whitelist');
+update_option('blacklist_keys', $value);
+update_option('comment_whitelist', $value);
+update_option(autoload: true, value: $value, option: 'blacklist_keys');

--- a/WordPress/Tests/WP/DeprecatedParameterValuesUnitTest.inc
+++ b/WordPress/Tests/WP/DeprecatedParameterValuesUnitTest.inc
@@ -27,3 +27,14 @@ echo bloginfo( function_name() );
 
 get_bloginfo( 'wpurl' ); // OK.
 add_settings_field( '', '', '', /* deliberately not passed */ ); // Valid for PHP 7.3+.
+
+// Safeguard support for PHP 8.0+ named parameters.
+add_settings_section( $id, $title, $callback, args: $args ); // OK, optional parameter skipped.
+add_settings_field( page: $page, section: $section, id: $id, title: $title, callback: $callback ); // OK, undetermined.
+add_settings_section( callback: $callback, page: 'general', section: $section, id: $id, title: $title, ); // OK, not the deprecated value.
+add_settings_field( page: 'misc', section: $section, id: $id, title: $title, callback: $callback ); // Error.
+
+get_bloginfo( filter: $filter ); // OK, optional parameter skipped.
+get_bloginfo( filter: $filter, show: $show, ); // OK, undetermined.
+get_bloginfo( filter: $filter, show: 'admin_email', ); // OK, not the deprecated value.
+get_bloginfo( filter: $filter, show: 'text_direction', ); // Error.

--- a/WordPress/Tests/WP/DeprecatedParameterValuesUnitTest.php
+++ b/WordPress/Tests/WP/DeprecatedParameterValuesUnitTest.php
@@ -41,6 +41,8 @@ class DeprecatedParameterValuesUnitTest extends AbstractSniffUnitTest {
 			16 => 1,
 			17 => 1,
 			18 => 1,
+			35 => 1,
+			40 => 1,
 		);
 	}
 

--- a/WordPress/Tests/WP/DeprecatedParameterValuesUnitTest.php
+++ b/WordPress/Tests/WP/DeprecatedParameterValuesUnitTest.php
@@ -43,6 +43,15 @@ class DeprecatedParameterValuesUnitTest extends AbstractSniffUnitTest {
 			18 => 1,
 			35 => 1,
 			40 => 1,
+			43 => 1,
+			44 => 1,
+			45 => 1,
+			46 => 1,
+			47 => 1,
+			48 => 1,
+			49 => 1,
+			50 => 1,
+			51 => 1,
 		);
 	}
 


### PR DESCRIPTION
### WP/DeprecatedParameterValues: add support for PHP 8.0+ named parameters

1. Adjusted the way the correct parameters are retrieved to use the new PHPCSUtils 1.0.0-alpha4 `PassedParameters::getParameterFromStack()` method.
2. Verified the parameter names used are in line with the name as per the WP 6.1 release.
    WP has been renaming parameters and is probably not done yet, but it doesn't look like those changes (so far) made it into changelog entries....
    For the purposes of this exercise, I've taken the _current_ parameter name as the "truth" as support for named parameters hasn't officially been announced yet, so any renames _after_ this moment are the only ones relevant.

Includes a change to the array format to allow for recording the parameter name.

Includes additional unit tests.

### WP/DeprecatedParameterValues: verify against WP Core

Updated the array of parameters and values to search for based on a review of all calls to the `_deprecated_argument()` function in WP Core.

Includes tests.

Refs:
* https://developer.wordpress.org/reference/functions/add_option/
* https://developer.wordpress.org/reference/functions/get_option/
* https://developer.wordpress.org/reference/functions/update_option/