### PR TITLE
WP/GlobalVariablesOverride: implement PHPCSUtils and support modern PHP

### DIFF
--- a/WordPress/Sniffs/WP/GlobalVariablesOverrideSniff.php
+++ b/WordPress/Sniffs/WP/GlobalVariablesOverrideSniff.php
@@ -340,7 +340,7 @@ class GlobalVariablesOverrideSniff extends Sniff {
 			}
 			$end = $this->tokens[ $functionPtr ]['scope_closer'];
 		} else {
-			// Global statement in the global namespace with file is being treated as scoped.
+			// Global statement in the global namespace in a file which is being treated as scoped.
 			$end = $this->phpcsFile->numTokens;
 		}
 

--- a/WordPress/Sniffs/WP/GlobalVariablesOverrideSniff.php
+++ b/WordPress/Sniffs/WP/GlobalVariablesOverrideSniff.php
@@ -312,7 +312,7 @@ class GlobalVariablesOverrideSniff extends Sniff {
 				if ( WPGlobalVariablesHelper::is_wp_global( $var_name )
 					&& isset( $this->override_allowed[ $var_name ] ) === false
 				) {
-					$search[] = $var['content'];
+					$search[ $var['content'] ] = true;
 				}
 			}
 
@@ -369,7 +369,7 @@ class GlobalVariablesOverrideSniff extends Sniff {
 						$var_name = '$' . TextStrings::stripQuotes( VariableHelper::get_array_access_key( $this->phpcsFile, $ptr ) );
 					}
 
-					if ( \in_array( $var_name, $search, true ) ) {
+					if ( isset( $search[ $var_name ] ) ) {
 						$this->process_variable_assignment( $ptr, true );
 					}
 				}
@@ -383,7 +383,7 @@ class GlobalVariablesOverrideSniff extends Sniff {
 				continue;
 			}
 
