### PR TITLE
Composer: update for PHPCSUtils + PHPCSExtra 1.0.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,8 +33,6 @@
 			"dealerdirect/phpcodesniffer-composer-installer": true
 		}
 	},
-	"minimum-stability": "dev",
-	"prefer-stable": true,
 	"scripts": {
 		"lint": [
 			"@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --show-deprecated --exclude vendor --exclude .git"


### PR DESCRIPTION
PHPCSUtils 1.0.0 and PHPCSExtra 1.0.0 have both been tagged & released. :tada:

This means that the `minimum-stability`/`prefer-stable` settings should no longer be needed.

Ref:
* https://github.com/PHPCSStandards/PHPCSUtils/releases/tag/v1.0.0
* https://github.com/PHPCSStandards/PHPCSExtra/releases/tag/v1.0.0