### PR TITLE
WP/EnqueuedResourceParameters: implement PHPCSUtils and support modern PHP

### DIFF
--- a/WordPress/Sniffs/WP/EnqueuedResourceParametersSniff.php
+++ b/WordPress/Sniffs/WP/EnqueuedResourceParametersSniff.php
@@ -130,7 +130,7 @@ class EnqueuedResourceParametersSniff extends AbstractFunctionParameterSniff {
 		 */
 
 		$version_param = PassedParameters::getParameterFromStack( $parameters, 4, 'ver' );
-		if ( false === $version_param || 'null' === $version_param['raw'] ) {
+		if ( false === $version_param || 'null' === $version_param['clean'] ) {
 			$type = 'script';
 			if ( strpos( $matched_content, '_style' ) !== false ) {
 				$type = 'style';

--- a/WordPress/Sniffs/WP/EnqueuedResourceParametersSniff.php
+++ b/WordPress/Sniffs/WP/EnqueuedResourceParametersSniff.php
@@ -130,6 +130,12 @@ class EnqueuedResourceParametersSniff extends AbstractFunctionParameterSniff {
 		 */
 
 		$version_param = PassedParameters::getParameterFromStack( $parameters, 4, 'ver' );
+
+		$error_ptr = $stackPtr;
+		if ( false !== $version_param ) {
+			$error_ptr = $this->phpcsFile->findNext( Tokens::$emptyTokens, $version_param['start'], ( $version_param['end'] + 1 ), true );
+		}
+
 		if ( false === $version_param || 'null' === $version_param['clean'] ) {
 			$type = 'script';
 			if ( strpos( $matched_content, '_style' ) !== false ) {
@@ -138,7 +144,7 @@ class EnqueuedResourceParametersSniff extends AbstractFunctionParameterSniff {
 
 			$this->phpcsFile->addWarning(
 				'Resource version not set in call to %s(). This means new versions of the %s may not always be loaded due to browser caching.',
-				$stackPtr,
+				$error_ptr,
 				'MissingVersion',
 				array( $matched_content, $type )
 			);
@@ -147,7 +153,7 @@ class EnqueuedResourceParametersSniff extends AbstractFunctionParameterSniff {
 			$this->phpcsFile->addError(
 				'Version parameter is not explicitly set or has been set to an equivalent of "false" for %s; ' .
 				'This means that the WordPress core version will be used which is not recommended for plugin or theme development.',
-				$stackPtr,
+				$error_ptr,
 				'NoExplicitVersion',
 				array( $matched_content )
 			);

--- a/WordPress/Sniffs/WP/EnqueuedResourceParametersSniff.php
+++ b/WordPress/Sniffs/WP/EnqueuedResourceParametersSniff.php
@@ -10,6 +10,7 @@
 namespace WordPressCS\WordPress\Sniffs\WP;
 
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Utils\Numbers;
 use PHPCSUtils\Utils\PassedParameters;
 use WordPressCS\WordPress\AbstractFunctionParameterSniff;
 
@@ -213,6 +214,14 @@ class EnqueuedResourceParametersSniff extends AbstractFunctionParameterSniff {
 			}
 
 			if ( isset( Tokens::$emptyTokens[ $this->tokens[ $i ]['code'] ] ) === true ) {
+				continue;
+			}
+
+			// Make sure that PHP 7.4 numeric literals and PHP 8.1 explicit octals don't cause problems.
+			if ( \T_LNUMBER === $this->tokens[ $i ]['code'] || \T_DNUMBER === $this->tokens[ $i ]['code'] ) {
+				$number_info  = Numbers::getCompleteNumber( $this->phpcsFile, $i );
+				$code_string .= $number_info['decimal'];
+				$i            = $number_info['last_token'];
 				continue;
 			}
 

--- a/WordPress/Sniffs/WP/EnqueuedResourceParametersSniff.php
+++ b/WordPress/Sniffs/WP/EnqueuedResourceParametersSniff.php
@@ -9,8 +9,9 @@
 
 namespace WordPressCS\WordPress\Sniffs\WP;
 
-use WordPressCS\WordPress\AbstractFunctionParameterSniff;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Utils\PassedParameters;
+use WordPressCS\WordPress\AbstractFunctionParameterSniff;
 
 /**
  * This checks the enqueued 4th and 5th parameters to make sure the version and in_footer are set.
@@ -118,9 +119,9 @@ class EnqueuedResourceParametersSniff extends AbstractFunctionParameterSniff {
 	 * @return void
 	 */
 	public function process_parameters( $stackPtr, $group_name, $matched_content, $parameters ) {
-
 		// Check to see if a source ($src) is specified.
-		if ( ! isset( $parameters[2] ) ) {
+		$src_param = PassedParameters::getParameterFromStack( $parameters, 2, 'src' );
+		if ( false === $src_param ) {
 			return;
 		}
 
@@ -128,7 +129,8 @@ class EnqueuedResourceParametersSniff extends AbstractFunctionParameterSniff {
 		 * Version Check: Check to make sure the version is set explicitly.
 		 */
 
-		if ( ! isset( $parameters[4] ) || 'null' === $parameters[4]['raw'] ) {
+		$version_param = PassedParameters::getParameterFromStack( $parameters, 4, 'ver' );
+		if ( false === $version_param || 'null' === $version_param['raw'] ) {
 			$type = 'script';
 			if ( strpos( $matched_content, '_style' ) !== false ) {
 				$type = 'style';
@@ -141,7 +143,7 @@ class EnqueuedResourceParametersSniff extends AbstractFunctionParameterSniff {
 				array( $matched_content, $type )
 			);
 			// The version argument should have a non-false value.
-		} elseif ( $this->is_falsy( $parameters[4]['start'], $parameters[4]['end'] ) ) {
+		} elseif ( $this->is_falsy( $version_param['start'], $version_param['end'] ) ) {
 			$this->phpcsFile->addError(
 				'Version parameter is not explicitly set or has been set to an equivalent of "false" for %s; ' .
 				'This means that the WordPress core version will be used which is not recommended for plugin or theme development.',
@@ -164,7 +166,8 @@ class EnqueuedResourceParametersSniff extends AbstractFunctionParameterSniff {
 			return;
 		}
 
-		if ( ! isset( $parameters[5] ) ) {
+		$infooter_param = PassedParameters::getParameterFromStack( $parameters, 5, 'in_footer' );
+		if ( false === $infooter_param ) {
 			// If in footer is not set, throw a warning about the default.
 			$this->phpcsFile->addWarning(
 				'In footer ($in_footer) is not set explicitly %s; ' .

--- a/WordPress/Tests/WP/EnqueuedResourceParametersUnitTest.inc
+++ b/WordPress/Tests/WP/EnqueuedResourceParametersUnitTest.inc
@@ -55,3 +55,15 @@ wp_register_script( 'someScript-js', 'https://example.com/someScript.js' , array
 
 wp_register_script( 'someScript-js', 'https://example.com/someScript.js' , array( 'jquery' ), (binary) 123, true ); // OK.
 wp_register_script( 'someScript-js', 'https://example.com/someScript.js' , array( 'jquery' ), b'0', true ); // Error - 0, false or NULL are not allowed.
+
+// Safeguard support for PHP 8.0+ named parameters.
+wp_register_script(
+	ver      : 0, // Error - 0, false or NULL are not allowed.
+	in_footer: false,
+	src      : 'https://example.com/someScript.js',
+	handle   : 'someScript-js',
+);
+wp_enqueue_script(
+	src: 'https://example.com/someScript.js',
+	handle: 'script-name',
+); // Warning - missing $ver, Warning - missing $in_footer.

--- a/WordPress/Tests/WP/EnqueuedResourceParametersUnitTest.inc
+++ b/WordPress/Tests/WP/EnqueuedResourceParametersUnitTest.inc
@@ -77,3 +77,9 @@ wp_register_script(
 	null,
 	true,
 );
+
+// Safeguard handling of PHP 7.4 numeric literals with underscores.
+wp_register_script( 'someScript-js', $url, [], 0_0.0_0, true ); // Error - 0, false or NULL are not allowed.
+
+// Safeguard handling of PHP 8.1 explicit octals.
+wp_register_script( 'someScript-js', $url, [], 0o0, true ); // Error - 0, false or NULL are not allowed.

--- a/WordPress/Tests/WP/EnqueuedResourceParametersUnitTest.inc
+++ b/WordPress/Tests/WP/EnqueuedResourceParametersUnitTest.inc
@@ -67,3 +67,13 @@ wp_enqueue_script(
 	src: 'https://example.com/someScript.js',
 	handle: 'script-name',
 ); // Warning - missing $ver, Warning - missing $in_footer.
+
+// Safeguard that comments in the parameters are ignored.
+wp_register_script(
+	'someScript-js',
+	'https://example.com/someScript.js',
+	array( 'jquery' ),
+	// Error - 0, false or NULL are not allowed.
+	null,
+	true,
+);

--- a/WordPress/Tests/WP/EnqueuedResourceParametersUnitTest.php
+++ b/WordPress/Tests/WP/EnqueuedResourceParametersUnitTest.php
@@ -37,6 +37,8 @@ class EnqueuedResourceParametersUnitTest extends AbstractSniffUnitTest {
 			54 => 1,
 			57 => 1,
 			61 => 1,
+			82 => 1,
+			85 => 1,
 		);
 	}
 

--- a/WordPress/Tests/WP/EnqueuedResourceParametersUnitTest.php
+++ b/WordPress/Tests/WP/EnqueuedResourceParametersUnitTest.php
@@ -36,7 +36,7 @@ class EnqueuedResourceParametersUnitTest extends AbstractSniffUnitTest {
 			22 => 1,
 			54 => 1,
 			57 => 1,
-			60 => 1,
+			61 => 1,
 		);
 	}
 
@@ -54,7 +54,7 @@ class EnqueuedResourceParametersUnitTest extends AbstractSniffUnitTest {
 			42 => 1,
 			45 => 1,
 			66 => 2,
-			72 => 1,
+			77 => 1,
 		);
 	}
 }

--- a/WordPress/Tests/WP/EnqueuedResourceParametersUnitTest.php
+++ b/WordPress/Tests/WP/EnqueuedResourceParametersUnitTest.php
@@ -54,6 +54,7 @@ class EnqueuedResourceParametersUnitTest extends AbstractSniffUnitTest {
 			42 => 1,
 			45 => 1,
 			66 => 2,
+			72 => 1,
 		);
 	}
 }

--- a/WordPress/Tests/WP/EnqueuedResourceParametersUnitTest.php
+++ b/WordPress/Tests/WP/EnqueuedResourceParametersUnitTest.php
@@ -36,6 +36,7 @@ class EnqueuedResourceParametersUnitTest extends AbstractSniffUnitTest {
 			22 => 1,
 			54 => 1,
 			57 => 1,
+			60 => 1,
 		);
 	}
 
@@ -52,7 +53,7 @@ class EnqueuedResourceParametersUnitTest extends AbstractSniffUnitTest {
 			39 => 2,
 			42 => 1,
 			45 => 1,
+			66 => 2,
 		);
 	}
-
 }


### PR DESCRIPTION
### WP/EnqueuedResourceParameters: add support for PHP 8.0+ named parameters

1. Adjusted the way the correct parameters are retrieved to use the new PHPCSUtils 1.0.0-alpha4 `PassedParameters::getParameterFromStack()` method.
2. Verified the parameter names used are in line with the name as per the WP 6.1 release.
    WP has been renaming parameters and is probably not done yet, but it doesn't look like those changes (so far) made it into changelog entries....
    For the purposes of this exercise, I've taken the _current_ parameter name as the "truth" as support for named parameters hasn't officially been announced yet, so any renames _after_ this moment are the only ones relevant.

Includes additional unit tests.

### WP/EnqueuedResourceParameters: prevent false positives

The `'raw'` key in the parameter arrays returned from the `PassedParameters` class contains - as per the name - the _raw_ contents of the parameter.

Since PHPCSUtils 1.0.0-alpha4, the return array also contain a `'clean'` index, which contains the contents of the parameter cleaned of comments.

By switching to using that key, a `null` value accompanied by a comment will no longer throw the wrong error.

Includes unit test demonstrating the issue and safeguarding the fix.

### WP/EnqueuedResourceParameters: improve error position precision

... for multi-line function calls.

### WP/EnqueuedResourceParameters: add support for PHP 7.4/8.1 numbers

PHP 7.4 introduced numeric literals with underscores.
PHP 8.1 introduced explicit octal notation.

While PHPCS backfills the tokens for this, this sniff uses an `eval()` call and if either of these PHP 7.4/8.1 syntaxes would be passed to this `eval()` while PHPCS is being run on PHP < 7.4, this will result in a parse error on the code passed to `eval()`.

By using the PHPCSUtils `Numbers::getCompleteNumber()` method, we can get access to the decimal value of the encountered number, which allows us to bypass the issue by using that in the code string passed to `eval()`.

Includes unit tests.