### PR TITLE
CS/QA: make (nearly) all classes `final`

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -70,6 +70,13 @@
 	<!-- Enforce PSR1 compatible namespaces. -->
 	<rule ref="PSR1.Classes.ClassDeclaration"/>
 
+	<!-- Enforce that classes are abstract or final. -->
+	<rule ref="Universal.Classes.RequireFinalClass">
+		<!-- ... with the exception of four sniffs which are known to be extended by external standards. -->
+		<exclude-pattern>/WordPress/Sniffs/NamingConventions/ValidHookNameSniff\.php$</exclude-pattern>
+		<exclude-pattern>/WordPress/Sniffs/Security/(EscapeOutput|NonceVerification|ValidatedSanitizedInput)Sniff\.php$</exclude-pattern>
+	</rule>
+
 
 	<!--
 	#############################################################################

--- a/WordPress/Sniffs/Arrays/ArrayDeclarationSpacingSniff.php
+++ b/WordPress/Sniffs/Arrays/ArrayDeclarationSpacingSniff.php
@@ -41,7 +41,7 @@ use PHPCSUtils\Utils\PassedParameters;
  *                 "must be multi-line" rule. This behaviour can be changed using the
  *                 `allow_single_item_single_line_associative_arrays` property.
  */
-class ArrayDeclarationSpacingSniff extends Sniff {
+final class ArrayDeclarationSpacingSniff extends Sniff {
 
 	/**
 	 * Whether or not to allow single item associative arrays to be single line.

--- a/WordPress/Sniffs/Arrays/ArrayIndentationSniff.php
+++ b/WordPress/Sniffs/Arrays/ArrayIndentationSniff.php
@@ -29,7 +29,7 @@ use PHPCSUtils\Utils\PassedParameters;
  * {@internal This sniff should eventually be pulled upstream as part of a solution
  * for https://github.com/squizlabs/PHP_CodeSniffer/issues/582 }}
  */
-class ArrayIndentationSniff extends Sniff {
+final class ArrayIndentationSniff extends Sniff {
 
 	/**
 	 * Should tabs be used for indenting?

--- a/WordPress/Sniffs/Arrays/ArrayKeySpacingRestrictionsSniff.php
+++ b/WordPress/Sniffs/Arrays/ArrayKeySpacingRestrictionsSniff.php
@@ -25,7 +25,7 @@ use WordPressCS\WordPress\Sniff;
  * @since   0.13.0 Class name changed: this class is now namespaced.
  * @since   2.2.0  The sniff now also checks the size of the spacing, if applicable.
  */
-class ArrayKeySpacingRestrictionsSniff extends Sniff {
+final class ArrayKeySpacingRestrictionsSniff extends Sniff {
 
 	/**
 	 * Returns an array of tokens this test wants to listen for.

--- a/WordPress/Sniffs/Arrays/CommaAfterArrayItemSniff.php
+++ b/WordPress/Sniffs/Arrays/CommaAfterArrayItemSniff.php
@@ -32,7 +32,7 @@ use WordPressCS\WordPress\Sniff;
  * @since   0.12.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class CommaAfterArrayItemSniff extends Sniff {
+final class CommaAfterArrayItemSniff extends Sniff {
 
 	/**
 	 * Returns an array of tokens this test wants to listen for.

--- a/WordPress/Sniffs/Arrays/MultipleStatementAlignmentSniff.php
+++ b/WordPress/Sniffs/Arrays/MultipleStatementAlignmentSniff.php
@@ -31,7 +31,7 @@ use WordPressCS\WordPress\Sniff;
  * {@internal This sniff should eventually be pulled upstream as part of a solution
  * for https://github.com/squizlabs/PHP_CodeSniffer/issues/582 }}
  */
-class MultipleStatementAlignmentSniff extends Sniff {
+final class MultipleStatementAlignmentSniff extends Sniff {
 
 	/**
 	 * Whether or not to ignore an array item for the purpose of alignment

--- a/WordPress/Sniffs/CodeAnalysis/AssignmentInTernaryConditionSniff.php
+++ b/WordPress/Sniffs/CodeAnalysis/AssignmentInTernaryConditionSniff.php
@@ -29,7 +29,7 @@ use WordPressCS\WordPress\Sniff;
  *
  * @link https://github.com/squizlabs/PHP_CodeSniffer/pull/1594 Upstream sniff.
  */
-class AssignmentInTernaryConditionSniff extends Sniff {
+final class AssignmentInTernaryConditionSniff extends Sniff {
 
 	/**
 	 * Assignment tokens to trigger on.

--- a/WordPress/Sniffs/CodeAnalysis/EscapedNotTranslatedSniff.php
+++ b/WordPress/Sniffs/CodeAnalysis/EscapedNotTranslatedSniff.php
@@ -22,7 +22,7 @@ use PHPCSUtils\Utils\GetTokensAsString;
  *
  * @since   2.2.0
  */
-class EscapedNotTranslatedSniff extends AbstractFunctionParameterSniff {
+final class EscapedNotTranslatedSniff extends AbstractFunctionParameterSniff {
 
 	/**
 	 * The group name for this group of functions.

--- a/WordPress/Sniffs/DB/DirectDatabaseQuerySniff.php
+++ b/WordPress/Sniffs/DB/DirectDatabaseQuerySniff.php
@@ -30,7 +30,7 @@ use WordPressCS\WordPress\Sniff;
  * @since   1.0.0  This sniff has been moved from the `VIP` category to the `DB` category.
  * @since   3.0.0  Support for the very sniff specific WPCS native ignore comment syntax has been removed.
  */
-class DirectDatabaseQuerySniff extends Sniff {
+final class DirectDatabaseQuerySniff extends Sniff {
 
 	/**
 	 * List of custom cache get functions.

--- a/WordPress/Sniffs/DB/PreparedSQLPlaceholdersSniff.php
+++ b/WordPress/Sniffs/DB/PreparedSQLPlaceholdersSniff.php
@@ -42,7 +42,7 @@ use WordPressCS\WordPress\Sniff;
  *
  * @since   0.14.0
  */
-class PreparedSQLPlaceholdersSniff extends Sniff {
+final class PreparedSQLPlaceholdersSniff extends Sniff {
 
 	use WPDBTrait;
 

--- a/WordPress/Sniffs/DB/PreparedSQLSniff.php
+++ b/WordPress/Sniffs/DB/PreparedSQLSniff.php
@@ -28,7 +28,7 @@ use WordPressCS\WordPress\Sniff;
  * @since   0.13.0 Class name changed: this class is now namespaced.
  * @since   1.0.0  This sniff has been moved from the `WP` category to the `DB` category.
  */
-class PreparedSQLSniff extends Sniff {
+final class PreparedSQLSniff extends Sniff {
 
 	use WPDBTrait;
 

--- a/WordPress/Sniffs/DB/RestrictedClassesSniff.php
+++ b/WordPress/Sniffs/DB/RestrictedClassesSniff.php
@@ -26,7 +26,7 @@ use WordPressCS\WordPress\AbstractClassRestrictionsSniff;
  * @since   0.10.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class RestrictedClassesSniff extends AbstractClassRestrictionsSniff {
+final class RestrictedClassesSniff extends AbstractClassRestrictionsSniff {
 
 	/**
 	 * Groups of classes to restrict.

--- a/WordPress/Sniffs/DB/RestrictedFunctionsSniff.php
+++ b/WordPress/Sniffs/DB/RestrictedFunctionsSniff.php
@@ -26,7 +26,7 @@ use WordPressCS\WordPress\AbstractFunctionRestrictionsSniff;
  * @since   0.10.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class RestrictedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
+final class RestrictedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 
 	/**
 	 * Groups of functions to restrict.

--- a/WordPress/Sniffs/DB/SlowDBQuerySniff.php
+++ b/WordPress/Sniffs/DB/SlowDBQuerySniff.php
@@ -22,7 +22,7 @@ use WordPressCS\WordPress\AbstractArrayAssignmentRestrictionsSniff;
  * @since   0.13.0 Class name changed: this class is now namespaced.
  * @since   1.0.0  This sniff has been moved from the `VIP` category to the `DB` category.
  */
-class SlowDBQuerySniff extends AbstractArrayAssignmentRestrictionsSniff {
+final class SlowDBQuerySniff extends AbstractArrayAssignmentRestrictionsSniff {
 
 	/**
 	 * Groups of variables to restrict.

--- a/WordPress/Sniffs/DateTime/CurrentTimeTimestampSniff.php
+++ b/WordPress/Sniffs/DateTime/CurrentTimeTimestampSniff.php
@@ -30,7 +30,7 @@ use WordPressCS\WordPress\AbstractFunctionParameterSniff;
  *
  * @since   2.2.0
  */
-class CurrentTimeTimestampSniff extends AbstractFunctionParameterSniff {
+final class CurrentTimeTimestampSniff extends AbstractFunctionParameterSniff {
 
 	/**
 	 * The group name for this group of functions.

--- a/WordPress/Sniffs/DateTime/RestrictedFunctionsSniff.php
+++ b/WordPress/Sniffs/DateTime/RestrictedFunctionsSniff.php
@@ -18,7 +18,7 @@ use WordPressCS\WordPress\AbstractFunctionRestrictionsSniff;
  *
  * @since 2.2.0
  */
-class RestrictedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
+final class RestrictedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 
 	/**
 	 * Groups of functions to restrict.

--- a/WordPress/Sniffs/Files/FileNameSniff.php
+++ b/WordPress/Sniffs/Files/FileNameSniff.php
@@ -35,7 +35,7 @@ use WordPressCS\WordPress\Helpers\IsUnitTestTrait;
  *
  * @uses    \WordPressCS\WordPress\Helpers\IsUnitTestTrait::$custom_test_classes
  */
-class FileNameSniff extends Sniff {
+final class FileNameSniff extends Sniff {
 
 	use IsUnitTestTrait;
 

--- a/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
+++ b/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
@@ -45,7 +45,7 @@ use WordPressCS\WordPress\Helpers\WPHookHelper;
  *
  * @uses    \WordPressCS\WordPress\Helpers\IsUnitTestTrait::$custom_test_classes
  */
-class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
+final class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 
 	use IsUnitTestTrait;
 

--- a/WordPress/Sniffs/NamingConventions/ValidFunctionNameSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidFunctionNameSniff.php
@@ -33,7 +33,7 @@ use WordPressCS\WordPress\Sniff;
  * @since   3.0.0  This sniff has been refactored and no longer extends the upstream
  *                 PEAR.NamingConventions.ValidFunctionName sniff.
  */
-class ValidFunctionNameSniff extends Sniff {
+final class ValidFunctionNameSniff extends Sniff {
 
 	/**
 	 * Returns an array of tokens this test wants to listen for.

--- a/WordPress/Sniffs/NamingConventions/ValidPostTypeSlugSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidPostTypeSlugSniff.php
@@ -27,7 +27,7 @@ use WordPressCS\WordPress\AbstractFunctionParameterSniff;
  *
  * @since 2.2.0
  */
-class ValidPostTypeSlugSniff extends AbstractFunctionParameterSniff {
+final class ValidPostTypeSlugSniff extends AbstractFunctionParameterSniff {
 
 	/**
 	 * Max length of a post type name is limited by the SQL field.

--- a/WordPress/Sniffs/NamingConventions/ValidVariableNameSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidVariableNameSniff.php
@@ -33,7 +33,7 @@ use WordPressCS\WordPress\Helpers\SnakeCaseHelper;
  * Last synced with base class January 2022 at commit 4b49a952bf0e2c3863d0a113256bae0d7fe63d52.
  * @link    https://github.com/squizlabs/PHP_CodeSniffer/blob/master/src/Standards/Squiz/Sniffs/NamingConventions/ValidVariableNameSniff.php
  */
-class ValidVariableNameSniff extends PHPCS_AbstractVariableSniff {
+final class ValidVariableNameSniff extends PHPCS_AbstractVariableSniff {
 
 	/**
 	 * Mixed-case variables used by WordPress.

--- a/WordPress/Sniffs/PHP/DevelopmentFunctionsSniff.php
+++ b/WordPress/Sniffs/PHP/DevelopmentFunctionsSniff.php
@@ -19,7 +19,7 @@ use WordPressCS\WordPress\AbstractFunctionRestrictionsSniff;
  * @since   0.11.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class DevelopmentFunctionsSniff extends AbstractFunctionRestrictionsSniff {
+final class DevelopmentFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 
 	/**
 	 * Groups of functions to restrict.

--- a/WordPress/Sniffs/PHP/DiscouragedPHPFunctionsSniff.php
+++ b/WordPress/Sniffs/PHP/DiscouragedPHPFunctionsSniff.php
@@ -20,7 +20,7 @@ use WordPressCS\WordPress\AbstractFunctionRestrictionsSniff;
  * @since   0.13.0 Class name changed: this class is now namespaced.
  * @since   0.14.0 `create_function` was moved to the PHP.RestrictedFunctions sniff.
  */
-class DiscouragedPHPFunctionsSniff extends AbstractFunctionRestrictionsSniff {
+final class DiscouragedPHPFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 
 	/**
 	 * Groups of functions to discourage.

--- a/WordPress/Sniffs/PHP/DontExtractSniff.php
+++ b/WordPress/Sniffs/PHP/DontExtractSniff.php
@@ -23,7 +23,7 @@ use WordPressCS\WordPress\AbstractFunctionRestrictionsSniff;
  * @since   0.13.0 Class name changed: this class is now namespaced.
  * @since   1.0.0  This sniff has been moved from the `Functions` category to the `PHP` category.
  */
-class DontExtractSniff extends AbstractFunctionRestrictionsSniff {
+final class DontExtractSniff extends AbstractFunctionRestrictionsSniff {
 
 	/**
 	 * Groups of functions to restrict.

--- a/WordPress/Sniffs/PHP/IniSetSniff.php
+++ b/WordPress/Sniffs/PHP/IniSetSniff.php
@@ -25,7 +25,7 @@ use WordPressCS\WordPress\AbstractFunctionParameterSniff;
  *
  * @since 2.1.0
  */
-class IniSetSniff extends AbstractFunctionParameterSniff {
+final class IniSetSniff extends AbstractFunctionParameterSniff {
 
 	/**
 	 * Array of functions that must be checked.

--- a/WordPress/Sniffs/PHP/NoSilencedErrorsSniff.php
+++ b/WordPress/Sniffs/PHP/NoSilencedErrorsSniff.php
@@ -26,7 +26,7 @@ use WordPressCS\WordPress\Sniff;
  *
  * @since   1.1.0
  */
-class NoSilencedErrorsSniff extends Sniff {
+final class NoSilencedErrorsSniff extends Sniff {
 
 	/**
 	 * Number of tokens to display in the error message to show

--- a/WordPress/Sniffs/PHP/POSIXFunctionsSniff.php
+++ b/WordPress/Sniffs/PHP/POSIXFunctionsSniff.php
@@ -25,7 +25,7 @@ use WordPressCS\WordPress\AbstractFunctionRestrictionsSniff;
  *                 `WordPress.PHP.DiscouragedPHPFunctions` sniffs.
  * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class POSIXFunctionsSniff extends AbstractFunctionRestrictionsSniff {
+final class POSIXFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 
 	/**
 	 * Groups of functions to restrict.

--- a/WordPress/Sniffs/PHP/PregQuoteDelimiterSniff.php
+++ b/WordPress/Sniffs/PHP/PregQuoteDelimiterSniff.php
@@ -19,7 +19,7 @@ use WordPressCS\WordPress\AbstractFunctionParameterSniff;
  *
  * @since   1.0.0
  */
-class PregQuoteDelimiterSniff extends AbstractFunctionParameterSniff {
+final class PregQuoteDelimiterSniff extends AbstractFunctionParameterSniff {
 
 	/**
 	 * The group name for this group of functions.

--- a/WordPress/Sniffs/PHP/RestrictedPHPFunctionsSniff.php
+++ b/WordPress/Sniffs/PHP/RestrictedPHPFunctionsSniff.php
@@ -18,7 +18,7 @@ use WordPressCS\WordPress\AbstractFunctionRestrictionsSniff;
  *
  * @since   0.14.0
  */
-class RestrictedPHPFunctionsSniff extends AbstractFunctionRestrictionsSniff {
+final class RestrictedPHPFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 
 	/**
 	 * Groups of functions to forbid.

--- a/WordPress/Sniffs/PHP/StrictInArraySniff.php
+++ b/WordPress/Sniffs/PHP/StrictInArraySniff.php
@@ -25,7 +25,7 @@ use WordPressCS\WordPress\AbstractFunctionParameterSniff;
  * @since   0.11.0 Refactored to extend the new WordPressCS native `AbstractFunctionParameterSniff` class.
  * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class StrictInArraySniff extends AbstractFunctionParameterSniff {
+final class StrictInArraySniff extends AbstractFunctionParameterSniff {
 
 	/**
 	 * The group name for this group of functions.

--- a/WordPress/Sniffs/PHP/TypeCastsSniff.php
+++ b/WordPress/Sniffs/PHP/TypeCastsSniff.php
@@ -27,7 +27,7 @@ use WordPressCS\WordPress\Sniff;
  * @since   2.0.0 No longer checks that type casts are lowercase or short form.
  *                Relevant PHPCS native sniffs have been included in the rulesets instead.
  */
-class TypeCastsSniff extends Sniff {
+final class TypeCastsSniff extends Sniff {
 
 	/**
 	 * Returns an array of tokens this test wants to listen for.

--- a/WordPress/Sniffs/PHP/YodaConditionsSniff.php
+++ b/WordPress/Sniffs/PHP/YodaConditionsSniff.php
@@ -24,7 +24,7 @@ use PHPCSUtils\Tokens\Collections;
  * @since   0.12.0 This class now extends the WordPressCS native `Sniff` class.
  * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class YodaConditionsSniff extends Sniff {
+final class YodaConditionsSniff extends Sniff {
 
 	/**
 	 * The tokens that indicate the start of a condition.

--- a/WordPress/Sniffs/Security/PluginMenuSlugSniff.php
+++ b/WordPress/Sniffs/Security/PluginMenuSlugSniff.php
@@ -25,7 +25,7 @@ use WordPressCS\WordPress\AbstractFunctionParameterSniff;
  * @since   0.13.0 Class name changed: this class is now namespaced.
  * @since   1.0.0  This sniff has been moved from the `VIP` category to the `Security` category.
  */
-class PluginMenuSlugSniff extends AbstractFunctionParameterSniff {
+final class PluginMenuSlugSniff extends AbstractFunctionParameterSniff {
 
 	/**
 	 * The group name for this group of functions.

--- a/WordPress/Sniffs/Security/SafeRedirectSniff.php
+++ b/WordPress/Sniffs/Security/SafeRedirectSniff.php
@@ -18,7 +18,7 @@ use WordPressCS\WordPress\AbstractFunctionRestrictionsSniff;
  *
  * @since   1.0.0
  */
-class SafeRedirectSniff extends AbstractFunctionRestrictionsSniff {
+final class SafeRedirectSniff extends AbstractFunctionRestrictionsSniff {
 
 	/**
 	 * Groups of functions to restrict.

--- a/WordPress/Sniffs/Utils/I18nTextDomainFixerSniff.php
+++ b/WordPress/Sniffs/Utils/I18nTextDomainFixerSniff.php
@@ -29,7 +29,7 @@ use WordPressCS\WordPress\Helpers\RulesetPropertyHelper;
  *
  * @since   1.2.0
  */
-class I18nTextDomainFixerSniff extends AbstractFunctionParameterSniff {
+final class I18nTextDomainFixerSniff extends AbstractFunctionParameterSniff {
 
 	/**
 	 * A list of tokenizers this sniff supports.

--- a/WordPress/Sniffs/WP/AlternativeFunctionsSniff.php
+++ b/WordPress/Sniffs/WP/AlternativeFunctionsSniff.php
@@ -26,7 +26,7 @@ use WordPressCS\WordPress\Helpers\MinimumWPVersionTrait;
  *
  * @uses    \WordPressCS\WordPress\Helpers\MinimumWPVersionTrait::$minimum_wp_version
  */
-class AlternativeFunctionsSniff extends AbstractFunctionRestrictionsSniff {
+final class AlternativeFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 
 	use MinimumWPVersionTrait;
 

--- a/WordPress/Sniffs/WP/CapabilitiesSniff.php
+++ b/WordPress/Sniffs/WP/CapabilitiesSniff.php
@@ -28,7 +28,7 @@ use WordPressCS\WordPress\Helpers\RulesetPropertyHelper;
  *
  * @uses    \WordPressCS\WordPress\Helpers\MinimumWPVersionTrait::$minimum_wp_version
  */
-class CapabilitiesSniff extends AbstractFunctionParameterSniff {
+final class CapabilitiesSniff extends AbstractFunctionParameterSniff {
 
 	use MinimumWPVersionTrait;
 

--- a/WordPress/Sniffs/WP/CapitalPDangitSniff.php
+++ b/WordPress/Sniffs/WP/CapitalPDangitSniff.php
@@ -26,7 +26,7 @@ use WordPressCS\WordPress\Sniff;
  * @since   0.13.0 Class name changed: this class is now namespaced.
  * @since   3.0.0  Now also checks namespace names.
  */
-class CapitalPDangitSniff extends Sniff {
+final class CapitalPDangitSniff extends Sniff {
 
 	/**
 	 * Regex to match a large number or spelling variations of WordPress in text strings.

--- a/WordPress/Sniffs/WP/ClassNameCaseSniff.php
+++ b/WordPress/Sniffs/WP/ClassNameCaseSniff.php
@@ -18,7 +18,7 @@ use WordPressCS\WordPress\AbstractClassRestrictionsSniff;
  *
  * @since 3.0.0
  */
-class ClassNameCaseSniff extends AbstractClassRestrictionsSniff {
+final class ClassNameCaseSniff extends AbstractClassRestrictionsSniff {
 
 	/**
 	 * List of all WP native classes.

--- a/WordPress/Sniffs/WP/CronIntervalSniff.php
+++ b/WordPress/Sniffs/WP/CronIntervalSniff.php
@@ -32,7 +32,7 @@ use PHPCSUtils\Utils\TextStrings;
  * @since   0.14.0 The minimum cron interval tested against is now configurable.
  * @since   1.0.0  This sniff has been moved from the `VIP` category to the `WP` category.
  */
-class CronIntervalSniff extends Sniff {
+final class CronIntervalSniff extends Sniff {
 
 	/**
 	 * Minimum allowed cron interval in seconds.

--- a/WordPress/Sniffs/WP/DeprecatedClassesSniff.php
+++ b/WordPress/Sniffs/WP/DeprecatedClassesSniff.php
@@ -32,7 +32,7 @@ use WordPressCS\WordPress\Helpers\MinimumWPVersionTrait;
  *
  * @uses    \WordPressCS\WordPress\Helpers\MinimumWPVersionTrait::$minimum_wp_version
  */
-class DeprecatedClassesSniff extends AbstractClassRestrictionsSniff {
+final class DeprecatedClassesSniff extends AbstractClassRestrictionsSniff {
 
 	use MinimumWPVersionTrait;
 

--- a/WordPress/Sniffs/WP/DeprecatedFunctionsSniff.php
+++ b/WordPress/Sniffs/WP/DeprecatedFunctionsSniff.php
@@ -32,7 +32,7 @@ use WordPressCS\WordPress\Helpers\MinimumWPVersionTrait;
  *
  * @uses    \WordPressCS\WordPress\Helpers\MinimumWPVersionTrait::$minimum_wp_version
  */
-class DeprecatedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
+final class DeprecatedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 
 	use MinimumWPVersionTrait;
 

--- a/WordPress/Sniffs/WP/DeprecatedParameterValuesSniff.php
+++ b/WordPress/Sniffs/WP/DeprecatedParameterValuesSniff.php
@@ -25,7 +25,7 @@ use WordPressCS\WordPress\Helpers\MinimumWPVersionTrait;
  *
  * @uses    \WordPressCS\WordPress\Helpers\MinimumWPVersionTrait::$minimum_wp_version
  */
-class DeprecatedParameterValuesSniff extends AbstractFunctionParameterSniff {
+final class DeprecatedParameterValuesSniff extends AbstractFunctionParameterSniff {
 
 	use MinimumWPVersionTrait;
 

--- a/WordPress/Sniffs/WP/DeprecatedParametersSniff.php
+++ b/WordPress/Sniffs/WP/DeprecatedParametersSniff.php
@@ -34,7 +34,7 @@ use WordPressCS\WordPress\Helpers\MinimumWPVersionTrait;
  *
  * @uses    \WordPressCS\WordPress\Helpers\MinimumWPVersionTrait::$minimum_wp_version
  */
-class DeprecatedParametersSniff extends AbstractFunctionParameterSniff {
+final class DeprecatedParametersSniff extends AbstractFunctionParameterSniff {
 
 	use MinimumWPVersionTrait;
 

--- a/WordPress/Sniffs/WP/DiscouragedConstantsSniff.php
+++ b/WordPress/Sniffs/WP/DiscouragedConstantsSniff.php
@@ -24,7 +24,7 @@ use PHPCSUtils\Utils\TextStrings;
  *
  * @since   0.14.0
  */
-class DiscouragedConstantsSniff extends AbstractFunctionParameterSniff {
+final class DiscouragedConstantsSniff extends AbstractFunctionParameterSniff {
 
 	/**
 	 * List of discouraged WP constants and their replacements.

--- a/WordPress/Sniffs/WP/DiscouragedFunctionsSniff.php
+++ b/WordPress/Sniffs/WP/DiscouragedFunctionsSniff.php
@@ -19,7 +19,7 @@ use WordPressCS\WordPress\AbstractFunctionRestrictionsSniff;
  * @since   0.11.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class DiscouragedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
+final class DiscouragedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 
 	/**
 	 * Groups of functions to restrict.

--- a/WordPress/Sniffs/WP/EnqueuedResourceParametersSniff.php
+++ b/WordPress/Sniffs/WP/EnqueuedResourceParametersSniff.php
@@ -29,7 +29,7 @@ use WordPressCS\WordPress\AbstractFunctionParameterSniff;
  *
  * @since 1.0.0
  */
-class EnqueuedResourceParametersSniff extends AbstractFunctionParameterSniff {
+final class EnqueuedResourceParametersSniff extends AbstractFunctionParameterSniff {
 
 	/**
 	 * The group name for this group of functions.

--- a/WordPress/Sniffs/WP/EnqueuedResourcesSniff.php
+++ b/WordPress/Sniffs/WP/EnqueuedResourcesSniff.php
@@ -27,7 +27,7 @@ use WordPressCS\WordPress\Sniff;
  * @since   3.0.0  Added a check for a complete text string in the case where it
  *                 spans two lines.
  */
-class EnqueuedResourcesSniff extends Sniff {
+final class EnqueuedResourcesSniff extends Sniff {
 
 	/**
 	 * Returns an array of tokens this test wants to listen for.

--- a/WordPress/Sniffs/WP/GlobalVariablesOverrideSniff.php
+++ b/WordPress/Sniffs/WP/GlobalVariablesOverrideSniff.php
@@ -38,7 +38,7 @@ use WordPressCS\WordPress\Sniff;
  *
  * @uses    \WordPressCS\WordPress\Helpers\IsUnitTestTrait::$custom_test_classes
  */
-class GlobalVariablesOverrideSniff extends Sniff {
+final class GlobalVariablesOverrideSniff extends Sniff {
 
 	use IsUnitTestTrait;
 

--- a/WordPress/Sniffs/WP/I18nSniff.php
+++ b/WordPress/Sniffs/WP/I18nSniff.php
@@ -36,7 +36,7 @@ use WordPressCS\WordPress\Helpers\RulesetPropertyHelper;
  *                 The parent `exclude` property is, however, disabled as it
  *                 would disable the whole sniff.
  */
-class I18nSniff extends AbstractFunctionRestrictionsSniff {
+final class I18nSniff extends AbstractFunctionRestrictionsSniff {
 
 	/**
 	 * These Regexes were originally copied from https://www.php.net/function.sprintf#93552

--- a/WordPress/Sniffs/WP/PostsPerPageSniff.php
+++ b/WordPress/Sniffs/WP/PostsPerPageSniff.php
@@ -25,7 +25,7 @@ use WordPressCS\WordPress\AbstractArrayAssignmentRestrictionsSniff;
  *                 limit being part of the WP category, and the check for pagination
  *                 disabling being part of the VIP category.
  */
-class PostsPerPageSniff extends AbstractArrayAssignmentRestrictionsSniff {
+final class PostsPerPageSniff extends AbstractArrayAssignmentRestrictionsSniff {
 
 	/**
 	 * Posts per page property

--- a/WordPress/Sniffs/WhiteSpace/CastStructureSpacingSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/CastStructureSpacingSniff.php
@@ -28,7 +28,7 @@ use PHP_CodeSniffer\Util\Tokens;
  *                 upstream `Generic.Formatting.SpaceAfterCast.NoSpace` error.
  * @since   2.2.0  Added exception for whitespace between spread operator and cast.
  */
-class CastStructureSpacingSniff extends Sniff {
+final class CastStructureSpacingSniff extends Sniff {
 
 	/**
 	 * Returns an array of tokens this test wants to listen for.

--- a/WordPress/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
@@ -29,7 +29,7 @@ use PHPCSUtils\Utils\UseStatements;
  * to see if there are upstream fixes made from which this sniff can benefit, is warranted.
  * @link    https://github.com/squizlabs/PHP_CodeSniffer/blob/master/CodeSniffer/Standards/Squiz/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
  */
-class ControlStructureSpacingSniff extends Sniff {
+final class ControlStructureSpacingSniff extends Sniff {
 
 	/**
 	 * Check for blank lines on start/end of control structures.

--- a/WordPress/Sniffs/WhiteSpace/ObjectOperatorSpacingSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/ObjectOperatorSpacingSniff.php
@@ -24,7 +24,7 @@ use PHP_CodeSniffer\Util\Tokens;
  * @since 3.0.0
  * @link  https://github.com/squizlabs/PHP_CodeSniffer/blob/master/src/Standards/Squiz/Sniffs/WhiteSpace/ObjectOperatorSpacingSniff.php
  */
-class ObjectOperatorSpacingSniff extends Squiz_ObjectOperatorSpacingSniff {
+final class ObjectOperatorSpacingSniff extends Squiz_ObjectOperatorSpacingSniff {
 
 	/**
 	 * Processes this test, when one of its tokens is encountered.

--- a/WordPress/Sniffs/WhiteSpace/OperatorSpacingSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/OperatorSpacingSniff.php
@@ -35,7 +35,7 @@ use PHP_CodeSniffer\Util\Tokens;
  * Last verified with base class July 2020 at commit a957a73e3533353451eb9fd62ee58bd0aba2773c.
  * @link    https://github.com/squizlabs/PHP_CodeSniffer/blob/master/CodeSniffer/Standards/Squiz/Sniffs/WhiteSpace/OperatorSpacingSniff.php
  */
-class OperatorSpacingSniff extends PHPCS_Squiz_OperatorSpacingSniff {
+final class OperatorSpacingSniff extends PHPCS_Squiz_OperatorSpacingSniff {
 
 	/**
 	 * Allow newlines instead of spaces.

--- a/WordPress/Tests/Arrays/ArrayDeclarationSpacingUnitTest.php
+++ b/WordPress/Tests/Arrays/ArrayDeclarationSpacingUnitTest.php
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @since   0.11.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class ArrayDeclarationSpacingUnitTest extends AbstractSniffUnitTest {
+final class ArrayDeclarationSpacingUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/WordPress/Tests/Arrays/ArrayIndentationUnitTest.php
+++ b/WordPress/Tests/Arrays/ArrayIndentationUnitTest.php
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @since   0.12.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class ArrayIndentationUnitTest extends AbstractSniffUnitTest {
+final class ArrayIndentationUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * The tab width to use during testing.

--- a/WordPress/Tests/Arrays/ArrayKeySpacingRestrictionsUnitTest.php
+++ b/WordPress/Tests/Arrays/ArrayKeySpacingRestrictionsUnitTest.php
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @since   0.3.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class ArrayKeySpacingRestrictionsUnitTest extends AbstractSniffUnitTest {
+final class ArrayKeySpacingRestrictionsUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/WordPress/Tests/Arrays/CommaAfterArrayItemUnitTest.php
+++ b/WordPress/Tests/Arrays/CommaAfterArrayItemUnitTest.php
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @since   0.12.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class CommaAfterArrayItemUnitTest extends AbstractSniffUnitTest {
+final class CommaAfterArrayItemUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/WordPress/Tests/Arrays/MultipleStatementAlignmentUnitTest.php
+++ b/WordPress/Tests/Arrays/MultipleStatementAlignmentUnitTest.php
@@ -22,7 +22,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since   0.14.0
  */
-class MultipleStatementAlignmentUnitTest extends AbstractSniffUnitTest {
+final class MultipleStatementAlignmentUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * The tab width to use during testing.

--- a/WordPress/Tests/CodeAnalysis/AssignmentInTernaryConditionUnitTest.php
+++ b/WordPress/Tests/CodeAnalysis/AssignmentInTernaryConditionUnitTest.php
@@ -18,7 +18,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since   0.14.0
  */
-class AssignmentInTernaryConditionUnitTest extends AbstractSniffUnitTest {
+final class AssignmentInTernaryConditionUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/WordPress/Tests/CodeAnalysis/EscapedNotTranslatedUnitTest.php
+++ b/WordPress/Tests/CodeAnalysis/EscapedNotTranslatedUnitTest.php
@@ -18,7 +18,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since   2.2.0
  */
-class EscapedNotTranslatedUnitTest extends AbstractSniffUnitTest {
+final class EscapedNotTranslatedUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/WordPress/Tests/DB/DirectDatabaseQueryUnitTest.php
+++ b/WordPress/Tests/DB/DirectDatabaseQueryUnitTest.php
@@ -20,7 +20,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @since   0.13.0 Class name changed: this class is now namespaced.
  * @since   1.0.0  This sniff has been moved from the `VIP` category to the `DB` category.
  */
-class DirectDatabaseQueryUnitTest extends AbstractSniffUnitTest {
+final class DirectDatabaseQueryUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/WordPress/Tests/DB/PreparedSQLPlaceholdersUnitTest.php
+++ b/WordPress/Tests/DB/PreparedSQLPlaceholdersUnitTest.php
@@ -18,7 +18,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since   0.14.0
  */
-class PreparedSQLPlaceholdersUnitTest extends AbstractSniffUnitTest {
+final class PreparedSQLPlaceholdersUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/WordPress/Tests/DB/PreparedSQLUnitTest.php
+++ b/WordPress/Tests/DB/PreparedSQLUnitTest.php
@@ -20,7 +20,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @since   0.13.0 Class name changed: this class is now namespaced.
  * @since   1.0.0  This sniff has been moved from the `WP` category to the `DB` category.
  */
-class PreparedSQLUnitTest extends AbstractSniffUnitTest {
+final class PreparedSQLUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/WordPress/Tests/DB/RestrictedClassesUnitTest.php
+++ b/WordPress/Tests/DB/RestrictedClassesUnitTest.php
@@ -21,7 +21,7 @@ use WordPressCS\WordPress\AbstractFunctionRestrictionsSniff;
  * @since   0.13.0 Class name changed: this class is now namespaced.
  * @since   3.0.0  Renamed the fixtures to create compatibility with PHPCS 4.x/PHPUnit >=8.
  */
-class RestrictedClassesUnitTest extends AbstractSniffUnitTest {
+final class RestrictedClassesUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Add a number of extra restricted classes to unit test the abstract

--- a/WordPress/Tests/DB/RestrictedFunctionsUnitTest.php
+++ b/WordPress/Tests/DB/RestrictedFunctionsUnitTest.php
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @since   0.10.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class RestrictedFunctionsUnitTest extends AbstractSniffUnitTest {
+final class RestrictedFunctionsUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/WordPress/Tests/DB/SlowDBQueryUnitTest.php
+++ b/WordPress/Tests/DB/SlowDBQueryUnitTest.php
@@ -20,7 +20,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @since   0.13.0 Class name changed: this class is now namespaced.
  * @since   1.0.0  This sniff has been moved from the `VIP` category to the `DB` category.
  */
-class SlowDBQueryUnitTest extends AbstractSniffUnitTest {
+final class SlowDBQueryUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/WordPress/Tests/DateTime/CurrentTimeTimestampUnitTest.php
+++ b/WordPress/Tests/DateTime/CurrentTimeTimestampUnitTest.php
@@ -18,7 +18,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since   2.2.0
  */
-class CurrentTimeTimestampUnitTest extends AbstractSniffUnitTest {
+final class CurrentTimeTimestampUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/WordPress/Tests/DateTime/RestrictedFunctionsUnitTest.php
+++ b/WordPress/Tests/DateTime/RestrictedFunctionsUnitTest.php
@@ -18,7 +18,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since   2.2.0
  */
-class RestrictedFunctionsUnitTest extends AbstractSniffUnitTest {
+final class RestrictedFunctionsUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/WordPress/Tests/Files/FileNameUnitTest.php
+++ b/WordPress/Tests/Files/FileNameUnitTest.php
@@ -20,7 +20,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @since   0.11.0     Actually added tests ;-)
  * @since   0.13.0     Class name changed: this class is now namespaced.
  */
-class FileNameUnitTest extends AbstractSniffUnitTest {
+final class FileNameUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Error files with the expected nr of errors.

--- a/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.php
+++ b/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.php
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @since   0.12.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class PrefixAllGlobalsUnitTest extends AbstractSniffUnitTest {
+final class PrefixAllGlobalsUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/WordPress/Tests/NamingConventions/ValidFunctionNameUnitTest.php
+++ b/WordPress/Tests/NamingConventions/ValidFunctionNameUnitTest.php
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @since   2013-06-11
  * @since   0.13.0     Class name changed: this class is now namespaced.
  */
-class ValidFunctionNameUnitTest extends AbstractSniffUnitTest {
+final class ValidFunctionNameUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/WordPress/Tests/NamingConventions/ValidHookNameUnitTest.php
+++ b/WordPress/Tests/NamingConventions/ValidHookNameUnitTest.php
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @since   0.10.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class ValidHookNameUnitTest extends AbstractSniffUnitTest {
+final class ValidHookNameUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/WordPress/Tests/NamingConventions/ValidPostTypeSlugUnitTest.php
+++ b/WordPress/Tests/NamingConventions/ValidPostTypeSlugUnitTest.php
@@ -18,7 +18,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since   2.2.0
  */
-class ValidPostTypeSlugUnitTest extends AbstractSniffUnitTest {
+final class ValidPostTypeSlugUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Set warnings level to 3 to trigger suggestions as warnings.

--- a/WordPress/Tests/NamingConventions/ValidVariableNameUnitTest.php
+++ b/WordPress/Tests/NamingConventions/ValidVariableNameUnitTest.php
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @since   0.9.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class ValidVariableNameUnitTest extends AbstractSniffUnitTest {
+final class ValidVariableNameUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/WordPress/Tests/PHP/DevelopmentFunctionsUnitTest.php
+++ b/WordPress/Tests/PHP/DevelopmentFunctionsUnitTest.php
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @since   0.11.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class DevelopmentFunctionsUnitTest extends AbstractSniffUnitTest {
+final class DevelopmentFunctionsUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/WordPress/Tests/PHP/DiscouragedPHPFunctionsUnitTest.php
+++ b/WordPress/Tests/PHP/DiscouragedPHPFunctionsUnitTest.php
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @since   0.11.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class DiscouragedPHPFunctionsUnitTest extends AbstractSniffUnitTest {
+final class DiscouragedPHPFunctionsUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/WordPress/Tests/PHP/DontExtractUnitTest.php
+++ b/WordPress/Tests/PHP/DontExtractUnitTest.php
@@ -20,7 +20,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @since   0.13.0 Class name changed: this class is now namespaced.
  * @since   1.0.0  This sniff has been moved from the `Functions` category to the `PHP` category.
  */
-class DontExtractUnitTest extends AbstractSniffUnitTest {
+final class DontExtractUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/WordPress/Tests/PHP/IniSetUnitTest.php
+++ b/WordPress/Tests/PHP/IniSetUnitTest.php
@@ -18,7 +18,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since 2.1.0
  */
-class IniSetUnitTest extends AbstractSniffUnitTest {
+final class IniSetUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/WordPress/Tests/PHP/NoSilencedErrorsUnitTest.php
+++ b/WordPress/Tests/PHP/NoSilencedErrorsUnitTest.php
@@ -18,7 +18,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since   1.1.0
  */
-class NoSilencedErrorsUnitTest extends AbstractSniffUnitTest {
+final class NoSilencedErrorsUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/WordPress/Tests/PHP/POSIXFunctionsUnitTest.php
+++ b/WordPress/Tests/PHP/POSIXFunctionsUnitTest.php
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @since   0.10.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class POSIXFunctionsUnitTest extends AbstractSniffUnitTest {
+final class POSIXFunctionsUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/WordPress/Tests/PHP/PregQuoteDelimiterUnitTest.php
+++ b/WordPress/Tests/PHP/PregQuoteDelimiterUnitTest.php
@@ -18,7 +18,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since   1.0.0
  */
-class PregQuoteDelimiterUnitTest extends AbstractSniffUnitTest {
+final class PregQuoteDelimiterUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/WordPress/Tests/PHP/RestrictedPHPFunctionsUnitTest.php
+++ b/WordPress/Tests/PHP/RestrictedPHPFunctionsUnitTest.php
@@ -18,7 +18,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since   0.14.0
  */
-class RestrictedPHPFunctionsUnitTest extends AbstractSniffUnitTest {
+final class RestrictedPHPFunctionsUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/WordPress/Tests/PHP/StrictInArrayUnitTest.php
+++ b/WordPress/Tests/PHP/StrictInArrayUnitTest.php
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @since   0.9.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class StrictInArrayUnitTest extends AbstractSniffUnitTest {
+final class StrictInArrayUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/WordPress/Tests/PHP/TypeCastsUnitTest.php
+++ b/WordPress/Tests/PHP/TypeCastsUnitTest.php
@@ -18,7 +18,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since 1.2.0
  */
-class TypeCastsUnitTest extends AbstractSniffUnitTest {
+final class TypeCastsUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/WordPress/Tests/PHP/YodaConditionsUnitTest.php
+++ b/WordPress/Tests/PHP/YodaConditionsUnitTest.php
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @since   0.3.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class YodaConditionsUnitTest extends AbstractSniffUnitTest {
+final class YodaConditionsUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/WordPress/Tests/Security/EscapeOutputUnitTest.php
+++ b/WordPress/Tests/Security/EscapeOutputUnitTest.php
@@ -20,7 +20,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @since   0.13.0     Class name changed: this class is now namespaced.
  * @since   1.0.0      This sniff has been moved from the `XSS` category to the `Security` category.
  */
-class EscapeOutputUnitTest extends AbstractSniffUnitTest {
+final class EscapeOutputUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/WordPress/Tests/Security/NonceVerificationUnitTest.php
+++ b/WordPress/Tests/Security/NonceVerificationUnitTest.php
@@ -20,7 +20,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @since   0.13.0 Class name changed: this class is now namespaced.
  * @since   1.0.0  This sniff has been moved from the `CSRF` category to the `Security` category.
  */
-class NonceVerificationUnitTest extends AbstractSniffUnitTest {
+final class NonceVerificationUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/WordPress/Tests/Security/PluginMenuSlugUnitTest.php
+++ b/WordPress/Tests/Security/PluginMenuSlugUnitTest.php
@@ -20,7 +20,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @since   0.13.0 Class name changed: this class is now namespaced.
  * @since   1.0.0  This sniff has been moved from the `VIP` category to the `Security` category.
  */
-class PluginMenuSlugUnitTest extends AbstractSniffUnitTest {
+final class PluginMenuSlugUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/WordPress/Tests/Security/SafeRedirectUnitTest.php
+++ b/WordPress/Tests/Security/SafeRedirectUnitTest.php
@@ -18,7 +18,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since   1.0.0
  */
-class SafeRedirectUnitTest extends AbstractSniffUnitTest {
+final class SafeRedirectUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/WordPress/Tests/Security/ValidatedSanitizedInputUnitTest.php
+++ b/WordPress/Tests/Security/ValidatedSanitizedInputUnitTest.php
@@ -20,7 +20,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @since   0.13.0 Class name changed: this class is now namespaced.
  * @since   1.0.0  This sniff has been moved from the `VIP` category to the `Security` category.
  */
-class ValidatedSanitizedInputUnitTest extends AbstractSniffUnitTest {
+final class ValidatedSanitizedInputUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.php
+++ b/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.php
@@ -19,7 +19,7 @@ use PHPCSUtils\BackCompat\Helper;
  *
  * @since   1.2.0
  */
-class I18nTextDomainFixerUnitTest extends AbstractSniffUnitTest {
+final class I18nTextDomainFixerUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * The tab width to use during testing.

--- a/WordPress/Tests/WP/AlternativeFunctionsUnitTest.php
+++ b/WordPress/Tests/WP/AlternativeFunctionsUnitTest.php
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @since   0.11.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class AlternativeFunctionsUnitTest extends AbstractSniffUnitTest {
+final class AlternativeFunctionsUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/WordPress/Tests/WP/CapabilitiesUnitTest.php
+++ b/WordPress/Tests/WP/CapabilitiesUnitTest.php
@@ -18,7 +18,7 @@ use PHPCSUtils\BackCompat\Helper;
  * @package WPCS\WordPressCodingStandards
  * @since   3.0.0
  */
-class CapabilitiesUnitTest extends AbstractSniffUnitTest {
+final class CapabilitiesUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Adjust the config to allow for testing with specific CLI arguments.

--- a/WordPress/Tests/WP/CapitalPDangitUnitTest.php
+++ b/WordPress/Tests/WP/CapitalPDangitUnitTest.php
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @since   0.12.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class CapitalPDangitUnitTest extends AbstractSniffUnitTest {
+final class CapitalPDangitUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/WordPress/Tests/WP/ClassNameCaseUnitTest.php
+++ b/WordPress/Tests/WP/ClassNameCaseUnitTest.php
@@ -18,7 +18,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since 3.0.0
  */
-class ClassNameCaseUnitTest extends AbstractSniffUnitTest {
+final class ClassNameCaseUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/WordPress/Tests/WP/CronIntervalUnitTest.php
+++ b/WordPress/Tests/WP/CronIntervalUnitTest.php
@@ -20,7 +20,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @since   0.13.0 Class name changed: this class is now namespaced.
  * @since   1.0.0  This sniff has been moved from the `VIP` category to the `WP` category.
  */
-class CronIntervalUnitTest extends AbstractSniffUnitTest {
+final class CronIntervalUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/WordPress/Tests/WP/DeprecatedClassesUnitTest.php
+++ b/WordPress/Tests/WP/DeprecatedClassesUnitTest.php
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @since   0.12.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class DeprecatedClassesUnitTest extends AbstractSniffUnitTest {
+final class DeprecatedClassesUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/WordPress/Tests/WP/DeprecatedFunctionsUnitTest.php
+++ b/WordPress/Tests/WP/DeprecatedFunctionsUnitTest.php
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @since   0.11.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class DeprecatedFunctionsUnitTest extends AbstractSniffUnitTest {
+final class DeprecatedFunctionsUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/WordPress/Tests/WP/DeprecatedParameterValuesUnitTest.php
+++ b/WordPress/Tests/WP/DeprecatedParameterValuesUnitTest.php
@@ -18,7 +18,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since   1.0.0
  */
-class DeprecatedParameterValuesUnitTest extends AbstractSniffUnitTest {
+final class DeprecatedParameterValuesUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/WordPress/Tests/WP/DeprecatedParametersUnitTest.php
+++ b/WordPress/Tests/WP/DeprecatedParametersUnitTest.php
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @since   0.12.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class DeprecatedParametersUnitTest extends AbstractSniffUnitTest {
+final class DeprecatedParametersUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/WordPress/Tests/WP/DiscouragedConstantsUnitTest.php
+++ b/WordPress/Tests/WP/DiscouragedConstantsUnitTest.php
@@ -17,7 +17,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @package WPCS\WordPressCodingStandards
  * @since   0.14.0
  */
-class DiscouragedConstantsUnitTest extends AbstractSniffUnitTest {
+final class DiscouragedConstantsUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/WordPress/Tests/WP/DiscouragedFunctionsUnitTest.php
+++ b/WordPress/Tests/WP/DiscouragedFunctionsUnitTest.php
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @since   0.11.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class DiscouragedFunctionsUnitTest extends AbstractSniffUnitTest {
+final class DiscouragedFunctionsUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/WordPress/Tests/WP/EnqueuedResourceParametersUnitTest.php
+++ b/WordPress/Tests/WP/EnqueuedResourceParametersUnitTest.php
@@ -18,7 +18,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since   1.0.0
  */
-class EnqueuedResourceParametersUnitTest extends AbstractSniffUnitTest {
+final class EnqueuedResourceParametersUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/WordPress/Tests/WP/EnqueuedResourcesUnitTest.php
+++ b/WordPress/Tests/WP/EnqueuedResourcesUnitTest.php
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @since   0.3.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class EnqueuedResourcesUnitTest extends AbstractSniffUnitTest {
+final class EnqueuedResourcesUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/WordPress/Tests/WP/GlobalVariablesOverrideUnitTest.php
+++ b/WordPress/Tests/WP/GlobalVariablesOverrideUnitTest.php
@@ -21,7 +21,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @since   1.0.0  This sniff has been moved from the `Variables` category to the `WP`
  *                 category and renamed from `GlobalVariables` to `GlobalVariablesOverride`.
  */
-class GlobalVariablesOverrideUnitTest extends AbstractSniffUnitTest {
+final class GlobalVariablesOverrideUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/WordPress/Tests/WP/I18nUnitTest.php
+++ b/WordPress/Tests/WP/I18nUnitTest.php
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @since   0.10.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class I18nUnitTest extends AbstractSniffUnitTest {
+final class I18nUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Set CLI values before the file is tested.

--- a/WordPress/Tests/WP/PostsPerPageUnitTest.php
+++ b/WordPress/Tests/WP/PostsPerPageUnitTest.php
@@ -22,7 +22,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *                 limit being part of the WP category, and the check for pagination
  *                 disabling being part of the VIP category.
  */
-class PostsPerPageUnitTest extends AbstractSniffUnitTest {
+final class PostsPerPageUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/WordPress/Tests/WhiteSpace/CastStructureSpacingUnitTest.php
+++ b/WordPress/Tests/WhiteSpace/CastStructureSpacingUnitTest.php
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @since   0.3.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
  */
-class CastStructureSpacingUnitTest extends AbstractSniffUnitTest {
+final class CastStructureSpacingUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.php
+++ b/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.php
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @since   2013-06-11
  * @since   0.13.0     Class name changed: this class is now namespaced.
  */
-class ControlStructureSpacingUnitTest extends AbstractSniffUnitTest {
+final class ControlStructureSpacingUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/WordPress/Tests/WhiteSpace/ObjectOperatorSpacingUnitTest.php
+++ b/WordPress/Tests/WhiteSpace/ObjectOperatorSpacingUnitTest.php
@@ -18,7 +18,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since 3.0.0
  */
-class ObjectOperatorSpacingUnitTest extends AbstractSniffUnitTest {
+final class ObjectOperatorSpacingUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/WordPress/Tests/WhiteSpace/OperatorSpacingUnitTest.php
+++ b/WordPress/Tests/WhiteSpace/OperatorSpacingUnitTest.php
@@ -21,7 +21,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *                     The rest of the sniff is unit tested upstream.
  * @since   0.13.0     Class name changed: this class is now namespaced.
  */
-class OperatorSpacingUnitTest extends AbstractSniffUnitTest {
+final class OperatorSpacingUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.


### PR DESCRIPTION
### QA: make all test classes final

### QA: make all non-abstract sniff classes final

The PHPCS autoloader does not always play nice with sniffs which extend other sniffs, especially if both sniffs (parent and child) are included in the same standard.

To discourage sniffs extending each other, I propose making all non-abstract sniff classes `final`with the exception of four classes of which it is known that those are being extended based on a public code search.

The four exceptions are:
* `NamingConventions.ValidHookName`
* `Security.EscapeOutput`
* `Security.NonceVerification`
* `Security.ValidatedSanitizedInput`

If needs be, a sniff in an external standard can still _use_ logic from the WPCS sniffs. On the one hand, they can use the new `Helper` classes and traits. On the other hand, they can do a preliminary check on certain data and defer to a new or preinstantiated instance of a WPCS sniff for everything else.

Note: this list of sniffs being extended is likely incomplete.
If reports come in from external standards that they are running into trouble using alternative logic, we can still remove the `final` keyword from select sniffs in a patch release. However, adding the `final` keyword needs to be done in a major.

Ref:
* https://sourcegraph.com/search?q=context:global+use+WordPressCS+-repo:%5Egithub%5C.com/WordPress/WordPress-Coding-Standards%24+-repo:%5Egithub%5C.com/WPTT/WPThemeReview%24+-file:%5E%28.*/%29%3Fvendor/wp-coding-standards/.*%24&patternType=standard&case=yes&sm=0

### PHPCS: enforce classes to be abstract or final

... for the files in this package.