### PR TITLE
PHPCS: ruleset tweak

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -47,6 +47,9 @@
 		<exclude name="WordPress.DB"/>
 		<exclude name="WordPress.Security"/>
 		<exclude name="WordPress.WP"/>
+
+		<!-- Linting is done in a separate CI job, no need to duplicate it. -->
+		<exclude name="Generic.PHP.Syntax"/>
 	</rule>
 
 	<!-- Check code for cross-version PHP compatibility. -->


### PR DESCRIPTION
For this repo, we use a separate package for linting code, so there is no need to have the `Generic.PHP.Syntax` sniff running when doing a PHPCS scan (the sniff is included in the `WordPress-Extra` ruleset).

An analysis of the performance of a sniff run on this repo revealed that this was the slowest sniff by far. As excluding it will not have any QA impact, let's make CS runs on the code in this repo faster.