### PR TITLE
NamingConventions/ValidVariableName: implement PHPCSUtils and support modern PHP

### DIFF
--- a/WordPress/Sniffs/NamingConventions/ValidVariableNameSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidVariableNameSniff.php
@@ -27,7 +27,7 @@ use WordPressCS\WordPress\Helpers\SnakeCaseHelper;
  * @since   2.0.0  - Defers to the upstream `$phpReservedVars` property.
  *                 - Now offers name suggestions for variables in violation.
  *
- * Last synced with base class June 2018 at commit 78ddbae97cac078f09928bf89e3ab9e53ad2ace0.
+ * Last synced with base class January 2022 at commit 4b49a952bf0e2c3863d0a113256bae0d7fe63d52.
  * @link    https://github.com/squizlabs/PHP_CodeSniffer/blob/master/src/Standards/Squiz/Sniffs/NamingConventions/ValidVariableNameSniff.php
  *
  * @uses PHP_CodeSniffer\Sniffs\AbstractVariableSniff::$phpReservedVars

--- a/WordPress/Sniffs/NamingConventions/ValidVariableNameSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidVariableNameSniff.php
@@ -13,6 +13,7 @@ use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\AbstractVariableSniff as PHPCS_AbstractVariableSniff;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\Utils\Scopes;
+use PHPCSUtils\Utils\Variables;
 use WordPressCS\WordPress\Helpers\RulesetPropertyHelper;
 use WordPressCS\WordPress\Helpers\SnakeCaseHelper;
 
@@ -25,13 +26,10 @@ use WordPressCS\WordPress\Helpers\SnakeCaseHelper;
  *
  * @since   0.9.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
- * @since   2.0.0  - Defers to the upstream `$phpReservedVars` property.
- *                 - Now offers name suggestions for variables in violation.
+ * @since   2.0.0  Now offers name suggestions for variables in violation.
  *
  * Last synced with base class January 2022 at commit 4b49a952bf0e2c3863d0a113256bae0d7fe63d52.
  * @link    https://github.com/squizlabs/PHP_CodeSniffer/blob/master/src/Standards/Squiz/Sniffs/NamingConventions/ValidVariableNameSniff.php
