### PR TITLE
DB/DirectDatabaseQuery: implement PHPCSUtils and support modern PHP 

### DIFF
--- a/WordPress/Sniffs/DB/DirectDatabaseQuerySniff.php
+++ b/WordPress/Sniffs/DB/DirectDatabaseQuerySniff.php
@@ -192,11 +192,11 @@ class DirectDatabaseQuerySniff extends Sniff {
 			return;
 		}
 
-		$endOfStatement = $this->phpcsFile->findNext( \T_SEMICOLON, ( $stackPtr + 1 ), null, false, null, true );
+		$endOfStatement = $this->phpcsFile->findNext( array( \T_SEMICOLON, \T_CLOSE_TAG ), ( $stackPtr + 1 ) );
 
 		// Check for Database Schema Changes.
 		for ( $_pos = ( $stackPtr + 1 ); $_pos < $endOfStatement; $_pos++ ) {
-			$_pos = $this->phpcsFile->findNext( Tokens::$textStringTokens, $_pos, $endOfStatement, false, null, true );
+			$_pos = $this->phpcsFile->findNext( Tokens::$textStringTokens, $_pos, $endOfStatement );
 			if ( false === $_pos ) {
 				break;
 			}

--- a/WordPress/Sniffs/DB/DirectDatabaseQuerySniff.php
+++ b/WordPress/Sniffs/DB/DirectDatabaseQuerySniff.php
@@ -183,7 +183,7 @@ class DirectDatabaseQuerySniff extends Sniff {
 			return;
 		}
 
-		$methodPtr = $this->phpcsFile->findNext( array( \T_WHITESPACE ), ( $is_object_call + 1 ), null, true, null, true );
+		$methodPtr = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $is_object_call + 1 ), null, true );
 		$method    = $this->tokens[ $methodPtr ]['content'];
 
 		$this->mergeFunctionLists();

--- a/WordPress/Sniffs/DB/DirectDatabaseQuerySniff.php
+++ b/WordPress/Sniffs/DB/DirectDatabaseQuerySniff.php
@@ -186,18 +186,7 @@ class DirectDatabaseQuerySniff extends Sniff {
 			return;
 		}
 
-		$endOfStatement   = $this->phpcsFile->findNext( \T_SEMICOLON, ( $stackPtr + 1 ), null, false, null, true );
-		$endOfLineComment = '';
-		for ( $i = ( $endOfStatement + 1 ); $i < $this->phpcsFile->numTokens; $i++ ) {
-
-			if ( $this->tokens[ $i ]['line'] !== $this->tokens[ $endOfStatement ]['line'] ) {
-				break;
-			}
-
-			if ( \T_COMMENT === $this->tokens[ $i ]['code'] ) {
-				$endOfLineComment .= $this->tokens[ $i ]['content'];
-			}
-		}
+		$endOfStatement = $this->phpcsFile->findNext( \T_SEMICOLON, ( $stackPtr + 1 ), null, false, null, true );
 
 		// Check for Database Schema Changes.
 		for ( $_pos = ( $stackPtr + 1 ); $_pos < $endOfStatement; $_pos++ ) {

--- a/WordPress/Sniffs/DB/DirectDatabaseQuerySniff.php
+++ b/WordPress/Sniffs/DB/DirectDatabaseQuerySniff.php
@@ -174,9 +174,13 @@ class DirectDatabaseQuerySniff extends Sniff {
 			return;
 		}
 
-		$is_object_call = $this->phpcsFile->findNext( \T_OBJECT_OPERATOR, ( $stackPtr + 1 ), null, false, null, true );
-		if ( false === $is_object_call ) {
-			return; // This is not a call to the wpdb object.
+		$is_object_call = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true );
+		if ( false === $is_object_call
+			|| ( \T_OBJECT_OPERATOR !== $this->tokens[ $is_object_call ]['code']
+				&& \T_NULLSAFE_OBJECT_OPERATOR !== $this->tokens[ $is_object_call ]['code'] )
+		) {
+			// This is not a call to the wpdb object.
+			return;
 		}
 
 		$methodPtr = $this->phpcsFile->findNext( array( \T_WHITESPACE ), ( $is_object_call + 1 ), null, true, null, true );

--- a/WordPress/Tests/DB/DirectDatabaseQueryUnitTest.inc
+++ b/WordPress/Tests/DB/DirectDatabaseQueryUnitTest.inc
@@ -294,3 +294,10 @@ function stabilize_token_walking($other_db) {
 	// This test is making sure that the `$other_db->query` code is not flagged as if it were a call to a `$wpdb` method.
 	$wpdb = $other_db->query;
 }
+
+function ignore_comments() {
+	global $wpdb;
+	$wpdb-> // Let's pretend this is a method-chain (this is the comment which should not confuse the sniff).
+		insert( 'table', array( 'column' => 'foo', 'field' => 'bar' ) ); // Warning direct DB call.
+}
+

--- a/WordPress/Tests/DB/DirectDatabaseQueryUnitTest.inc
+++ b/WordPress/Tests/DB/DirectDatabaseQueryUnitTest.inc
@@ -280,3 +280,17 @@ function non_cachable() {
 	global $wpdb;
 	$wpdb->insert( 'table', array( 'column' => 'foo', 'field' => 'bar' ) ); // Warning direct DB call.
 }
+
+// Safeguard recognition of PHP 8.0+ nullsafe object operator.
+function nullsafe_object_operator() {
+	global $wpdb;
+	$listofthings = $wpdb?->get_col( 'SELECT something FROM somewhere WHERE someotherthing = 1' ); // Warning x 2.
+	$last = $wpdb?->insert( $wpdb->users, $data, $where ); // Warning x 1.
+}
+
+function stabilize_token_walking($other_db) {
+	global $wpdb;
+	// Overwritting $wpdb is bad, of course, but that's not the concern of this sniff.
+	// This test is making sure that the `$other_db->query` code is not flagged as if it were a call to a `$wpdb` method.
+	$wpdb = $other_db->query;
+}

--- a/WordPress/Tests/DB/DirectDatabaseQueryUnitTest.inc
+++ b/WordPress/Tests/DB/DirectDatabaseQueryUnitTest.inc
@@ -274,3 +274,9 @@ EOD
 		wp_cache_add( 'baz', $baz );
 	}
 }
