### PR TITLE
Move "snake case" related utility to dedicated SnakeCaseHelper + bug fix in method

### DIFF
--- a/WordPress/Helpers/SnakeCaseHelper.php
+++ b/WordPress/Helpers/SnakeCaseHelper.php
@@ -39,10 +39,8 @@ final class SnakeCaseHelper {
 	 * @return string
 	 */
 	public static function get_suggestion( $name ) {
-		$suggested = preg_replace( '`([A-Z])`', '_$1', $name );
+		$suggested = preg_replace( '`(?<!_|^)([A-Z])`', '_$1', $name );
 		$suggested = strtolower( $suggested );
-		$suggested = str_replace( '__', '_', $suggested );
-		$suggested = trim( $suggested, '_' );
 		return $suggested;
 	}
 }

--- a/WordPress/Helpers/SnakeCaseHelper.php
+++ b/WordPress/Helpers/SnakeCaseHelper.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPressCS\WordPress\Helpers;
+
+/**
+ * Helper utilities for checking if a name is in snake_case.
+ *
+ * ---------------------------------------------------------------------------------------------
+ * This class is only intended for internal use by WordPressCS and is not part of the public API.
+ * This also means that it has no promise of backward compatibility. Use at your own risk.
+ * ---------------------------------------------------------------------------------------------
+ *
+ * {@internal The functionality in this class will likely be replaced at some point in
+ * the future by functions from PHPCSUtils.}
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @since   3.0.0 The method in this class was previously contained in the
+ *                `WordPressCS\WordPress\Sniff` class and has been moved here.
+ */
+final class SnakeCaseHelper {
+
+	/**
+	 * Transform the name of a PHP construct (function, variable etc) to one in snake_case.
+	 *
+	 * @since 2.0.0 Moved from the `WordPress.NamingConventions.ValidFunctionName` sniff
+	 *              to this class, renamed from `get_name_suggestion` and made static
+	 *              so it can also be used by classes which don't extend this class.
+	 * @since 3.0.0 Moved from the Sniff class to this class.
+	 *
+	 * @param string $name The construct name.
+	 *
+	 * @return string
+	 */
+	public static function get_suggestion( $name ) {
+		$suggested = preg_replace( '`([A-Z])`', '_$1', $name );
+		$suggested = strtolower( $suggested );
+		$suggested = str_replace( '__', '_', $suggested );
+		$suggested = trim( $suggested, '_' );
+		return $suggested;
+	}
+}

