### PR TITLE
Various sniffs: improve error messages

### DIFF
--- a/WordPress/Sniffs/CodeAnalysis/EscapedNotTranslatedSniff.php
+++ b/WordPress/Sniffs/CodeAnalysis/EscapedNotTranslatedSniff.php
@@ -81,7 +81,7 @@ class EscapedNotTranslatedSniff extends AbstractFunctionParameterSniff {
 		);
 
 		$this->phpcsFile->addWarning(
-			'%s() expects only one parameter. Did you mean to use %s() ? Found: %s',
+			'%s() expects only a $text parameter. Did you mean to use %s() ? Found: %s',
 			$stackPtr,
 			'Found',
 			$data

--- a/WordPress/Sniffs/PHP/PregQuoteDelimiterSniff.php
+++ b/WordPress/Sniffs/PHP/PregQuoteDelimiterSniff.php
@@ -63,7 +63,7 @@ class PregQuoteDelimiterSniff extends AbstractFunctionParameterSniff {
 		}
 
 		$this->phpcsFile->addWarning(
-			'Passing the $delimiter to preg_quote() is strongly recommended.',
+			'Passing the $delimiter parameter to preg_quote() is strongly recommended.',
 			$stackPtr,
 			'Missing'
 		);

--- a/WordPress/Sniffs/PHP/RestrictedPHPFunctionsSniff.php
+++ b/WordPress/Sniffs/PHP/RestrictedPHPFunctionsSniff.php
@@ -37,7 +37,7 @@ class RestrictedPHPFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 		return array(
 			'create_function' => array(
 				'type'      => 'error',
-				'message'   => '%s() is deprecated as of PHP 7.2 and removed in PHP 8.0, please use full fledged functions or anonymous functions instead.',
+				'message'   => '%s() is deprecated as of PHP 7.2 and removed in PHP 8.0. Please use declared named or anonymous functions instead.',
 				'functions' => array(
 					'create_function',
 				),

--- a/WordPress/Sniffs/PHP/TypeCastsSniff.php
+++ b/WordPress/Sniffs/PHP/TypeCastsSniff.php
@@ -73,7 +73,7 @@ class TypeCastsSniff extends Sniff {
 
 			case \T_UNSET_CAST:
 				$this->phpcsFile->addError(
-					'Using the "(unset)" cast is forbidden as the type cast is removed in PHP 8. Use the "unset()" language construct or assign "null" as the value to the variable instead.',
+					'Using the "(unset)" cast is forbidden as the type cast is removed in PHP 8.0. Use the "unset()" language construct instead.',
 					$stackPtr,
 					'UnsetFound'
 				);

--- a/WordPress/Sniffs/Security/SafeRedirectSniff.php
+++ b/WordPress/Sniffs/Security/SafeRedirectSniff.php
@@ -37,7 +37,7 @@ class SafeRedirectSniff extends AbstractFunctionRestrictionsSniff {
 		return array(
 			'wp_redirect' => array(
 				'type'      => 'warning',
-				'message'   => '%s() found. Using wp_safe_redirect(), along with the allowed_redirect_hosts filter if needed, can help avoid any chances of malicious redirects within code. It is also important to remember to call exit() after a redirect so that no other unwanted code is executed.',
+				'message'   => '%s() found. Using wp_safe_redirect(), along with the "allowed_redirect_hosts" filter if needed, can help avoid any chances of malicious redirects within code. It is also important to remember to call exit() after a redirect so that no other unwanted code is executed.',
 				'functions' => array(
 					'wp_redirect',
 				),


### PR DESCRIPTION
### CodeAnalysis/EscapedNotTranslated: improvement to the error message

... to remove the presumption that positional parameters are being used.

### PHP/PregQuoteDelimiter: minor message tweak for clarity

### PHP/RestrictedPHPFunctions: minor message tweak for clarity

### PHP/TypeCasts: minor message tweak for clarity

... and remove the advise to assign `null` as this could cause yet other problems due to the PHP 8.1 "passing null to non-nullable" deprecation (though passing an unassigned variable is in a way just as bad, but that's a whole other story).

### Security/SafeRedirect: minor message tweak for clarity 