### PR TITLE
WP/DiscouragedConstants: implement PHPCSUtils and support modern PHP 

### DIFF
--- a/WordPress/Sniffs/WP/DiscouragedConstantsSniff.php
+++ b/WordPress/Sniffs/WP/DiscouragedConstantsSniff.php
@@ -219,9 +219,16 @@ class DiscouragedConstantsSniff extends AbstractFunctionParameterSniff {
 		$clean_content = TextStrings::stripQuotes( $found_param['clean'] );
 
 		if ( isset( $this->discouraged_constants[ $clean_content ] ) ) {
+			$first_non_empty = $this->phpcsFile->findNext(
+				Tokens::$emptyTokens,
+				$found_param['start'],
+				( $found_param['end'] + 1 ),
+				true
+			);
+
 			$this->phpcsFile->addWarning(
 				'Found declaration of constant "%s". Use %s instead.',
-				$stackPtr,
+				$first_non_empty,
 				MessageHelper::stringToErrorcode( $clean_content . 'DeclarationFound' ),
 				array(
 					$clean_content,

--- a/WordPress/Sniffs/WP/DiscouragedConstantsSniff.php
+++ b/WordPress/Sniffs/WP/DiscouragedConstantsSniff.php
@@ -166,9 +166,8 @@ class DiscouragedConstantsSniff extends AbstractFunctionParameterSniff {
 		if ( false !== $first_on_line && \T_USE === $this->tokens[ $first_on_line ]['code'] ) {
 			$next_on_line = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $first_on_line + 1 ), null, true );
 			if ( false !== $next_on_line ) {
-				if ( ( \T_STRING === $this->tokens[ $next_on_line ]['code']
-						&& 'const' === $this->tokens[ $next_on_line ]['content'] )
-					|| \T_CONST === $this->tokens[ $next_on_line ]['code'] // Happens in some PHPCS versions.
+				if ( \T_STRING === $this->tokens[ $next_on_line ]['code']
+					&& 'const' === $this->tokens[ $next_on_line ]['content']
 				) {
 					$has_ns_sep = $this->phpcsFile->findNext( \T_NS_SEPARATOR, ( $next_on_line + 1 ), $stackPtr );
 					if ( false !== $has_ns_sep ) {

--- a/WordPress/Sniffs/WP/DiscouragedConstantsSniff.php
+++ b/WordPress/Sniffs/WP/DiscouragedConstantsSniff.php
@@ -67,9 +67,6 @@ class DiscouragedConstantsSniff extends AbstractFunctionParameterSniff {
 	private $preceding_tokens_to_ignore = array(
 		\T_NAMESPACE       => true,
 		\T_USE             => true,
-		\T_CLASS           => true,
-		\T_TRAIT           => true,
-		\T_INTERFACE       => true,
 		\T_EXTENDS         => true,
 		\T_IMPLEMENTS      => true,
 		\T_NEW             => true,
@@ -82,6 +79,7 @@ class DiscouragedConstantsSniff extends AbstractFunctionParameterSniff {
 	 * Constructor to enrich a property.
 	 */
 	public function __construct() {
+		$this->preceding_tokens_to_ignore += Tokens::$ooScopeTokens;
 		$this->preceding_tokens_to_ignore += Collections::objectOperators();
 	}
 

--- a/WordPress/Sniffs/WP/DiscouragedConstantsSniff.php
+++ b/WordPress/Sniffs/WP/DiscouragedConstantsSniff.php
@@ -216,16 +216,16 @@ class DiscouragedConstantsSniff extends AbstractFunctionParameterSniff {
 			return;
 		}
 
-		$raw_content = TextStrings::stripQuotes( $found_param['raw'] );
+		$clean_content = TextStrings::stripQuotes( $found_param['clean'] );
 
-		if ( isset( $this->discouraged_constants[ $raw_content ] ) ) {
+		if ( isset( $this->discouraged_constants[ $clean_content ] ) ) {
 			$this->phpcsFile->addWarning(
 				'Found declaration of constant "%s". Use %s instead.',
 				$stackPtr,
-				MessageHelper::stringToErrorcode( $raw_content . 'DeclarationFound' ),
+				MessageHelper::stringToErrorcode( $clean_content . 'DeclarationFound' ),
 				array(
-					$raw_content,
-					$this->discouraged_constants[ $raw_content ],
+					$clean_content,
+					$this->discouraged_constants[ $clean_content ],
 				)
 			);
 		}

--- a/WordPress/Sniffs/WP/DiscouragedConstantsSniff.php
+++ b/WordPress/Sniffs/WP/DiscouragedConstantsSniff.php
@@ -11,6 +11,7 @@ namespace WordPressCS\WordPress\Sniffs\WP;
 
 use WordPressCS\WordPress\AbstractFunctionParameterSniff;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\MessageHelper;
 use PHPCSUtils\Utils\Scopes;
 use PHPCSUtils\Utils\TextStrings;
@@ -59,6 +60,8 @@ class DiscouragedConstantsSniff extends AbstractFunctionParameterSniff {
 	/**
 	 * Array of tokens which if found preceding the $stackPtr indicate that a T_STRING is not a constant.
 	 *
+	 * Additional tokens are added from within the contructor.
+	 *
 	 * @var array
 	 */
 	private $preceding_tokens_to_ignore = array(
@@ -71,11 +74,16 @@ class DiscouragedConstantsSniff extends AbstractFunctionParameterSniff {
 		\T_IMPLEMENTS      => true,
 		\T_NEW             => true,
 		\T_FUNCTION        => true,
-		\T_DOUBLE_COLON    => true,
-		\T_OBJECT_OPERATOR => true,
 		\T_INSTANCEOF      => true,
 		\T_GOTO            => true,
 	);
+
+	/**
+	 * Constructor to enrich a property.
+	 */
+	public function __construct() {
+		$this->preceding_tokens_to_ignore += Collections::objectOperators();
+	}
 
 	/**
 	 * Processes this test, when one of its tokens is encountered.

--- a/WordPress/Tests/WP/DiscouragedConstantsUnitTest.inc
+++ b/WordPress/Tests/WP/DiscouragedConstantsUnitTest.inc
@@ -70,3 +70,6 @@ switch(	STYLESHEETPATH ) {
 
 define( 'STYLESHEETPATH', 'something' );
 const STYLESHEETPATH = 'something';
+
+// Ignore also as "not a global constant" when the nullsafe object operator is used.
+echo $obj?->STYLESHEETPATH;

--- a/WordPress/Tests/WP/DiscouragedConstantsUnitTest.inc
+++ b/WordPress/Tests/WP/DiscouragedConstantsUnitTest.inc
@@ -73,3 +73,7 @@ const STYLESHEETPATH = 'something';
 
 // Ignore also as "not a global constant" when the nullsafe object operator is used.
 echo $obj?->STYLESHEETPATH;
+
+// Ignore enum names as not a global constant.
+enum STYLESHEETPATH {}
+enum BACKGROUND_COLOR: string implements Colorful {}

--- a/WordPress/Tests/WP/DiscouragedConstantsUnitTest.inc
+++ b/WordPress/Tests/WP/DiscouragedConstantsUnitTest.inc
@@ -81,3 +81,11 @@ enum BACKGROUND_COLOR: string implements Colorful {}
 // Safeguard support for PHP 8.0+ named parameters.
 define( case_insensitive: false, value: 'something' ); // OK. Well, not really as missing a required param, but that's not the concern of this sniff.
 define( case_insensitive: false, constant_name: 'STYLESHEETPATH', value: 'something' ); // Bad.
+
+// Safeguard that comments in the parameters are ignored.
+define(
+	// Name.
+	'STYLESHEETPATH',
+	// Value.
+	'something'
+);

--- a/WordPress/Tests/WP/DiscouragedConstantsUnitTest.inc
+++ b/WordPress/Tests/WP/DiscouragedConstantsUnitTest.inc
@@ -77,3 +77,7 @@ echo $obj?->STYLESHEETPATH;
 // Ignore enum names as not a global constant.
 enum STYLESHEETPATH {}
 enum BACKGROUND_COLOR: string implements Colorful {}
+
+// Safeguard support for PHP 8.0+ named parameters.
+define( case_insensitive: false, value: 'something' ); // OK. Well, not really as missing a required param, but that's not the concern of this sniff.
+define( case_insensitive: false, constant_name: 'STYLESHEETPATH', value: 'something' ); // Bad.

--- a/WordPress/Tests/WP/DiscouragedConstantsUnitTest.inc
+++ b/WordPress/Tests/WP/DiscouragedConstantsUnitTest.inc
@@ -89,3 +89,14 @@ define(
 	// Value.
 	'something'
 );
+
+// Safeguard that constants and methods in enums and traits are ignored.
+trait ContainsConst {
+	const STYLESHEETPATH = 'something';
+	private function &STYLESHEETPATH() {}
+}
+
+enum ContainsConst {
+	const STYLESHEETPATH = 'something';
+	private function STYLESHEETPATH() {}
+}

--- a/WordPress/Tests/WP/DiscouragedConstantsUnitTest.php
+++ b/WordPress/Tests/WP/DiscouragedConstantsUnitTest.php
@@ -54,6 +54,7 @@ class DiscouragedConstantsUnitTest extends AbstractSniffUnitTest {
 			71 => 1,
 			72 => 1,
 			83 => 1,
+			86 => 1,
 		);
 	}
 }

--- a/WordPress/Tests/WP/DiscouragedConstantsUnitTest.php
+++ b/WordPress/Tests/WP/DiscouragedConstantsUnitTest.php
@@ -54,7 +54,7 @@ class DiscouragedConstantsUnitTest extends AbstractSniffUnitTest {
 			71 => 1,
 			72 => 1,
 			83 => 1,
-			86 => 1,
+			88 => 1,
 		);
 	}
 }

--- a/WordPress/Tests/WP/DiscouragedConstantsUnitTest.php
+++ b/WordPress/Tests/WP/DiscouragedConstantsUnitTest.php
@@ -53,7 +53,7 @@ class DiscouragedConstantsUnitTest extends AbstractSniffUnitTest {
 			67 => 1,
 			71 => 1,
 			72 => 1,
+			83 => 1,
 		);
 	}
-
 }


### PR DESCRIPTION
### WP/DiscouragedConstants: allow for the PHP 8.0+ nullsafe object operator

Ignore tokens preceded by the nullsafe object operator as they won't be the global constant.

Includes minor maintenance tweak to use a predefined array for all object operators.

Includes unit test.

### WP/DiscouragedConstants: allow for PHP 8.1+ enums

Ignore tokens preceded by the `enum` keyword as they won't be the global constant.

Includes minor maintenance tweak to use a predefined array for all OO keywords.

Includes unit test.

### WP/DiscouragedConstants: add support for PHP 8.0+ named parameters

1. Adjusted the way the correct parameters are retrieved to use the new PHPCSUtils 1.0.0-alpha4 `PassedParameters::getParameterFromStack()` method.
2. Verified the parameter names used are in line with the names as per the PHP 8.0 release.
    PHP itself renamed a lot of parameters in PHP 8.0. As named parameters did not exist before PHP 8.0, the parameter name as per PHP 8.0 (or above) is the only relevant name.
    Ref: https://www.php.net/manual/en/function.define

Includes additional unit tests.

### WP/DiscouragedConstants: prevent some false positives

The `'raw'` key in the parameter arrays returned from the `PassedParameters` class contains - as per the name - the _raw_ contents of the parameter.

Since PHPCSUtils 1.0.0-alpha4, the return array also contain a `'clean'` index, which contains the contents of the parameter cleaned of comments.

By switching to using that key, some false negatives get fixed.

Includes unit tests demonstrating the issue and safeguarding the fix.

Includes ensuring that the information displayed in the error message will also not contain comments.

### WP/DiscouragedConstants: improve error position precision

... for multi-line function calls.

### WP/DiscouragedConstants: add tests with trait and enum constants

... to ensure those aren't recognized as if they were the global constant.

Enums are a PHP 8.1+ features.
Constants in traits are allowed since PHP 8.2.

### WP/DiscouragedConstants: remove redundant code

... which is no longer needed now support for PHPCS < 3.7.1 has been dropped.