-			if ( \in_array( $this->tokens[ $ptr ]['content'], $search, true ) === false ) {
+			if ( isset( $search[ $this->tokens[ $ptr ]['content'] ] ) === false ) {
 				// Not one of the variables we're interested in.
 				continue;
 			}

--- a/WordPress/Sniffs/WP/GlobalVariablesOverrideSniff.php
+++ b/WordPress/Sniffs/WP/GlobalVariablesOverrideSniff.php
@@ -208,7 +208,10 @@ class GlobalVariablesOverrideSniff extends Sniff {
 		if ( 'GLOBALS' === $var_name ) {
 			$bracketPtr = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true );
 
-			if ( false === $bracketPtr || \T_OPEN_SQUARE_BRACKET !== $this->tokens[ $bracketPtr ]['code'] || ! isset( $this->tokens[ $bracketPtr ]['bracket_closer'] ) ) {
+			if ( false === $bracketPtr
+				|| \T_OPEN_SQUARE_BRACKET !== $this->tokens[ $bracketPtr ]['code']
+				|| ! isset( $this->tokens[ $bracketPtr ]['bracket_closer'] )
+			) {
 				return;
 			}
 

--- a/WordPress/Sniffs/WP/GlobalVariablesOverrideSniff.php
+++ b/WordPress/Sniffs/WP/GlobalVariablesOverrideSniff.php
@@ -297,28 +297,22 @@ class GlobalVariablesOverrideSniff extends Sniff {
 		/*
 		 * Collect the variables to watch for.
 		 */
-		$search = array();
-		$ptr    = ( $stackPtr + 1 );
-		while ( isset( $this->tokens[ $ptr ] ) ) {
-			$var = $this->tokens[ $ptr ];
+		$search           = array();
+		$ptr              = ( $stackPtr + 1 );
+		$end_of_statement = $this->phpcsFile->findNext( array( \T_SEMICOLON, \T_CLOSE_TAG ), $ptr );
 
-			// Halt the loop at end of statement.
-			if ( \T_SEMICOLON === $var['code'] ) {
-				break;
-			}
-
-			if ( \T_VARIABLE === $var['code'] ) {
-				$var_name = substr( $var['content'], 1 );
+		while ( isset( $this->tokens[ $ptr ] ) && $ptr < $end_of_statement ) {
+			if ( \T_VARIABLE === $this->tokens[ $ptr ]['code'] ) {
+				$var_name = substr( $this->tokens[ $ptr ]['content'], 1 );
 				if ( WPGlobalVariablesHelper::is_wp_global( $var_name )
 					&& isset( $this->override_allowed[ $var_name ] ) === false
 				) {
-					$search[ $var['content'] ] = true;
+					$search[ $this->tokens[ $ptr ]['content'] ] = true;
 				}
 			}
 
 			++$ptr;
 		}
-		unset( $var );
 
 		if ( empty( $search ) ) {
 			return;

--- a/WordPress/Tests/WP/GlobalVariablesOverrideUnitTest.1.inc
+++ b/WordPress/Tests/WP/GlobalVariablesOverrideUnitTest.1.inc
@@ -276,3 +276,21 @@ class ConstructorPropertyPromotion {
 		$post = null
 	) {} // Ok.
 }
+
+/*
+ * Safeguard that assignment in PHP 8.1+ enums are treated correctly.
+ * Note: enums cannot contain property declaration.
+ */
+enum Suit: string implements Colorful {
+	case Hearts = 'H';
+	case Diamonds = 'D';
+	case Clubs = 'C';
+	case Spades = 'S';
+
+	public function color( $_wp_admin_css_colors = 'red' ): string { // OK, parameter, not the global variable.
+		global $status, $mode;
+		$status = 'something'; // Bad, global variable in function scope.
+		$post = '2017'; // Ok, non-global variable in function scope.
+		[$mode] = $array; // Bad, global variable in function scope.
+	}
+}

--- a/WordPress/Tests/WP/GlobalVariablesOverrideUnitTest.1.inc
+++ b/WordPress/Tests/WP/GlobalVariablesOverrideUnitTest.1.inc
@@ -240,3 +240,7 @@ list( $active_signup, list( $s => $typenow, $GLOBALS['status'], ), $ignore ) = $
 
 // List with array assignments.
 [ $path[ $type ], , ] = $array; // Bad x 1.
+
+function use_of_globals_without_key() {
+	$keys = array_keys( $GLOBALS ); // OK, this is just about handling the $GLOBALS without a key.
+}

--- a/WordPress/Tests/WP/GlobalVariablesOverrideUnitTest.1.inc
+++ b/WordPress/Tests/WP/GlobalVariablesOverrideUnitTest.1.inc
@@ -259,3 +259,6 @@ function global_import_ended_by_close_tag_false_positive() {
 	$post = '2016'; // Ok, non-global variable in function scope. Would previously be seen as part of the global statement...
 	$post = '2017'; // Ok, non-global variable in function scope.
 }
+
+// Safeguard correct handling of PHP 7.4+ arrow functions.
+$arrow = fn($urls = []) => $urls + ['extra']; // OK, default value assignment to arrow function parameter should be disregarded.

--- a/WordPress/Tests/WP/GlobalVariablesOverrideUnitTest.1.inc
+++ b/WordPress/Tests/WP/GlobalVariablesOverrideUnitTest.1.inc
@@ -262,3 +262,8 @@ function global_import_ended_by_close_tag_false_positive() {
 
 // Safeguard correct handling of PHP 7.4+ arrow functions.
 $arrow = fn($urls = []) => $urls + ['extra']; // OK, default value assignment to arrow function parameter should be disregarded.
+
+function recognize_nullcoalesce_equals() {
+	global $tax;
+	$tax ??= 'other'; // Bad, potentially overrides the variable.
+}

--- a/WordPress/Tests/WP/GlobalVariablesOverrideUnitTest.1.inc
+++ b/WordPress/Tests/WP/GlobalVariablesOverrideUnitTest.1.inc
@@ -267,3 +267,12 @@ function recognize_nullcoalesce_equals() {
 	global $tax;
 	$tax ??= 'other'; // Bad, potentially overrides the variable.
 }
+
+// Safeguard that assignments to properties using PHP 8.0+ constructor property promotion don't lead to false positives.
+class ConstructorPropertyPromotion {
+	public function __construct(
+		public int $timestart = 0,
+		protected int|bool $timeend = false,
+		$post = null
+	) {} // Ok.
+}

--- a/WordPress/Tests/WP/GlobalVariablesOverrideUnitTest.1.inc
+++ b/WordPress/Tests/WP/GlobalVariablesOverrideUnitTest.1.inc
@@ -244,3 +244,18 @@ list( $active_signup, list( $s => $typenow, $GLOBALS['status'], ), $ignore ) = $
 function use_of_globals_without_key() {
 	$keys = array_keys( $GLOBALS ); // OK, this is just about handling the $GLOBALS without a key.
 }
+
+function global_import_ended_by_close_tag_false_negative() {
+	global $pagenow ?>
+	<div>Some HTML</div>
+	<?php
+	$pagenow = 'test'; // Bad, global variable in function scope.
+}
+
+function global_import_ended_by_close_tag_false_positive() {
+	global $pagenow ?>
+	<div>Some HTML</div>
+	<?php
+	$post = '2016'; // Ok, non-global variable in function scope. Would previously be seen as part of the global statement...
+	$post = '2017'; // Ok, non-global variable in function scope.
+}

--- a/WordPress/Tests/WP/GlobalVariablesOverrideUnitTest.php
+++ b/WordPress/Tests/WP/GlobalVariablesOverrideUnitTest.php
@@ -64,6 +64,8 @@ class GlobalVariablesOverrideUnitTest extends AbstractSniffUnitTest {
 					242 => 1,
 					252 => 1,
 					268 => 1,
+					292 => 1,
+					294 => 1,
 				);
 
 			case 'GlobalVariablesOverrideUnitTest.2.inc':

--- a/WordPress/Tests/WP/GlobalVariablesOverrideUnitTest.php
+++ b/WordPress/Tests/WP/GlobalVariablesOverrideUnitTest.php
@@ -63,6 +63,7 @@ class GlobalVariablesOverrideUnitTest extends AbstractSniffUnitTest {
 					239 => 3,
 					242 => 1,
 					252 => 1,
+					268 => 1,
 				);
 
 			case 'GlobalVariablesOverrideUnitTest.2.inc':

--- a/WordPress/Tests/WP/GlobalVariablesOverrideUnitTest.php
+++ b/WordPress/Tests/WP/GlobalVariablesOverrideUnitTest.php
@@ -62,6 +62,7 @@ class GlobalVariablesOverrideUnitTest extends AbstractSniffUnitTest {
 					234 => 2,
 					239 => 3,
 					242 => 1,
+					252 => 1,
 				);
 
 			case 'GlobalVariablesOverrideUnitTest.2.inc':


### PR DESCRIPTION
### WP/GlobalVariablesOverride: implement PHPCSUtils

### WP/GlobalVariablesOverride: minor efficiency tweak

Change the format of the `$search` array to have the "value" as the key instead of as the value, which allows for using the more performance friendly `isset()` instead of `in_array()`.

### WP/GlobalVariablesOverride: add extra test

... to cover an edge case which was already handled in the code, but not covered by a test.

### WP/GlobalVariablesOverride: bug fix - allow for global statement closed via close tag

The parsing of a `global` variable import statement would walk until the next semi-colon, while the statement can also be ended by a PHP close tag.

This could lead to false positives as well as false negatives.

Fixed now.

Includes unit tests.

Includes removing a redundant variable assignment.

### WP/GlobalVariablesOverride: add support for PHP 7.4+ arrow functions

PHP 7.4 introduced arrow functions.

For the purposes of this sniff, default value assignments to parameters declared in an arrow function should be ignored to prevent false positives.

I've also reviewed the other places where _special handling_ is in place for functions/closures and have concluded that this does not apply to arrow functions.

I have updated line 333 to use the PHPCSUtils `Collections::functionDeclarationTokens()` token array for convenience, but it won't have any effect on arrow functions as `global` statements are not supported in arrow functions (well, that is, I haven't been able to set up any code which didn't result in a parse error for that. May need revisiting if someone more creative than me comes up with a way to do it...)

Includes unit test for the parameter default value part.

### WP/GlobalVariablesOverride: add test with PHP 7.4+ null coalesce assignment

PHP 7.4 introduced the null coalesce equal operator.

As the `VariableHelper::is_assignment()` uses the `Tokens::$assignmentTokens` array to determine whether something is an assignment and the `T_COALESCE_EQUAL` token is included in that array, no functional changes need to be made to support this.

Just adding a test to safeguard the support.

### WP/GlobalVariablesOverride: add test with PHP 8.0+ constructor property promotion

PHP 8.0 introduced constructor property promotion.

As default value assignments in function declaration statements are excluded already, no functional changes need to be made to support this.

Just adding a test to safeguard that this is handled correctly.

### WP/GlobalVariablesOverride: add test with PHP 8.1+ enums

PHP 8.1 introduced enums.

As enums cannot be used as test classes, there isn't really anything special about them, so no functional changes need to be made to support this.

Just adding a test to safeguard that they are handled correctly.

### WP/GlobalVariablesOverride: minor code readability improvement

### WP/GlobalVariablesOverride: minor comment fix 