### PR TITLE
Utils/I18nTextDomainFixer: implement PHPCSUtils and support modern PHP 

### DIFF
--- a/WordPress/Sniffs/Utils/I18nTextDomainFixerSniff.php
+++ b/WordPress/Sniffs/Utils/I18nTextDomainFixerSniff.php
@@ -10,6 +10,7 @@
 namespace WordPressCS\WordPress\Sniffs\Utils;
 
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\BackCompat\Helper;
 use PHPCSUtils\Utils\TextStrings;
 use WordPressCS\WordPress\AbstractFunctionParameterSniff;
 use WordPressCS\WordPress\Helpers\RulesetPropertyHelper;
@@ -334,14 +335,7 @@ class I18nTextDomainFixerSniff extends AbstractFunctionParameterSniff {
 		}
 
 		if ( isset( $this->tab_width ) === false ) {
-			if ( isset( $this->phpcsFile->config->tabWidth ) === false
-				|| 0 === $this->phpcsFile->config->tabWidth
-			) {
-				// We have no idea how wide tabs are, so assume 4 spaces for fixing.
-				$this->tab_width = 4;
-			} else {
-				$this->tab_width = $this->phpcsFile->config->tabWidth;
-			}
+			$this->tab_width = Helper::getTabWidth( $this->phpcsFile );
 		}
 
 		if ( \T_DOC_COMMENT_OPEN_TAG === $this->tokens[ $stackPtr ]['code']

--- a/WordPress/Sniffs/Utils/I18nTextDomainFixerSniff.php
+++ b/WordPress/Sniffs/Utils/I18nTextDomainFixerSniff.php
@@ -157,23 +157,26 @@ class I18nTextDomainFixerSniff extends AbstractFunctionParameterSniff {
 	 *            required (true) or optional (false) header.
 	 */
 	private $theme_headers = array(
-		'Theme Name'  => true,
-		'Theme URI'   => false,
-		'Author'      => true,
-		'Author URI'  => false,
-		'Description' => true,
-		'Version'     => true,
-		'License'     => true,
-		'License URI' => true,
-		'Tags'        => false,
-		'Text Domain' => true,
-		'Domain Path' => false,
+		'Theme Name'        => true,
+		'Theme URI'         => false,
+		'Author'            => true,
+		'Author URI'        => false,
+		'Description'       => true,
+		'Version'           => true,
+		'Requires at least' => true,
+		'Tested up to'      => true,
+		'Requires PHP'      => true,
+		'License'           => true,
+		'License URI'       => true,
+		'Text Domain'       => true,
+		'Tags'              => false,
+		'Domain Path'       => false,
 	);
 
 	/**
 	 * Possible headers for a plugin.
 	 *
-	 * @link https://developer.wordpress.org/plugins/the-basics/header-requirements/
+	 * @link https://developer.wordpress.org/plugins/plugin-basics/header-requirements/
 	 *
 	 * @since 1.2.0
 	 *
@@ -181,17 +184,20 @@ class I18nTextDomainFixerSniff extends AbstractFunctionParameterSniff {
 	 *            required (true) or optional (false) header.
 	 */
 	private $plugin_headers = array(
-		'Plugin Name' => true,
-		'Plugin URI'  => false,
-		'Description' => false,
-		'Version'     => false,
-		'Author'      => false,
-		'Author URI'  => false,
-		'License'     => false,
-		'License URI' => false,
-		'Text Domain' => false,
-		'Domain Path' => false,
-		'Network'     => false,
+		'Plugin Name'       => true,
+		'Plugin URI'        => false,
+		'Description'       => false,
+		'Version'           => false,
+		'Requires at least' => false,
+		'Requires PHP'      => false,
+		'Author'            => false,
+		'Author URI'        => false,
+		'License'           => false,
+		'License URI'       => false,
+		'Text Domain'       => false,
+		'Domain Path'       => false,
+		'Network'           => false,
+		'Update URI'        => false,
 	);
 
 	/**

--- a/WordPress/Sniffs/Utils/I18nTextDomainFixerSniff.php
+++ b/WordPress/Sniffs/Utils/I18nTextDomainFixerSniff.php
@@ -81,6 +81,7 @@ class I18nTextDomainFixerSniff extends AbstractFunctionParameterSniff {
 		'load_muplugin_textdomain'               => 1,
 		'load_theme_textdomain'                  => 1,
 		'load_child_theme_textdomain'            => 1,
+		'load_script_textdomain'                 => 2,
 		'unload_textdomain'                      => 1,
 
 		'__'                                     => 2,

--- a/WordPress/Sniffs/Utils/I18nTextDomainFixerSniff.php
+++ b/WordPress/Sniffs/Utils/I18nTextDomainFixerSniff.php
@@ -11,6 +11,7 @@ namespace WordPressCS\WordPress\Sniffs\Utils;
 
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\BackCompat\Helper;
+use PHPCSUtils\Utils\PassedParameters;
 use PHPCSUtils\Utils\TextStrings;
 use WordPressCS\WordPress\AbstractFunctionParameterSniff;
 use WordPressCS\WordPress\Helpers\RulesetPropertyHelper;
@@ -73,51 +74,159 @@ class I18nTextDomainFixerSniff extends AbstractFunctionParameterSniff {
 	 * The WP Internationalization related functions to target for the replacements.
 	 *
 	 * @since 1.2.0
+	 * @since 3.0.0 The format of the value has changed from a numerically indexed
+	 *              array containing parameter positions to an array with the parameter
+	 *              position as the index and the parameter name as value.
 	 *
-	 * @var array <string function name> => <int parameter position>
+	 * @var array<string, array<string, int|string>> Function name as key, array with target
+	 *                                               parameter and name as value.
 	 */
 	protected $target_functions = array(
-		'load_textdomain'                        => 1,
-		'load_plugin_textdomain'                 => 1,
-		'load_muplugin_textdomain'               => 1,
-		'load_theme_textdomain'                  => 1,
-		'load_child_theme_textdomain'            => 1,
-		'load_script_textdomain'                 => 2,
-		'unload_textdomain'                      => 1,
+		'load_textdomain' => array(
+			'position' => 1,
+			'name'     => 'domain',
+		),
+		'load_plugin_textdomain' => array(
+			'position' => 1,
+			'name'     => 'domain',
+		),
+		'load_muplugin_textdomain' => array(
+			'position' => 1,
+			'name'     => 'domain',
+		),
+		'load_theme_textdomain' => array(
+			'position' => 1,
+			'name'     => 'domain',
+		),
+		'load_child_theme_textdomain' => array(
+			'position' => 1,
+			'name'     => 'domain',
+		),
+		'load_script_textdomain' => array(
+			'position' => 2,
+			'name'     => 'domain',
+		),
+		'unload_textdomain' => array(
+			'position' => 1,
+			'name'     => 'domain',
+		),
 
-		'__'                                     => 2,
-		'_e'                                     => 2,
-		'_x'                                     => 3,
-		'_ex'                                    => 3,
-		'_n'                                     => 4,
-		'_nx'                                    => 5,
-		'_n_noop'                                => 3,
-		'_nx_noop'                               => 4,
-		'translate_nooped_plural'                => 3,
-		'_c'                                     => 2, // Deprecated.
-		'_nc'                                    => 4, // Deprecated.
-		'__ngettext'                             => 4, // Deprecated.
-		'__ngettext_noop'                        => 3, // Deprecated.
-		'translate_with_context'                 => 2, // Deprecated.
+		'__' => array(
+			'position' => 2,
+			'name'     => 'domain',
+		),
+		'_e' => array(
+			'position' => 2,
+			'name'     => 'domain',
+		),
+		'_x' => array(
+			'position' => 3,
+			'name'     => 'domain',
+		),
+		'_ex' => array(
+			'position' => 3,
+			'name'     => 'domain',
+		),
+		'_n' => array(
+			'position' => 4,
+			'name'     => 'domain',
+		),
+		'_nx' => array(
+			'position' => 5,
+			'name'     => 'domain',
+		),
+		'_n_noop' => array(
+			'position' => 3,
+			'name'     => 'domain',
+		),
+		'_nx_noop' => array(
+			'position' => 4,
+			'name'     => 'domain',
+		),
+		'translate_nooped_plural' => array(
+			'position' => 3,
+			'name'     => 'domain',
+		),
 
-		'esc_html__'                             => 2,
-		'esc_html_e'                             => 2,
-		'esc_html_x'                             => 3,
-		'esc_attr__'                             => 2,
-		'esc_attr_e'                             => 2,
-		'esc_attr_x'                             => 3,
+		'esc_html__' => array(
+			'position' => 2,
+			'name'     => 'domain',
+		),
+		'esc_html_e' => array(
+			'position' => 2,
+			'name'     => 'domain',
+		),
+		'esc_html_x' => array(
+			'position' => 3,
+			'name'     => 'domain',
+		),
+		'esc_attr__' => array(
+			'position' => 2,
+			'name'     => 'domain',
+		),
+		'esc_attr_e' => array(
+			'position' => 2,
+			'name'     => 'domain',
+		),
+		'esc_attr_x' => array(
+			'position' => 3,
+			'name'     => 'domain',
+		),
 
-		'is_textdomain_loaded'                   => 1,
-		'get_translations_for_domain'            => 1,
+		'is_textdomain_loaded' => array(
+			'position' => 1,
+			'name'     => 'domain',
+		),
+		'get_translations_for_domain' => array(
+			'position' => 1,
+			'name'     => 'domain',
+		),
+
+		// Deprecated functions.
+		'_c' => array(
+			'position' => 2,
+			'name'     => 'domain',
+		),
+		'_nc' => array(
+			'position' => 4,
+			'name'     => 'domain',
+		),
+		'__ngettext' => array(
+			'position' => 4,
+			'name'     => 'domain',
+		),
+		'__ngettext_noop' => array(
+			'position' => 3,
+			'name'     => 'domain',
+		),
+		'translate_with_context' => array(
+			'position' => 2,
+			'name'     => 'domain',
+		),
 
 		// Shouldn't be used by plugins/themes.
-		'translate'                              => 2,
-		'translate_with_gettext_context'         => 3,
+		'translate' => array(
+			'position' => 2,
+			'name'     => 'domain',
+		),
+		'translate_with_gettext_context' => array(
+			'position' => 3,
+			'name'     => 'domain',
+		),
 
 		// WP private functions. Shouldn't be used by plugins/themes.
-		'_load_textdomain_just_in_time'          => 1,
-		'_get_path_to_translation_from_lang_dir' => 1,
-		'_get_path_to_translation'               => 1,
+		'_load_textdomain_just_in_time' => array(
+			'position' => 1,
+			'name'     => 'domain',
+		),
+		'_get_path_to_translation_from_lang_dir' => array(
+			'position' => 1,
+			'name'     => 'domain',
+		),
+		'_get_path_to_translation' => array(
+			'position' => 1,
+			'name'     => 'domain',
+		),
 	);
 
 	/**
@@ -364,18 +473,27 @@ class I18nTextDomainFixerSniff extends AbstractFunctionParameterSniff {
 	 * @return void
 	 */
 	public function process_parameters( $stackPtr, $group_name, $matched_content, $parameters ) {
-		$target_param = $this->target_functions[ $matched_content ];
+		$target_param_specs = $this->target_functions[ $matched_content ];
+		$found_param        = PassedParameters::getParameterFromStack( $parameters, $target_param_specs['position'], $target_param_specs['name'] );
 
-		if ( isset( $parameters[ $target_param ] ) === false && 1 !== $target_param ) {
+		if ( false === $found_param && 1 !== $target_param_specs['position'] ) {
 			$error_msg  = 'Missing $domain arg';
 			$error_code = 'MissingArgDomain';
 
-			if ( isset( $parameters[ ( $target_param - 1 ) ] ) ) {
+			$has_named_params = false;
+			foreach ( $parameters as $param ) {
+				if ( isset( $param['name'] ) ) {
+					$has_named_params = true;
+					break;
+				}
+			}
+
+			if ( false === $has_named_params && isset( $parameters[ ( $target_param_specs['position'] - 1 ) ] ) ) {
 				$fix = $this->phpcsFile->addFixableError( $error_msg, $stackPtr, $error_code );
 
 				if ( true === $fix ) {
-					$start_previous = $parameters[ ( $target_param - 1 ) ]['start'];
-					$end_previous   = $parameters[ ( $target_param - 1 ) ]['end'];
+					$start_previous = $parameters[ ( $target_param_specs['position'] - 1 ) ]['start'];
+					$end_previous   = $parameters[ ( $target_param_specs['position'] - 1 ) ]['end'];
 					if ( \T_WHITESPACE === $this->tokens[ $start_previous ]['code']
 						&& $this->tokens[ $start_previous ]['content'] === $this->phpcsFile->eolChar
 					) {
@@ -404,6 +522,16 @@ class I18nTextDomainFixerSniff extends AbstractFunctionParameterSniff {
 						$this->phpcsFile->fixer->addContent( $end_previous, $replacement );
 					}
 				}
+			} elseif ( true === $has_named_params ) {
+				/*
+				 * Function call using named arguments. For now, we will not auto-fix this.
+				 *
+				 * {@internal If we don't bother with indentation and such, this can be made
+				 * auto-fixable by getting the 'end' of the last seen parameter and adding the
+				 * domain parameter, with the 'domain: ' parameter label, after the last
+				 * seen parameter.}
+				 */
+				$this->phpcsFile->addError( $error_msg, $stackPtr, $error_code );
 			} else {
 				$error_msg .= ' and preceding argument(s)';
 				$error_code = 'MissingArgs';
@@ -416,8 +544,8 @@ class I18nTextDomainFixerSniff extends AbstractFunctionParameterSniff {
 		}
 
 		// Target parameter found. Let's examine it.
-		$domain_param_start = $parameters[ $target_param ]['start'];
-		$domain_param_end   = $parameters[ $target_param ]['end'];
+		$domain_param_start = $found_param['start'];
+		$domain_param_end   = $found_param['end'];
 		$domain_token       = null;
 
 		for ( $i = $domain_param_start; $i <= $domain_param_end; $i++ ) {
@@ -471,10 +599,9 @@ class I18nTextDomainFixerSniff extends AbstractFunctionParameterSniff {
 	 * @return void
 	 */
 	public function process_no_parameters( $stackPtr, $group_name, $matched_content ) {
-
 		$target_param = $this->target_functions[ $matched_content ];
 
-		if ( 1 !== $target_param ) {
+		if ( 1 !== $target_param['position'] ) {
 			// Only process the no param case as fixable if the text domain is expected to be the first parameter.
 			$this->phpcsFile->addWarning( 'Missing $domain arg and preceding argument(s)', $stackPtr, 'MissingArgs' );
 			return;

--- a/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.4.inc
+++ b/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.4.inc
@@ -217,5 +217,34 @@ function foo() {
     );
 }
 
+/*
+ * Safeguard support for PHP 8.0+ named parameters.
+ */
+// Missing domain parameter.
+_n( plural: $plural, single: $single ); // Error.
+esc_attr_x(
+	context : $context
+	text    : $text,
+);
+
+// Has correct domain parameter.
+load_textdomain( mofile: '/path/to/file.mo', domain: 'something-else', );
+_e( $text, domain: 'something-else' );
+_nx_noop(
+	domain: 'something-else',
+	context: $context,
+	singular: $singular,
+	plural: $plural,
+);
+
+// Has incorrect domain parameter.
+load_muplugin_textdomain( mu_plugin_rel_path: '/languages/', domain: 'other-text-domain', );
+__( $text, domain: 'text-domain' );
+esc_html_x(
+	$text,
+	domain: 'text-domain',
+	context: $context,
+);
+
 // phpcs:set WordPress.Utils.I18nTextDomainFixer old_text_domain[]
 // phpcs:set WordPress.Utils.I18nTextDomainFixer new_text_domain false

--- a/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.4.inc
+++ b/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.4.inc
@@ -207,5 +207,15 @@ translate_with_context( $text, 'third-text-domain' ); // Error.
 load_script_textdomain( $handle, 'something-else', '/path/to/languages/' ); // OK.
 load_script_textdomain( $handle, 'third-text-domain', '/path/to/languages/' ); // Error.
 
+// Test ignoring multi-token text domains.
+__( $text, 'my' 'domain' ); // Parse error, but not our concern.
+
+// Test with space based code indentation
+function foo() {
+    unload_textdomain(
+        /* Missing domain. */
+    );
+}
+
 // phpcs:set WordPress.Utils.I18nTextDomainFixer old_text_domain[]
 // phpcs:set WordPress.Utils.I18nTextDomainFixer new_text_domain false

--- a/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.4.inc
+++ b/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.4.inc
@@ -203,5 +203,9 @@ __ngettext( $singular, $plural, $number ); // Error.
 __ngettext_noop( $singular, $plural, 'other-text-domain' ); // Error.
 translate_with_context( $text, 'third-text-domain' ); // Error.
 
+// New WP function.
+load_script_textdomain( $handle, 'something-else', '/path/to/languages/' ); // OK.
+load_script_textdomain( $handle, 'third-text-domain', '/path/to/languages/' ); // Error.
+
 // phpcs:set WordPress.Utils.I18nTextDomainFixer old_text_domain[]
 // phpcs:set WordPress.Utils.I18nTextDomainFixer new_text_domain false

--- a/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.4.inc.fixed
+++ b/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.4.inc.fixed
@@ -207,5 +207,9 @@ __ngettext( $singular, $plural, $number, 'something-else' ); // Error.
 __ngettext_noop( $singular, $plural, 'something-else' ); // Error.
 translate_with_context( $text, 'something-else' ); // Error.
 
+// New WP function.
+load_script_textdomain( $handle, 'something-else', '/path/to/languages/' ); // OK.
+load_script_textdomain( $handle, 'something-else', '/path/to/languages/' ); // Error.
+
 // phpcs:set WordPress.Utils.I18nTextDomainFixer old_text_domain[]
 // phpcs:set WordPress.Utils.I18nTextDomainFixer new_text_domain false

--- a/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.4.inc.fixed
+++ b/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.4.inc.fixed
@@ -222,5 +222,34 @@ function foo() {
     );
 }
 
+/*
+ * Safeguard support for PHP 8.0+ named parameters.
+ */
+// Missing domain parameter.
+_n( plural: $plural, single: $single ); // Error.
+esc_attr_x(
+	context : $context
+	text    : $text,
+);
+
+// Has correct domain parameter.
+load_textdomain( mofile: '/path/to/file.mo', domain: 'something-else', );
+_e( $text, domain: 'something-else' );
+_nx_noop(
+	domain: 'something-else',
+	context: $context,
+	singular: $singular,
+	plural: $plural,
+);
+
+// Has incorrect domain parameter.
+load_muplugin_textdomain( mu_plugin_rel_path: '/languages/', domain: 'something-else', );
+__( $text, domain: 'something-else' );
+esc_html_x(
+	$text,
+	domain: 'something-else',
+	context: $context,
+);
+
 // phpcs:set WordPress.Utils.I18nTextDomainFixer old_text_domain[]
 // phpcs:set WordPress.Utils.I18nTextDomainFixer new_text_domain false

--- a/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.4.inc.fixed
+++ b/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.4.inc.fixed
@@ -211,5 +211,16 @@ translate_with_context( $text, 'something-else' ); // Error.
 load_script_textdomain( $handle, 'something-else', '/path/to/languages/' ); // OK.
 load_script_textdomain( $handle, 'something-else', '/path/to/languages/' ); // Error.
 
+// Test ignoring multi-token text domains.
+__( $text, 'my' 'domain' ); // Parse error, but not our concern.
+
+// Test with space based code indentation
+function foo() {
+    unload_textdomain(
+        /* Missing domain. */
+        'something-else'
+    );
+}
+
 // phpcs:set WordPress.Utils.I18nTextDomainFixer old_text_domain[]
 // phpcs:set WordPress.Utils.I18nTextDomainFixer new_text_domain false

--- a/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.5.inc
+++ b/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.5.inc
@@ -1,0 +1,9 @@
+<?php
+// phpcs:set WordPress.Utils.I18nTextDomainFixer new_text_domain
+
+// Testing behaviour when the `new_text_domain` property is not set.
+
+load_textdomain( 'something-else', '/path/to/file.mo' );
+__( $text, 'something-else' );
+
+// phpcs:set WordPress.Utils.I18nTextDomainFixer new_text_domain false

--- a/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.6.inc
+++ b/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.6.inc
@@ -1,0 +1,11 @@
+<?php
+// phpcs:set WordPress.Utils.I18nTextDomainFixer old_text_domain[]
+// phpcs:set WordPress.Utils.I18nTextDomainFixer new_text_domain something-else
+
+// Testing behaviour when the `old_text_domain` property is not set.
+
+load_textdomain( 'old-domain', '/path/to/file.mo' );
+__( $text, 'old-domain' );
+
+// phpcs:set WordPress.Utils.I18nTextDomainFixer old_text_domain[]
+// phpcs:set WordPress.Utils.I18nTextDomainFixer new_text_domain false

--- a/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.php
+++ b/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.php
@@ -141,6 +141,7 @@ class I18nTextDomainFixerUnitTest extends AbstractSniffUnitTest {
 					203 => 1,
 					204 => 1,
 					208 => 1,
+					215 => 1,
 				);
 
 			default:

--- a/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.php
+++ b/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.php
@@ -142,6 +142,11 @@ class I18nTextDomainFixerUnitTest extends AbstractSniffUnitTest {
 					204 => 1,
 					208 => 1,
 					215 => 1,
+					224 => 1,
+					225 => 1,
+					241 => 1,
+					242 => 1,
+					245 => 1,
 				);
 
 			default:

--- a/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.php
+++ b/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.php
@@ -140,6 +140,7 @@ class I18nTextDomainFixerUnitTest extends AbstractSniffUnitTest {
 					202 => 1,
 					203 => 1,
 					204 => 1,
+					208 => 1,
 				);
 
 			default:


### PR DESCRIPTION
### Utils/I18nTextDomainFixer: add load_script_textdomain() function

The `load_script_textdomain()` function was added to WP in WP 5.0.

Ref: https://developer.wordpress.org/reference/functions/load_script_textdomain/

### Utils/I18nTextDomainFixer: update lists of plugin/theme headers

... as per the current lists of supported headers in the linked theme/plugin handbook pages.

### Utils/I18nTextDomainFixer: add some extra tests

... for a few situations which were handled by the sniff, but so far not covered by tests.

### Utils/I18nTextDomainFixer: implement PHPCSUtils

### Utils/I18nTextDomainFixer: add support for PHP 8.0+ named parameters

1. Adjusted the way the correct parameters are retrieved to use the new PHPCSUtils 1.0.0-alpha4 `PassedParameters::getParameterFromStack()` method.
2. Verified the parameter names used are in line with the name as per the WP 6.1 release.
    WP has been renaming parameters and is probably not done yet, but it doesn't look like those changes (so far) made it into changelog entries....
    For the purposes of this exercise, I've taken the _current_ parameter name as the "truth" as support for named parameters hasn't officially been announced yet, so any renames _after_ this moment are the only ones relevant.

Includes a change to the array format to allow for recording the parameter name.

Note: for now, I've not (yet) made the `MissingArgDomain` error auto-fixable in function calls with named arguments. I do think it's possible to do so, but also need to prioritize and I deem this sniff low priority (as it is "off" by default unless certain required properties are passed).

Includes additional unit tests.