### PR TITLE
NamingConventions/PrefixAllGlobals: implement PHPCSUtils and support modern PHP 

### DIFF
--- a/WordPress/Docs/NamingConventions/PrefixAllGlobalsStandard.xml
+++ b/WordPress/Docs/NamingConventions/PrefixAllGlobalsStandard.xml
@@ -5,7 +5,7 @@
     >
     <standard>
     <![CDATA[
-    All globals terms must be prefixed with a theme/plugin specific term. Global terms include Namespace names, Class/Interface/Trait names (when not namespaced), Functions (when not namespaced or in an OO structure), Constants/Variable names declared in the global namespace, and Hook names.
+    All globals terms must be prefixed with a theme/plugin specific term. Global terms include Namespace names, Class/Interface/Trait/Enum names (when not namespaced), Functions (when not namespaced or in an OO structure), Constants/Variable names declared in the global namespace, and Hook names.
 
     A prefix must be distinct and unique to the plugin/theme, in order to prevent potential conflicts with other plugins/themes and with WordPress itself.
 

--- a/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
+++ b/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
@@ -473,7 +473,7 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 					break;
 
 				case \T_CONST:
-					// Constants in a class do not need to be prefixed.
+					// Constants in an OO construct do not need to be prefixed.
 					if ( true === Scopes::isOOConstant( $this->phpcsFile, $stackPtr ) ) {
 						return;
 					}

--- a/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
+++ b/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
@@ -424,6 +424,7 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 				case \T_CLASS:
 				case \T_INTERFACE:
 				case \T_TRAIT:
+				case \T_ENUM:
 					$item_name  = ObjectDeclarations::getName( $this->phpcsFile, $stackPtr );
 					$error_text = 'Classes declared';
 					$error_code = 'NonPrefixedClassFound';
@@ -455,6 +456,17 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 
 							$error_text = 'Traits declared';
 							$error_code = 'NonPrefixedTraitFound';
+							break;
+
+						case \T_ENUM:
+							// phpcs:ignore PHPCompatibility.FunctionUse.NewFunctions.enum_existsFound
+							if ( function_exists( '\enum_exists' ) && enum_exists( '\\' . $item_name, false ) ) {
+								// Backfill for PHP native enum.
+								return;
+							}
+
+							$error_text = 'Enums declared';
+							$error_code = 'NonPrefixedEnumFound';
 							break;
 					}
 

--- a/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
+++ b/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
@@ -385,8 +385,8 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 			$error_text = 'Unknown syntax used';
 			$error_code = 'NonPrefixedSyntaxFound';
 
-			switch ( $this->tokens[ $stackPtr ]['type'] ) {
-				case 'T_FUNCTION':
+			switch ( $this->tokens[ $stackPtr ]['code'] ) {
+				case \T_FUNCTION:
 					// Methods in a class do not need to be prefixed.
 					if ( $this->phpcsFile->hasCondition( $stackPtr, Tokens::$ooScopeTokens ) === true ) {
 						return;
@@ -411,22 +411,22 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 					$error_code = 'NonPrefixedFunctionFound';
 					break;
 
-				case 'T_CLASS':
-				case 'T_INTERFACE':
-				case 'T_TRAIT':
+				case \T_CLASS:
+				case \T_INTERFACE:
+				case \T_TRAIT:
 					$item_name  = $this->phpcsFile->getDeclarationName( $stackPtr );
 					$error_text = 'Classes declared';
 					$error_code = 'NonPrefixedClassFound';
 
-					switch ( $this->tokens[ $stackPtr ]['type'] ) {
-						case 'T_CLASS':
+					switch ( $this->tokens[ $stackPtr ]['code'] ) {
+						case \T_CLASS:
 							if ( class_exists( '\\' . $item_name, false ) ) {
 								// Backfill for PHP native class.
 								return;
 							}
 							break;
 
-						case 'T_INTERFACE':
+						case \T_INTERFACE:
 							if ( interface_exists( '\\' . $item_name, false ) ) {
 								// Backfill for PHP native interface.
 								return;
@@ -436,7 +436,7 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 							$error_code = 'NonPrefixedInterfaceFound';
 							break;
 
-						case 'T_TRAIT':
+						case \T_TRAIT:
 							// phpcs:ignore PHPCompatibility.FunctionUse.NewFunctions.trait_existsFound
 							if ( function_exists( '\trait_exists' ) && trait_exists( '\\' . $item_name, false ) ) {
 								// Backfill for PHP native trait.
@@ -454,7 +454,7 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 
 					break;
 
-				case 'T_CONST':
+				case \T_CONST:
 					// Constants in a class do not need to be prefixed.
 					if ( true === Scopes::isOOConstant( $this->phpcsFile, $stackPtr ) ) {
 						return;

--- a/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
+++ b/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
@@ -968,8 +968,13 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 				continue;
 			}
 
-			// Validate the prefix against characters allowed for function, class, constant names etc.
-			if ( preg_match( '`^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff\\\\]*$`', $prefix ) !== 1 ) {
+			/*
+			 * Validate the prefix against characters allowed for function, class, constant names etc.
+			 * Note: this does not use the PHPCSUtils `NamingConventions::isValidIdentifierName()` method
+			 * as we want to allow namespace separators in the prefixes.
+			 */
+			if ( preg_match( '`^[a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff\\\\]*$`', $prefix ) !== 1 ) {
+
 				$this->phpcsFile->addWarning(
 					'The "%s" prefix is not a valid namespace/function/class/variable/constant prefix in PHP.',
 					0,

--- a/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
+++ b/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
@@ -808,18 +808,18 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 			return;
 		}
 
-		$is_error    = true;
-		$raw_content = TextStrings::stripQuotes( $target_param['raw'] );
+		$is_error      = true;
+		$clean_content = TextStrings::stripQuotes( $target_param['clean'] );
 
 		if ( ( 'define' !== $matched_content
-			&& isset( $this->allowed_core_hooks[ $raw_content ] ) )
+			&& isset( $this->allowed_core_hooks[ $clean_content ] ) )
 			|| ( 'define' === $matched_content
-			&& isset( $this->allowed_core_constants[ $raw_content ] ) )
+			&& isset( $this->allowed_core_constants[ $clean_content ] ) )
 		) {
 			return;
 		}
 
-		if ( $this->is_prefixed( $target_param['start'], $raw_content ) === true ) {
+		if ( $this->is_prefixed( $target_param['start'], $clean_content ) === true ) {
 			return;
 		} else {
 			// This may be a dynamic hook/constant name.
@@ -863,12 +863,12 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 		}
 
 		if ( 'define' === $matched_content ) {
-			if ( \defined( '\\' . $raw_content ) ) {
+			if ( \defined( '\\' . $clean_content ) ) {
 				// Backfill for PHP native constant.
 				return;
 			}
 
-			if ( strpos( $raw_content, '\\' ) !== false ) {
+			if ( strpos( $clean_content, '\\' ) !== false ) {
 				// Namespaced or unreachable constant.
 				return;
 			}
@@ -886,12 +886,12 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 			}
 		}
 
-		$data[] = $raw_content;
+		$data[] = $clean_content;
 
 		$recorded = MessageHelper::addMessage( $this->phpcsFile, self::ERROR_MSG, $first_non_empty, $is_error, $error_code, $data );
 
 		if ( true === $recorded ) {
-			$this->record_potential_prefix_metric( $stackPtr, $raw_content );
+			$this->record_potential_prefix_metric( $stackPtr, $clean_content );
 		}
 	}
 

--- a/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
+++ b/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
@@ -718,8 +718,10 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 			$functionPtr = Conditions::getLastCondition( $this->phpcsFile, $stackPtr, Collections::functionDeclarationTokens() );
 			if ( false !== $functionPtr ) {
 				$has_global = $this->phpcsFile->findPrevious( \T_GLOBAL, ( $stackPtr - 1 ), $this->tokens[ $functionPtr ]['scope_opener'] );
-				if ( false === $has_global ) {
-					// No variable import happening.
+				if ( false === $has_global
+					|| Conditions::getLastCondition( $this->phpcsFile, $has_global, Collections::functionDeclarationTokens() ) !== $functionPtr
+				) {
+					// No variable import happening in the current scope.
 					return;
 				}
 

--- a/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
+++ b/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
@@ -724,7 +724,7 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 				}
 
 				// Ok, this may be an imported global variable.
-				$end_of_statement = $this->phpcsFile->findNext( \T_SEMICOLON, ( $has_global + 1 ) );
+				$end_of_statement = $this->phpcsFile->findNext( array( \T_SEMICOLON, \T_CLOSE_TAG ), ( $has_global + 1 ) );
 				if ( false === $end_of_statement ) {
 					// No semi-colon - live coding.
 					return;

--- a/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
+++ b/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
@@ -446,10 +446,6 @@ class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 							$error_text = 'Traits declared';
 							$error_code = 'NonPrefixedTraitFound';
 							break;
-
-						default:
-							// Left empty on purpose.
-							break;
 					}
 
 					break;

--- a/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.1.inc
+++ b/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.1.inc
@@ -584,4 +584,10 @@ apply_filters_ref_array( args: $var, hook_name: 'acronym_filter', ); // OK.
 apply_filters_ref_array( args: $var, hook_name: 'theme_filter', ); // Bad.
 apply_filters_ref_array( hook_name: 'theme_filter_' . $acronym_filter_var ); // Bad.
 
+// Safeguard that comments in the parameters are ignored.
+apply_filters( /* test */ 'widget_title', $title );
+do_action( /* test */ 'add_meta_boxes' );
+
+define( /* test */ 'FORCE_SSL_ADMIN', true );
+
 // phpcs:set WordPress.NamingConventions.PrefixAllGlobals prefixes[]

--- a/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.1.inc
+++ b/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.1.inc
@@ -552,4 +552,9 @@ $acronym_fn = fn($a, $b) =>
 		return $a + $b;
 	};
 
+// Safeguard that assignments using the PHP 7.4+ null coalesce equals operator are handled correctly.
+function acronym_null_coalesce_equals() {
+	$GLOBALS['my_key'] ??= 10; // Bad.
+}
+
 // phpcs:set WordPress.NamingConventions.PrefixAllGlobals prefixes[]

--- a/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.1.inc
+++ b/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.1.inc
@@ -557,4 +557,7 @@ function acronym_null_coalesce_equals() {
 	$GLOBALS['my_key'] ??= 10; // Bad.
 }
 
+// Safeguard that property assignments using the PHP 8.0 nullsafe object operator do not trigger false positives.
+$acronym_object??->property = 10;
+
 // phpcs:set WordPress.NamingConventions.PrefixAllGlobals prefixes[]

--- a/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.1.inc
+++ b/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.1.inc
@@ -634,4 +634,14 @@ function acronym_close_tag_can_end_global_statement() {
 	$breakOutOfTheStatement = 'value'; // OK.
 }
 
+// Safeguard improved checking if global statement is in the current scope.
+function acronym_only_check_global_statement_in_current_scope() {
+	$closure = function() {
+		global $something;
+		return $something;
+	};
+
+	$something = 'value'; // OK, global statement is in different scope.
+}
+
 // phpcs:set WordPress.NamingConventions.PrefixAllGlobals prefixes[]

--- a/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.1.inc
+++ b/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.1.inc
@@ -599,4 +599,23 @@ class Acronym_ConstructorPropertyPromotion {
 	) {} // Ok.
 }
 
+/*
+ * Safeguard that PHP 8.1+ enums are treated correctly.
+ */
+enum Example {} // Bad.
+enum Another_Example: int {} // Bad.
+
+enum Acronym: string implements SomeInterface {} // OK.
+enum AcronymExample { // OK.
+	// Constants and methods declared within an enum do not need to be prefixed. (Properties are not allowed)
+	const SOME_CONSTANT = 'value'; // OK.
+	public function do_something( $param = 'default' ) {} // OK x2.
+
+	// Global constants and hook names still do need to be prefixed when defined within an enum.
+	protected function hello() {
+		define( 'FOO', 'value' ); // Bad.
+		apply_filters( 'foo', $args ); // Bad.
+	}
+}
+
 // phpcs:set WordPress.NamingConventions.PrefixAllGlobals prefixes[]

--- a/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.1.inc
+++ b/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.1.inc
@@ -590,4 +590,13 @@ do_action( /* test */ 'add_meta_boxes' );
 
 define( /* test */ 'FORCE_SSL_ADMIN', true );
 
+// Safeguard that assignments to properties using PHP 8.0+ constructor property promotion don't lead to false positives.
+class Acronym_ConstructorPropertyPromotion {
+	public function __construct(
+		public int $timestart = 0,
+		protected int|bool $timeend = false,
+		$post = null
+	) {} // Ok.
+}
+
 // phpcs:set WordPress.NamingConventions.PrefixAllGlobals prefixes[]

--- a/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.1.inc
+++ b/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.1.inc
@@ -519,4 +519,17 @@ function 😊_do_something(){}
 // phpcs:set WordPress.NamingConventions.PrefixAllGlobals prefixes[] 😊😊
 function 😊😊_do_something(){}
 
+// Reset to the standard test prefixes.
+// phpcs:set WordPress.NamingConventions.PrefixAllGlobals prefixes[] acronym,tgmpa
+
+if ( ! interface_exists( 'Serializable' ) ) {
+	interface Serializable {} // Introduced in PHP 5.1.0.
+}
+
+// Not wrapped in a `defined()` as the `const` keyword can only be used in the top-level scope.
+// Just presume the file containing this code is included conditionally ;-)
+const E_DEPRECATED = 8192; // Introduced in PHP 5.3.0.
+
+apply_filters( /* name missing */, $var ); // Ignore as undetermined.
+
 // phpcs:set WordPress.NamingConventions.PrefixAllGlobals prefixes[]

--- a/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.1.inc
+++ b/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.1.inc
@@ -532,4 +532,24 @@ const E_DEPRECATED = 8192; // Introduced in PHP 5.3.0.
 
 apply_filters( /* name missing */, $var ); // Ignore as undetermined.
 
+/*
+ * Safeguard correct handling (ignoring) of PHP 7.4+ arrow functions.
+ */
+// Parameters in a arrow function declaration do not need to be prefixed.
+$acronym_fn = fn($foo = 10, $bar = 20) => $foo;
+
+// Variable variables local to the arrow function do not need to be prefixed.
+$acronym_fn = fn($acronym_name, $acronym_value) => $$acronym_name = $acronym_value;
+
+// Function local variables in a arrow function declaration do not need to be prefixed.
+$acronym_fn = fn($acronym_name, $acronym_value) => $new = $acronym_value;
+
+// The `$GLOBAL['my_key']` assignment and the function declaration within the closure should still be flagged.
+$acronym_fn = fn($a, $b) =>
+	$no_prefix = function($a, $b) { // The `$no_prefix` variable should be ignored.
+		$GLOBALS['my_key'] = 10; // Bad.
+		function named() {} // Bad.
+		return $a + $b;
+	};
+
 // phpcs:set WordPress.NamingConventions.PrefixAllGlobals prefixes[]

--- a/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.1.inc
+++ b/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.1.inc
@@ -618,4 +618,9 @@ enum AcronymExample { // OK.
 	}
 }
 
+// Safeguard that the sniff ignores PHP 8.2+ constants in traits correctly.
+trait Acronym_Has_Constant {
+	final const NON_PREFIXED = true; // OK.
+}
+
 // phpcs:set WordPress.NamingConventions.PrefixAllGlobals prefixes[]

--- a/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.1.inc
+++ b/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.1.inc
@@ -623,4 +623,15 @@ trait Acronym_Has_Constant {
 	final const NON_PREFIXED = true; // OK.
 }
 
+// Safeguard improved finding of end of global statement.
+function acronym_close_tag_can_end_global_statement() {
+	global $something, $acronym_else ?>
+
+	<?php
+	echo $breakOutOfTheStatement;
+	$acronym_else = 'value'; // OK.
+	$something = 'value'; // Bad.
+	$breakOutOfTheStatement = 'value'; // OK.
+}
+
 // phpcs:set WordPress.NamingConventions.PrefixAllGlobals prefixes[]

--- a/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.1.inc
+++ b/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.1.inc
@@ -557,7 +557,31 @@ function acronym_null_coalesce_equals() {
 	$GLOBALS['my_key'] ??= 10; // Bad.
 }
 
-// Safeguard that property assignments using the PHP 8.0 nullsafe object operator do not trigger false positives.
+// Safeguard that property assignments using the PHP 8.0+ nullsafe object operator do not trigger false positives.
 $acronym_object??->property = 10;
+
+/*
+ * Safeguard support for function calls using PHP 8.0+ named parameters.
+ */
+define( value: 0 ); // OK. Well, not really as missing a required param, but that's not the concern of this sniff.
+define(
+	value        : 'not_prefixed',
+	constant_name: 'NOT_PREFIXED', // Bad.
+);
+define(
+	case_insensitive: true,
+	constant_name: 'ACRONYM_PREFIXED', // OK.
+	value: 0,
+);
+
+do_action_ref_array( hook: 'My-Hook', args: $args ); // OK. Well, not really, but using the wrong parameter name, so not our concern.
+do_action_ref_array( args: $args, hook_name: 'acronym_hook', ); // OK.
+do_action_ref_array( args: $args, hook_name: 'My-Hook', ); // Bad.
+do_action( hook_name: "acronym_plugin_action_{$acronym_filter_var}" ); // OK.
+
+apply_filters_ref_array( args: $args ); // OK. Well, not really, but missing required parameter, so not our concern.
+apply_filters_ref_array( args: $var, hook_name: 'acronym_filter', ); // OK.
+apply_filters_ref_array( args: $var, hook_name: 'theme_filter', ); // Bad.
+apply_filters_ref_array( hook_name: 'theme_filter_' . $acronym_filter_var ); // Bad.
 
 // phpcs:set WordPress.NamingConventions.PrefixAllGlobals prefixes[]

--- a/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.2.inc
+++ b/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.2.inc
@@ -17,4 +17,6 @@ trait T_Example {}
 // Issue #1056.
 define( __NAMESPACE__ . '\PLUGIN_FILE', __FILE__ );
 
+enum E_Example {}
+
 // phpcs:set WordPress.NamingConventions.PrefixAllGlobals prefixes[]

--- a/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.5.inc
+++ b/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.5.inc
@@ -1,0 +1,9 @@
+<?php
+// phpcs:set WordPress.NamingConventions.PrefixAllGlobals prefixes[]
+
+/*
+ * This test just safeguards that the sniff bows out when there are no prefixes.
+ * This test file should generate no errors or warnings.
+ */
+
+class ABC {}

--- a/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.6.inc
+++ b/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.6.inc
@@ -1,0 +1,11 @@
+<?php
+// phpcs:set WordPress.NamingConventions.PrefixAllGlobals prefixes[] acronym,tgmpa
+
+/*
+ * This test safeguards the sniff bows out correctly during live coding/when certain parse errors are encountered.
+ * This test file should generate no errors or warnings.
+ */
+
+const
+
+// phpcs:set WordPress.NamingConventions.PrefixAllGlobals prefixes[]

--- a/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.7.inc
+++ b/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.7.inc
@@ -1,0 +1,12 @@
+<?php
+
+// phpcs:set WordPress.NamingConventions.PrefixAllGlobals prefixes[] acronym,tgmpa
+
+/*
+ * This test safeguards an edge case and makes sure the sniff bows out correctly during live coding with variable variables.
+ * This test file should generate no errors or warnings.
+ */
+
+echo ${$testing_non_assignment_variable_variable}['deref']
+
+// phpcs:set WordPress.NamingConventions.PrefixAllGlobals prefixes[]

--- a/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.8.inc
+++ b/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.8.inc
@@ -1,0 +1,17 @@
+<?php
+
+// phpcs:set WordPress.NamingConventions.PrefixAllGlobals prefixes[] acronym,tgmpa
+
+/*
+ * This test safeguards a few edge cases and makes sure the sniff bows out correctly when it finds:
+ * - $GLOBALS without a key. Note: overwritting the $GLOBALS variable is no longer allowed since PHP 8.1.
+ * - $GLOBALS without a key due to live coding.
+ *
+ * This test file should generate no errors or warnings.
+ */
+
+$GLOBALS = 'overwritten';
+
+$GLOBALS
+
+// phpcs:set WordPress.NamingConventions.PrefixAllGlobals prefixes[]

--- a/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.9.inc
+++ b/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.9.inc
@@ -1,0 +1,18 @@
+<?php
+
+// phpcs:set WordPress.NamingConventions.PrefixAllGlobals prefixes[] acronym,tgmpa
+
+/*
+ * This test safeguards yet another edge case to make sure the sniff bows out correctly
+ * for unfinished global statements within functions (live coding/parse error).
+ *
+ * This test file should generate no errors or warnings.
+ */
+
+function acronym_unfinished_global_statement($param) {
+	global $var1, $var2 // Deliberately missing semi-colon.
+	
+	foreach ($param as $var2) {}
+}
+
+// phpcs:set WordPress.NamingConventions.PrefixAllGlobals prefixes[]

--- a/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.php
+++ b/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.php
@@ -93,6 +93,7 @@ class PrefixAllGlobalsUnitTest extends AbstractSniffUnitTest {
 					606 => 1,
 					616 => 1,
 					617 => 1,
+					633 => 1,
 				);
 
 			case 'PrefixAllGlobalsUnitTest.4.inc':

--- a/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.php
+++ b/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.php
@@ -85,6 +85,10 @@ class PrefixAllGlobalsUnitTest extends AbstractSniffUnitTest {
 					550 => 1,
 					551 => 1,
 					557 => 1,
+					569 => 1,
+					579 => 1,
+					584 => 1,
+					585 => 1,
 				);
 
 			case 'PrefixAllGlobalsUnitTest.4.inc':

--- a/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.php
+++ b/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.php
@@ -82,6 +82,8 @@ class PrefixAllGlobalsUnitTest extends AbstractSniffUnitTest {
 					464 => 2,
 					465 => 1,
 					468 => 1,
+					550 => 1,
+					551 => 1,
 				);
 
 			case 'PrefixAllGlobalsUnitTest.4.inc':

--- a/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.php
+++ b/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.php
@@ -84,6 +84,7 @@ class PrefixAllGlobalsUnitTest extends AbstractSniffUnitTest {
 					468 => 1,
 					550 => 1,
 					551 => 1,
+					557 => 1,
 				);
 
 			case 'PrefixAllGlobalsUnitTest.4.inc':

--- a/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.php
+++ b/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.php
@@ -89,6 +89,10 @@ class PrefixAllGlobalsUnitTest extends AbstractSniffUnitTest {
 					579 => 1,
 					584 => 1,
 					585 => 1,
+					605 => 1,
+					606 => 1,
+					616 => 1,
+					617 => 1,
 				);
 
 			case 'PrefixAllGlobalsUnitTest.4.inc':


### PR DESCRIPTION
### NamingConventions/PrefixAllGlobals: minor code tweak

Using `type` instead of `code` is not currently needed as all relevant tokens will exist in PHPCS 3.7.1.
Using `code` has a minor advantage as it will allow for IDE auto-completion.

### NamingConventions/PrefixAllGlobals: remove some redundant code

... which could never be reached anyway.

### NamingConventions/PrefixAllGlobals: add extra tests

... to cover some previously uncovered code.

None of these should lead to errors/warnings.

### NamingConventions/PrefixAllGlobals: implement PHPCSUtils

No functional changes.

### NamingConventions/PrefixAllGlobals: minor bug fix

The regex as-was allowed for the `x7f` (= DEL) character to be part of a name.

The origin of this bug was the PHP manual, where the regexes were originally incorrect. This was fixed in php/doc-en@6187696

No unit tests included as, to be honest, I haven't got a clue how to add a test with the DEL character ;-)

Includes adding a note about why this condition is not using PHPCSUtils.

### NamingConventions/PrefixAllGlobals: (mostly) ignore PHP 7.4+ arrow functions

PHP 7.4 introduced arrow functions.

For the purposes of this sniff:
* Parameters declared by arrow functions (with a default value assignment) do not need to be prefixed.
* New variables declared within an arrow function are local to the arrow function, so can be ignored.
* A `global` statement is not allowed within an arrow function.

And as an arrow function can only contain one statement, the chances of anything else within the arrow function needing to be flagged are slim, except when an arrow function declares a closure.
Note: nesting a named function declaration in an arrow function is not allowed (parse error).

PHPCS adds the `parenthesis_*` keys correctly and adds the arrow function parentheses to the `nested_parenthesis` array, so the function parameters can be handled same like parameters for closures/named functions.

However, while PHPCS does add the `scope_*` keys to the `T_FN` function, it does **not** add the `T_FN` to the `conditions` array for tokens between the `scope_opener` and the `scope_closer`.
The reason for this, is that the `scope_closer` of arrow functions can overlap with other `scope_closer`s, like in nested arrow function, which would make the `conditions` array unusable.

With the above in mind, I'm proposing to skip over the contents of arrow functions and ignore everything in them completely, with the one exception, that if an arrow function declares a closure, the closure will still be examined.

While this could potentially lead to some false negatives, I do believe this is the best we can do for now.

Includes unit tests.

### NamingConventions/PrefixAllGlobals: add test with PHP 7.4 null coalesce equals

... to safeguard assignments using that operator are recognized correctly.

### NamingConventions/PrefixAllGlobals: add test with PHP 8.0 nullsafe object operator

... to safeguard assignments to properties are not flagged when using that operator.

### NamingConventions/PrefixAllGlobals: add support for PHP 8.0+ named parameters

1. Adjusted the logic in the sniff to allow for named parameters using the new PHPCSUtils 1.0.0-alpha4 `PassedParameters::getParameterFromStack()` method and the new `WPHookHelper::get_hook_name_param()` method.
2. The parameter name used for `define()` is in line with the name as per the PHP 8.0 release.
    PHP itself renamed a lot of parameters in PHP 8.0. As named parameters did not exist before PHP 8.0, the parameter name as per PHP 8.0 (or above) is the only relevant name.

Includes additional unit tests.

Note: function calls with named arguments are not supported for the `do_action()` or `apply_filters()` functions as those have a parameter with a spread operator (but that's irrelevant for the sniff).

### NamingConventions/PrefixAllGlobals: prevent some false positives

The `'raw'` key in the parameter arrays returned from the `PassedParameters` class contains - as per the name - the _raw_ contents of the parameter.

Since PHPCSUtils 1.0.0-alpha4, the return array also contain a `'clean'` index, which contains the contents of the parameter cleaned of comments.

By switching to using that key, some false positives get fixed.

Includes unit tests demonstrating the issue and safeguarding the fix.

Includes renaming the variable name to which the value was being assigned to allow it to continue to be descriptive.

The switch to using the `clean` key also makes sure that the information displayed in the error message will not contain comments, making those message cleaner too.

### NamingConventions/PrefixAllGlobals: add test with PHP 8.0+ constructor property promotion

PHP 8.0 introduced constructor property promotion.

As default value assignments in function declaration statements are excluded already, no functional changes need to be made to support this.

Just adding a test to safeguard that this is handled correctly.

### NamingConventions/PrefixAllGlobals: add support for PHP 8.1+ enums

PHP 8.1 introduced enums as a new OO structure.

Unless in a (prefixed) namespace, enum names should also be prefixed.

The `Tokens::$ooScopeTokens` array used in the `register()` method already contains the `T_ENUM` token, so the sniff is already listening for it.

This commit now adjusts the sniff to actually handle enums as well.

Includes additional unit tests.

Note: enums cannot `extend`, so cannot ever be regarded as "test classes" for the purposes of this sniff.

### NamingConventions/PrefixAllGlobals: add tests with PHP 8.2+ constants in traits

... to ensure those aren't recognized as if they were the global constant.

Constants in traits are allowed since PHP 8.2.
The `final` keyword can be used with OO constants since PHP 8.1.

### NamingConventions/PrefixAllGlobals: bug fix - finding end of global statement

Prevent false positives when a global statement is ended by a PHP close tag.

Includes unit tests.

### NamingConventions/PrefixAllGlobals: bug fix - only check global statement in current scope

Prevent false positives when a nested function/closure declaration also contains a `global` statement.

Includes unit test.