+
+// Non-cachable call should bow out after `DirectQuery` warning.
+function non_cachable() {
+	global $wpdb;
+	$wpdb->insert( 'table', array( 'column' => 'foo', 'field' => 'bar' ) ); // Warning direct DB call.
+}

--- a/WordPress/Tests/DB/DirectDatabaseQueryUnitTest.inc
+++ b/WordPress/Tests/DB/DirectDatabaseQueryUnitTest.inc
@@ -301,3 +301,9 @@ function ignore_comments() {
 		insert( 'table', array( 'column' => 'foo', 'field' => 'bar' ) ); // Warning direct DB call.
 }
 
+function correctly_determine_end_of_statement() {
+	global $wpdb;
+	$wpdb->get_col( $query, $col ) ?><-- Warning x 2 -->
+	<?php
+	$next_query = 'ALTER TABLE TO ADD SOME FIELDS' ); // Should not be flagged as not in a call to $wpdb.
+}

--- a/WordPress/Tests/DB/DirectDatabaseQueryUnitTest.inc
+++ b/WordPress/Tests/DB/DirectDatabaseQueryUnitTest.inc
@@ -307,3 +307,13 @@ function correctly_determine_end_of_statement() {
 	<?php
 	$next_query = 'ALTER TABLE TO ADD SOME FIELDS' ); // Should not be flagged as not in a call to $wpdb.
 }
+
+function stay_silent_for_truncate_query() {
+	global $wpdb;
+	$wpdb->query(
+		$wpdb->prepare(
+			'TRUNCATE TABLE `%1$s`',
+			plugin_get_table_name( 'Name' )
+		)
+	);
+}

--- a/WordPress/Tests/DB/DirectDatabaseQueryUnitTest.php
+++ b/WordPress/Tests/DB/DirectDatabaseQueryUnitTest.php
@@ -87,6 +87,7 @@ class DirectDatabaseQueryUnitTest extends AbstractSniffUnitTest {
 			281 => 1,
 			287 => 2,
 			288 => 1,
+			300 => 1,
 		);
 	}
 }

--- a/WordPress/Tests/DB/DirectDatabaseQueryUnitTest.php
+++ b/WordPress/Tests/DB/DirectDatabaseQueryUnitTest.php
@@ -85,6 +85,8 @@ class DirectDatabaseQueryUnitTest extends AbstractSniffUnitTest {
 			265 => 1,
 			269 => 1,
 			281 => 1,
+			287 => 2,
+			288 => 1,
 		);
 	}
 }

--- a/WordPress/Tests/DB/DirectDatabaseQueryUnitTest.php
+++ b/WordPress/Tests/DB/DirectDatabaseQueryUnitTest.php
@@ -84,7 +84,7 @@ class DirectDatabaseQueryUnitTest extends AbstractSniffUnitTest {
 			252 => 1,
 			265 => 1,
 			269 => 1,
+			281 => 1,
 		);
 	}
-
 }

--- a/WordPress/Tests/DB/DirectDatabaseQueryUnitTest.php
+++ b/WordPress/Tests/DB/DirectDatabaseQueryUnitTest.php
@@ -88,6 +88,7 @@ class DirectDatabaseQueryUnitTest extends AbstractSniffUnitTest {
 			287 => 2,
 			288 => 1,
 			300 => 1,
+			306 => 2,
 		);
 	}
 }


### PR DESCRIPTION
### DB/DirectDatabaseQuery: remove redundant code

This code is a remnant of the old-style custom ignore comment mechanism which was removed in #2063.

### DB/DirectDatabaseQuery: add missing test case

... to cover the one uncovered line.

### DB/DirectDatabaseQuery: implement PHPCSUtils

👉 This change will be easier to review while ignoring whitespace changes.

### DB/DirectDatabaseQuery: add support for PHP 8.0+ nullsafe object operator

Prevent false negatives in case someone would use the PHP 8.0 nullsafe object operator on the `$wpdb` variable.

Also makes the token walking more stable by preventing an unrelated object operator from being recognized as if it were an operator operating on the `$wpdb` object (false positive).

Includes tests.

### DB/DirectDatabaseQuery: bug fix - code style independent token walking

Don't allow the sniff to get confused by comments.

Related to #763

Includes tests.

### DB/DirectDatabaseQuery: bug fix - finding end of statement

Prevent false positives from walking too far when a database query statement is ended by a PHP close tag.

Includes unit tests.

### DB/DirectDatabaseQuery: bug fix - ignore TRUNCATE queries

Prevent unsolvable false positives for `TRUNCATE` queries. Those cannot be cached and need a direct DB query. **(second opinion appreciated!)**

Includes unit tests.

Fixes #1947