- *
- * @uses PHP_CodeSniffer\Sniffs\AbstractVariableSniff::$phpReservedVars
  */
 class ValidVariableNameSniff extends PHPCS_AbstractVariableSniff {
 
@@ -109,17 +107,17 @@ class ValidVariableNameSniff extends PHPCS_AbstractVariableSniff {
 	 * @return void
 	 */
 	protected function processVariable( File $phpcs_file, $stack_ptr ) {
-
-		$tokens   = $phpcs_file->getTokens();
-		$var_name = ltrim( $tokens[ $stack_ptr ]['content'], '$' );
+		$tokens = $phpcs_file->getTokens();
 
 		// If it's a php reserved var, then its ok.
-		if ( isset( $this->phpReservedVars[ $var_name ] ) ) {
+		if ( Variables::isPHPReservedVarName( $tokens[ $stack_ptr ]['content'] ) ) {
 			return;
 		}
 
 		// Merge any custom variables with the defaults.
 		$this->merge_allow_lists();
+
+		$var_name = ltrim( $tokens[ $stack_ptr ]['content'], '$' );
 
 		// Likewise if it is a mixed-case var used by WordPress core.
 		if ( isset( $this->wordpress_mixed_case_vars[ $var_name ] ) ) {
@@ -241,7 +239,7 @@ class ValidVariableNameSniff extends PHPCS_AbstractVariableSniff {
 
 			foreach ( $matches[1] as $var_name ) {
 				// If it's a php reserved var, then its ok.
-				if ( isset( $this->phpReservedVars[ $var_name ] ) ) {
+				if ( Variables::isPHPReservedVarName( $var_name ) ) {
 					continue;
 				}
 

--- a/WordPress/Sniffs/NamingConventions/ValidVariableNameSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidVariableNameSniff.php
@@ -12,6 +12,7 @@ namespace WordPressCS\WordPress\Sniffs\NamingConventions;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\AbstractVariableSniff as PHPCS_AbstractVariableSniff;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\Scopes;
 use PHPCSUtils\Utils\TextStrings;
 use PHPCSUtils\Utils\Variables;
@@ -126,7 +127,9 @@ class ValidVariableNameSniff extends PHPCS_AbstractVariableSniff {
 		}
 
 		$obj_operator = $phpcs_file->findNext( Tokens::$emptyTokens, ( $stack_ptr + 1 ), null, true );
-		if ( \T_OBJECT_OPERATOR === $tokens[ $obj_operator ]['code'] ) {
+		if ( \T_OBJECT_OPERATOR === $tokens[ $obj_operator ]['code']
+			|| \T_NULLSAFE_OBJECT_OPERATOR === $tokens[ $obj_operator ]['code']
+		) {
 			// Check to see if we are using a variable from an object.
 			$var = $phpcs_file->findNext( Tokens::$emptyTokens, ( $obj_operator + 1 ), null, true );
 			if ( \T_STRING === $tokens[ $var ]['code'] ) {
@@ -156,7 +159,7 @@ class ValidVariableNameSniff extends PHPCS_AbstractVariableSniff {
 
 		$in_class     = false;
 		$obj_operator = $phpcs_file->findPrevious( Tokens::$emptyTokens, ( $stack_ptr - 1 ), null, true );
-		if ( \T_DOUBLE_COLON === $tokens[ $obj_operator ]['code'] || \T_OBJECT_OPERATOR === $tokens[ $obj_operator ]['code'] ) {
+		if ( isset( Collections::objectOperators()[ $tokens[ $obj_operator ]['code'] ] ) ) {
 			// The variable lives within a class, and is referenced like
 			// this: MyClass::$_variable or $class->variable.
 			$in_class = true;
@@ -300,5 +303,4 @@ class ValidVariableNameSniff extends PHPCS_AbstractVariableSniff {
 			$this->addedCustomProperties['properties'] = $this->allowed_custom_properties;
 		}
 	}
-
 }

--- a/WordPress/Sniffs/NamingConventions/ValidVariableNameSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidVariableNameSniff.php
@@ -251,7 +251,7 @@ class ValidVariableNameSniff extends PHPCS_AbstractVariableSniff {
 
 				// Likewise if it is a mixed-case var used by WordPress core.
 				if ( isset( $this->wordpress_mixed_case_vars[ $var_name ] ) ) {
-					return;
+					continue;
 				}
 
 				if ( false === self::isSnakeCase( $var_name ) ) {

--- a/WordPress/Tests/NamingConventions/ValidVariableNameUnitTest.inc
+++ b/WordPress/Tests/NamingConventions/ValidVariableNameUnitTest.inc
@@ -95,7 +95,7 @@ echo $comment->comment_author_IP;
 class Foo {
 	public $_public_leading_underscore;
 	private $private_no_underscore_loading;
-	
+
 	function Bar( $VARname ) { // Bad.
 		$localVariable = false; // Bad.
 		echo Some_Class::$VarName; // Bad.
@@ -176,7 +176,7 @@ class MultiVarDeclarations {
 		$multiVar5 = false, // Bad.
 		$multiVar6 = 123, // Bad.
 		$multi_var7 = 'string'; // Ok.
-		
+
 	public function testMultiGlobalAndStatic() {
 		global $multiGlobal1, $multi_global2, // Bad x 1.
 			$multiGlobal3; // Bad.
@@ -188,3 +188,8 @@ class MultiVarDeclarations {
 }
 
 echo "This is $post_ID with $ThisShouldBeFlagged"; // Bad.
+
+// Safeguard that illegal property declarations are ignored.
+interface PropertiesNotAllowed {
+	public $notAllowed;
+}

--- a/WordPress/Tests/NamingConventions/ValidVariableNameUnitTest.inc
+++ b/WordPress/Tests/NamingConventions/ValidVariableNameUnitTest.inc
@@ -186,3 +186,5 @@ class MultiVarDeclarations {
 			$multiStatic3 = ''; // Bad.
 	}
 }
+
+echo "This is $post_ID with $ThisShouldBeFlagged"; // Bad.

--- a/WordPress/Tests/NamingConventions/ValidVariableNameUnitTest.inc
+++ b/WordPress/Tests/NamingConventions/ValidVariableNameUnitTest.inc
@@ -127,7 +127,7 @@ echo "This is a $comment_ID"; // Bad
 echo "This is $PHP_SELF with $HTTP_RAW_POST_DATA"; // Ok.
 
 /*
- * Ignoring unit tests.
+ * Testing custom properties.
  */
 // phpcs:set WordPress.NamingConventions.ValidVariableName allowed_custom_properties[] varName,DOMProperty
 echo MyClass::$varName; // Ok, allowed.

--- a/WordPress/Tests/NamingConventions/ValidVariableNameUnitTest.inc
+++ b/WordPress/Tests/NamingConventions/ValidVariableNameUnitTest.inc
@@ -211,3 +211,9 @@ $arrow = fn ( $without_default, $with_default = 'default' ) => 10; // OK.
 function has_params( $withoutDefault, $withDefault = 'default' ) {} // Bad x 2.
 $closure = function ( $withoutDefault, $withDefault = 'default' ) {}; // Bad x 2.
 $arrow = fn ( $withoutDefault, $withDefault = 'default' ) => 10; // Bad x 2.
+
+// Safeguard recognizing property access using PHP 8.0 nullsafe operator.
+echo $this?->varName2; // Bad.
+echo $this?->var_name2;
+echo $this?->varname2;
+echo $this?->_varName2; // Bad.

--- a/WordPress/Tests/NamingConventions/ValidVariableNameUnitTest.inc
+++ b/WordPress/Tests/NamingConventions/ValidVariableNameUnitTest.inc
@@ -202,3 +202,12 @@ echo "This is {${getName()}}"; // OK, expression, should be ignored.
 echo "This is $Foo?->bar"; // Bad, expression, but the $Foo in it should still be flagged.
 echo "This is {$foo['bar']?->baz()()}"; // OK.
 echo "This is {$Foo['bar']?->baz()()}"; // Bad, expression, but the $Foo in it should still be flagged.
+
+// Safeguard that parameters in all types of function declarations, including PHP 7.4+ arrow functions, are flagged.
+function has_params( $without_default, $with_default = 'default' ) {} // OK.
+$closure = function ( $without_default, $with_default = 'default' ) {}; // OK.
+$arrow = fn ( $without_default, $with_default = 'default' ) => 10; // OK.
+
+function has_params( $withoutDefault, $withDefault = 'default' ) {} // Bad x 2.
+$closure = function ( $withoutDefault, $withDefault = 'default' ) {}; // Bad x 2.
+$arrow = fn ( $withoutDefault, $withDefault = 'default' ) => 10; // Bad x 2.

--- a/WordPress/Tests/NamingConventions/ValidVariableNameUnitTest.inc
+++ b/WordPress/Tests/NamingConventions/ValidVariableNameUnitTest.inc
@@ -11,19 +11,19 @@ class MyClass {
 	var $_varName = 'hello'; // Bad.
 
 	public $varNamf  = 'hello'; // Bad.
-	public $var_namf = 'hello';
+	public bool $var_namf = 'hello';
 	public $varnamf  = 'hello';
 	public $_varNamf = 'hello'; // Bad.
 
 	protected $varNamg  = 'hello'; // Bad.
 	protected $var_namg = 'hello';
 	protected $varnamg  = 'hello';
-	protected $_varNamg = 'hello'; // Bad.
+	protected string $_varNamg = 'hello'; // Bad.
 
 	private $_varNamh  = 'hello'; // Bad.
 	private $_var_namh = 'hello';
 	private $_varnamh  = 'hello';
-	private $varNamh   = 'hello'; // Bad.
+	private int|string $varNamh   = 'hello'; // Bad.
 }
 
 echo $varName; // Bad.

--- a/WordPress/Tests/NamingConventions/ValidVariableNameUnitTest.inc
+++ b/WordPress/Tests/NamingConventions/ValidVariableNameUnitTest.inc
@@ -193,3 +193,12 @@ echo "This is $post_ID with $ThisShouldBeFlagged"; // Bad.
 interface PropertiesNotAllowed {
 	public $notAllowed;
 }
+
+echo "This is \$someName"; // OK, variable is literal text.
+
+echo "This is ${$someName}"; // Bad.
+echo "This is ${Foo}"; // Bad.
+echo "This is {${getName()}}"; // OK, expression, should be ignored.
+echo "This is $Foo?->bar"; // Bad, expression, but the $Foo in it should still be flagged.
+echo "This is {$foo['bar']?->baz()()}"; // OK.
+echo "This is {$Foo['bar']?->baz()()}"; // Bad, expression, but the $Foo in it should still be flagged.

--- a/WordPress/Tests/NamingConventions/ValidVariableNameUnitTest.inc
+++ b/WordPress/Tests/NamingConventions/ValidVariableNameUnitTest.inc
@@ -217,3 +217,13 @@ echo $this?->varName2; // Bad.
 echo $this?->var_name2;
 echo $this?->varname2;
 echo $this?->_varName2; // Bad.
+
+// Safeguard handling of PHP 8.1 enums.
+enum EnumExample {
+	public $notAllowed; // OK, well, not really, but properties are not allowed in enums, so ignore.
+
+	public function method( $paramName ) { // Bad.
+		$local_variable = 'OK';
+		$localVariable  = 'Bad';
+	}
+}

--- a/WordPress/Tests/NamingConventions/ValidVariableNameUnitTest.inc
+++ b/WordPress/Tests/NamingConventions/ValidVariableNameUnitTest.inc
@@ -227,3 +227,8 @@ enum EnumExample {
 		$localVariable  = 'Bad';
 	}
 }
+
+// Safeguard ignoring of allowed mixed case property names.
+class Has_Mixed_Case_Property {
+	public $post_ID; // OK.
+}

--- a/WordPress/Tests/NamingConventions/ValidVariableNameUnitTest.php
+++ b/WordPress/Tests/NamingConventions/ValidVariableNameUnitTest.php
@@ -87,6 +87,9 @@ class ValidVariableNameUnitTest extends AbstractSniffUnitTest {
 			200 => 1,
 			202 => 1,
 			204 => 1,
+			211 => 2,
+			212 => 2,
+			213 => 2,
 		);
 	}
 

--- a/WordPress/Tests/NamingConventions/ValidVariableNameUnitTest.php
+++ b/WordPress/Tests/NamingConventions/ValidVariableNameUnitTest.php
@@ -92,6 +92,8 @@ class ValidVariableNameUnitTest extends AbstractSniffUnitTest {
 			213 => 2,
 			216 => 1,
 			219 => 1,
+			225 => 1,
+			227 => 1,
 		);
 	}
 

--- a/WordPress/Tests/NamingConventions/ValidVariableNameUnitTest.php
+++ b/WordPress/Tests/NamingConventions/ValidVariableNameUnitTest.php
@@ -83,6 +83,10 @@ class ValidVariableNameUnitTest extends AbstractSniffUnitTest {
 			184 => 1,
 			186 => 1,
 			190 => 1,
+			199 => 1,
+			200 => 1,
+			202 => 1,
+			204 => 1,
 		);
 	}
 

--- a/WordPress/Tests/NamingConventions/ValidVariableNameUnitTest.php
+++ b/WordPress/Tests/NamingConventions/ValidVariableNameUnitTest.php
@@ -82,6 +82,7 @@ class ValidVariableNameUnitTest extends AbstractSniffUnitTest {
 			182 => 1,
 			184 => 1,
 			186 => 1,
+			190 => 1,
 		);
 	}
 

--- a/WordPress/Tests/NamingConventions/ValidVariableNameUnitTest.php
+++ b/WordPress/Tests/NamingConventions/ValidVariableNameUnitTest.php
@@ -90,6 +90,8 @@ class ValidVariableNameUnitTest extends AbstractSniffUnitTest {
 			211 => 2,
 			212 => 2,
 			213 => 2,
+			216 => 1,
+			219 => 1,
 		);
 	}
 


### PR DESCRIPTION
### NamingConventions/ValidVariableName: sync with upstream

Synced in relevant changes as made upstream in the following commit:
* squizlabs/PHP_CodeSniffer@beeb36f - Making sure the sniff works correctly with PHP 7.4+ typed properties.

### NamingConventions/ValidVariableName: bug fix

When a text string with interpolated variables contained a variable on the `$wordpress_mixed_case_vars` list, any variables found in the text string _after_ it would not be examined or flagged.

Fixed now.

Includes test proving the bug and safeguarding the fix.

### NamingConventions/ValidVariableName: implement PHPCSUtils [1]

Includes minor efficiency tweak.

Includes adding a test for the OO property verification, which was so far untested.

### NamingConventions/ValidVariableName: implement PHPCSUtils [2]

Includes minor efficiency tweaks.

### NamingConventions/ValidVariableName: implement PHPCSUtils [3]

Improve and stabilize the retrieval of embedded variables by:
1. Using the `TextStrings::getEmbed()` method to retrieve all embedded expressions.
2. Subsequently still using the regex to match variables within embedded expressions, but with an improved regex.
    - Fixed the `\x7f-\xff` range to `\x80-\xff` (was originally wrong in the PHP manual).
    - Only match a variable in braces - `${foo}` - when the braces are balanced.
        Note: this syntax is deprecated as per PHP 8.2, but that's not the concern of this sniff.
    - Capture the variable name in a named match.

Includes tests.

### NamingConventions/ValidVariableName: add tests with PHP 7.4+ arrow functions

... to safeguard those are handled correctly.

### NamingConventions/ValidVariableName: allow for the PHP 8.0+ nullsafe object operator

Check for both the `T_OBJECT_OPERATOR` as well as the `T_NULLSAFE_OBJECT_OPERATOR`.

Includes unit tests.

### NamingConventions/ValidVariableName: add tests with PHP 8.1+ enums

... to safeguard variables found in those are handled correctly.

### NamingConventions/ValidVariableName: add extra test

... which tests code previously untested.

### NamingConventions/ValidVariableName: minor documentation improvement 