--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -460,25 +460,6 @@ abstract class Sniff implements PHPCS_Sniff {
 	}
 
 	/**
-	 * Transform the name of a PHP construct (function, variable etc) to one in snake_case.
-	 *
-	 * @since 2.0.0 Moved from the `WordPress.NamingConventions.ValidFunctionName` sniff
-	 *              to this class, renamed from `get_name_suggestion` and made static
-	 *              so it can also be used by classes which don't extend this class.
-	 *
-	 * @param string $name The construct name.
-	 *
-	 * @return string
-	 */
-	public static function get_snake_case_name_suggestion( $name ) {
-		$suggested = preg_replace( '`([A-Z])`', '_$1', $name );
-		$suggested = strtolower( $suggested );
-		$suggested = str_replace( '__', '_', $suggested );
-		$suggested = trim( $suggested, '_' );
-		return $suggested;
-	}
-
-	/**
 	 * Get the last pointer in a line.
 	 *
 	 * @since 0.4.0

--- a/WordPress/Sniffs/NamingConventions/ValidFunctionNameSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidFunctionNameSniff.php
@@ -14,6 +14,7 @@ use PHPCSUtils\Utils\FunctionDeclarations;
 use PHPCSUtils\Utils\ObjectDeclarations;
 use PHPCSUtils\Utils\Scopes;
 use WordPressCS\WordPress\Helpers\DeprecationHelper;
+use WordPressCS\WordPress\Helpers\SnakeCaseHelper;
 use WordPressCS\WordPress\Sniff;
 
 /**
@@ -115,7 +116,7 @@ class ValidFunctionNameSniff extends Sniff {
 			$error     = 'Function name "%s" is not in snake case format, try "%s"';
 			$errorData = array(
 				$functionName,
-				$this->get_snake_case_name_suggestion( $functionName ),
+				SnakeCaseHelper::get_suggestion( $functionName ),
 			);
 			$this->phpcsFile->addError( $error, $stackPtr, 'FunctionNameInvalid', $errorData );
 		}
@@ -182,7 +183,7 @@ class ValidFunctionNameSniff extends Sniff {
 			$errorData = array(
 				$methodName,
 				$className,
-				$this->get_snake_case_name_suggestion( $methodName ),
+				SnakeCaseHelper::get_suggestion( $methodName ),
 			);
 			$this->phpcsFile->addError( $error, $stackPtr, 'MethodNameInvalid', $errorData );
 		}

--- a/WordPress/Sniffs/NamingConventions/ValidVariableNameSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidVariableNameSniff.php
@@ -13,7 +13,7 @@ use PHP_CodeSniffer\Sniffs\AbstractVariableSniff as PHPCS_AbstractVariableSniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 use WordPressCS\WordPress\Helpers\RulesetPropertyHelper;
-use WordPressCS\WordPress\Sniff;
+use WordPressCS\WordPress\Helpers\SnakeCaseHelper;
 
 /**
  * Checks the naming of variables and member variables.
@@ -146,7 +146,7 @@ class ValidVariableNameSniff extends PHPCS_AbstractVariableSniff {
 						$error = 'Object property "$%s" is not in valid snake_case format, try "$%s"';
 						$data  = array(
 							$original_var_name,
-							Sniff::get_snake_case_name_suggestion( $original_var_name ),
+							SnakeCaseHelper::get_suggestion( $original_var_name ),
 						);
 						$phpcs_file->addError( $error, $var, 'UsedPropertyNotSnakeCase', $data );
 					}
@@ -182,7 +182,7 @@ class ValidVariableNameSniff extends PHPCS_AbstractVariableSniff {
 			if ( isset( $error, $error_name ) ) {
 				$data = array(
 					$original_var_name,
-					Sniff::get_snake_case_name_suggestion( $original_var_name ),
+					SnakeCaseHelper::get_suggestion( $original_var_name ),
 				);
 				$phpcs_file->addError( $error, $stack_ptr, $error_name, $data );
 			}
@@ -219,7 +219,7 @@ class ValidVariableNameSniff extends PHPCS_AbstractVariableSniff {
 			$error = 'Member variable "$%s" is not in valid snake_case format, try "$%s"';
 			$data  = array(
 				$var_name,
-				Sniff::get_snake_case_name_suggestion( $var_name ),
+				SnakeCaseHelper::get_suggestion( $var_name ),
 			);
 			$phpcs_file->addError( $error, $stack_ptr, 'PropertyNotSnakeCase', $data );
 		}
@@ -258,7 +258,7 @@ class ValidVariableNameSniff extends PHPCS_AbstractVariableSniff {
 					$error = 'Variable "$%s" is not in valid snake_case format, try "$%s"';
 					$data  = array(
 						$var_name,
-						Sniff::get_snake_case_name_suggestion( $var_name ),
+						SnakeCaseHelper::get_suggestion( $var_name ),
 					);
 					$phpcs_file->addError( $error, $stack_ptr, 'InterpolatedVariableNotSnakeCase', $data );
 				}

--- a/WordPress/Tests/NamingConventions/ValidFunctionNameUnitTest.inc
+++ b/WordPress/Tests/NamingConventions/ValidFunctionNameUnitTest.inc
@@ -177,3 +177,10 @@ class DeprecatedWithAttribute {
 	#[AnotherAttribute]
 	public static function __deprecatedMethod() {}
 }
+
+// Safeguard that the suggested replacement name does not suggest undue changes to underscores in the name.
+class UnderScoreHandling {
+	public function ___Leading_Underscores() {} // Bad, replacement suggestion should be: ___leading_underscores.
+	public function Multiple_______Underscores() {} // Bad, replacement suggestion should be: multiple_______underscores.
+	public function Trailing_Underscores___() {}// Bad, replacement suggestion should be: trailing_underscores___.
+}

--- a/WordPress/Tests/NamingConventions/ValidFunctionNameUnitTest.php
+++ b/WordPress/Tests/NamingConventions/ValidFunctionNameUnitTest.php
@@ -47,6 +47,9 @@ class ValidFunctionNameUnitTest extends AbstractSniffUnitTest {
 			116 => 1,
 			117 => 1,
 			157 => 2,
+			183 => 1,
+			184 => 1,
+			185 => 1,
 		);
 	}
 


### PR DESCRIPTION
### Move "snake case" related utility to dedicated SnakeCaseHelper

The "snake case" related utility method is only used by a small set of sniffs, so is better placed in a dedicated class.

This commit moves the `get_snake_case_name_suggestion()` method to the new `WordPressCS\WordPress\Helpers\SnakeCaseHelper` and starts using that class in the relevant sniffs.

**Note**:
It is expected for PHPCSUtils to have dedicated methods for the same at some point in the future. If/when those methods become available, it is recommended for the sniffs to start using the PHPCSUtils methods.
With that in mind, this class is marked as not part of the public API.

Related to #1465

### SnakeCaseHelper::get_suggestion(): bug fix - underscore handling

The `SnakeCaseHelper::get_suggestion()` method should have no opinion on the use of leading/trailing/double underscores in a name.

In practice, however, it did and the suggested name would be incorrect.

Fixed now.

Includes tests to safeguard this fix in the `ValidFunctionName` test case file, though the current methodology for testing would not catch a regression.

To illustrate the issue - originally, the error messages for these new tests would read:
```
216 | ERROR | Method name "___Leading_Underscores" in class UnderScoreHandling is not in snake case format, try "leading_underscores"
 217 | ERROR | Method name "Multiple_______Underscores" in class UnderScoreHandling is not in snake case format, try "multiple____underscores"
 218 | ERROR | Method name "Trailing_Underscores___" in class UnderScoreHandling is not in snake case format, try "trailing_underscores"
```

With the fix, the error messages for the new tests read:
```
 216 | ERROR | Method name "___Leading_Underscores" in class UnderScoreHandling is not in snake case format, try "___leading_underscores"
 217 | ERROR | Method name "Multiple_______Underscores" in class UnderScoreHandling is not in snake case format, try "multiple_______underscores"
 218 | ERROR | Method name "Trailing_Underscores___" in class UnderScoreHandling is not in snake case format, try "trailing_underscores___"
```