### PR TITLE
NamingConventions/ValidFunctionName: implement PHPCSUtils and support modern PHP

### DIFF
--- a/WordPress/Sniffs/NamingConventions/ValidFunctionNameSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidFunctionNameSniff.php
@@ -128,7 +128,7 @@ class ValidFunctionNameSniff extends Sniff {
 	 *
 	 * @since 0.1.0
 	 * @since 3.0.0 Renamed from `processTokenWithinScope()` to `process_method_declaration()`.
-	 *              Method signature has been changed as well as this method no longer overloads
+	 *              Method signature has been changed as well, as this method no longer overloads
 	 *              a method from the PEAR sniff which was previously the sniff parent.
 	 *
 	 * @param int    $stackPtr   The position where this token was found.

--- a/WordPress/Sniffs/NamingConventions/ValidFunctionNameSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidFunctionNameSniff.php
@@ -11,6 +11,7 @@ namespace WordPressCS\WordPress\Sniffs\NamingConventions;
 
 use PHPCSUtils\BackCompat\BCTokens;
 use PHPCSUtils\Utils\FunctionDeclarations;
+use PHPCSUtils\Utils\NamingConventions;
 use PHPCSUtils\Utils\ObjectDeclarations;
 use PHPCSUtils\Utils\Scopes;
 use WordPressCS\WordPress\Helpers\DeprecationHelper;
@@ -142,19 +143,16 @@ class ValidFunctionNameSniff extends Sniff {
 			$className = '[Anonymous Class]';
 		} else {
 			$className = ObjectDeclarations::getName( $this->phpcsFile, $currScope );
-		}
 
-		$methodNameLc = strtolower( $methodName );
-		$classNameLc  = strtolower( $className );
+			// PHP4 constructors are allowed to break our rules.
+			if ( NamingConventions::isEqual( $methodName, $className ) === true ) {
+				return;
+			}
 
-		// PHP4 constructors are allowed to break our rules.
-		if ( $methodNameLc === $classNameLc ) {
-			return;
-		}
-
-		// PHP4 destructors are allowed to break our rules.
-		if ( '_' . $classNameLc === $methodNameLc ) {
-			return;
+			// PHP4 destructors are allowed to break our rules.
+			if ( NamingConventions::isEqual( $methodName, '_' . $className ) === true ) {
+				return;
+			}
 		}
 
 		// PHP magic methods are exempt from our rules.
@@ -178,7 +176,7 @@ class ValidFunctionNameSniff extends Sniff {
 		}
 
 		// Check for all lowercase.
-		if ( $methodNameLc !== $methodName ) {
+		if ( strtolower( $methodName ) !== $methodName ) {
 			$error     = 'Method name "%s" in class %s is not in snake case format, try "%s"';
 			$errorData = array(
 				$methodName,
@@ -188,5 +186,4 @@ class ValidFunctionNameSniff extends Sniff {
 			$this->phpcsFile->addError( $error, $stackPtr, 'MethodNameInvalid', $errorData );
 		}
 	}
-
 }

--- a/WordPress/Tests/NamingConventions/ValidFunctionNameUnitTest.inc
+++ b/WordPress/Tests/NamingConventions/ValidFunctionNameUnitTest.inc
@@ -184,3 +184,14 @@ class UnderScoreHandling {
 	public function Multiple_______Underscores() {} // Bad, replacement suggestion should be: multiple_______underscores.
 	public function Trailing_Underscores___() {}// Bad, replacement suggestion should be: trailing_underscores___.
 }
+
+// Safeguard that functions with a name only consisting of underscores are always ignored.
+function __() {}
+
+class OnlyUnderscores {
+	public function _____() {}
+}
+
+// Live coding/parse error.
+// This has to be the last test in the file.
+function

--- a/WordPress/Tests/NamingConventions/ValidFunctionNameUnitTest.inc
+++ b/WordPress/Tests/NamingConventions/ValidFunctionNameUnitTest.inc
@@ -192,6 +192,13 @@ class OnlyUnderscores {
 	public function _____() {}
 }
 
+// Class vs function name PHP case-sensitivity quirks.
+class FooBÃÈ {
+	function FooBÃÈ() {} // OK, same case.
+	function fOOBÃÈ() {} // OK, same case for the non-ascii chars.
+	function FooBãè() {} // Bad - not PHP 4-type constructor, non ascii chars not in same case - POC: https://3v4l.org/YOc2R.
+}
+
 // Live coding/parse error.
 // This has to be the last test in the file.
 function

--- a/WordPress/Tests/NamingConventions/ValidFunctionNameUnitTest.inc
+++ b/WordPress/Tests/NamingConventions/ValidFunctionNameUnitTest.inc
@@ -199,6 +199,25 @@ class FooBÃÈ {
 	function FooBãè() {} // Bad - not PHP 4-type constructor, non ascii chars not in same case - POC: https://3v4l.org/YOc2R.
 }
 
+// Safeguard that methods in enums are correctly handled by the sniff.
+enum Suit {
+	case Hearts;
+	case Diamonds;
+
+	public function color(): string {} // OK.
+	public function __changeColor(): string {} // Bad
+
+	public function &getShape(): string // Bad.
+	{
+		return "Rectangle";
+	}
+
+	// These are the only three magic methods allowed in enums.
+	public function __call( $a, $b ) {} // Ok.
+	public static function __callStatic( $a, $b ) {} // Ok.
+	public function __invoke() {} // Ok.
+}
+
 // Live coding/parse error.
 // This has to be the last test in the file.
 function

--- a/WordPress/Tests/NamingConventions/ValidFunctionNameUnitTest.php
+++ b/WordPress/Tests/NamingConventions/ValidFunctionNameUnitTest.php
@@ -51,6 +51,8 @@ class ValidFunctionNameUnitTest extends AbstractSniffUnitTest {
 			184 => 1,
 			185 => 1,
 			199 => 1,
+			208 => 2,
+			210 => 1,
 		);
 	}
 

--- a/WordPress/Tests/NamingConventions/ValidFunctionNameUnitTest.php
+++ b/WordPress/Tests/NamingConventions/ValidFunctionNameUnitTest.php
@@ -50,6 +50,7 @@ class ValidFunctionNameUnitTest extends AbstractSniffUnitTest {
 			183 => 1,
 			184 => 1,
 			185 => 1,
+			199 => 1,
 		);
 	}
 
@@ -61,5 +62,4 @@ class ValidFunctionNameUnitTest extends AbstractSniffUnitTest {
 	public function getWarningList() {
 		return array();
 	}
-
 }


### PR DESCRIPTION
### NamingConventions/ValidFunctionName: add extra tests

The handling of function names only consisting of underscore was already special cased in the sniff, but not covered by tests.

Similarly, live coding was not covered.

### NamingConventions/ValidFunctionName: implement PHPCSUtils methods

PHP is largely case-insensitive for class and method name, but not completely: the case-insensitivety does not apply to the non-ascii range.

The PHPCSUtils methods recognize this correctly.

Includes minor efficiency tweak by only doing the PHP4 constructor/destructor comparison when it's a real class as a name match can never be made for anonymous classes anyway.

Includes unit tests.

Note: the test would previously pass, but only due to the `strtolower()` mangling both the class name as well as the method name equally.

### NamingConventions/ValidFunctionName: add tests covering PHP 8.1+ enums

The various PHPCSUtils `Scopes` functions support enums since PHPCSUtils 1.0.0-alpha4, so enums are automatically supported now, but let's safeguard this with a test anyway.

### NamingConventions/ValidFunctionName: minor comment fix 