### PR TITLE
WP/I18n: complete refactor, implement PHPCSUtils, modern PHP and more

### DIFF
--- a/WordPress/Sniffs/WP/I18nSniff.php
+++ b/WordPress/Sniffs/WP/I18nSniff.php
@@ -123,18 +123,6 @@ final class I18nSniff extends AbstractFunctionParameterSniff {
 	);
 
 	/**
-	 * Toggle whether or not to check for translators comments for text string containing placeholders.
-	 *
-	 * Intended to make this part of the sniff unit testable, but can be used by end-users too,
-	 * though they can just as easily disable this via the sniff code.
-	 *
-	 * @since 0.11.0
-	 *
-	 * @var bool
-	 */
-	public $check_translator_comments = true;
-
-	/**
 	 * Whether or not the `default` text domain is one of the allowed text domains.
 	 *
 	 * @since 0.14.0
@@ -411,9 +399,7 @@ final class I18nSniff extends AbstractFunctionParameterSniff {
 		/*
 		 * Check if a translators comments is necessary and if so, if it exists.
 		 */
-		if ( true === $this->check_translator_comments ) {
-			$this->check_for_translator_comment( $stackPtr, $matched_content, $parameter_details );
-		}
+		$this->check_for_translator_comment( $stackPtr, $matched_content, $parameter_details );
 	}
 
 	/**

--- a/WordPress/Sniffs/WP/I18nSniff.php
+++ b/WordPress/Sniffs/WP/I18nSniff.php
@@ -235,10 +235,7 @@ final class I18nSniff extends AbstractFunctionRestrictionsSniff {
 	public function process_matched_token( $stack_ptr, $group_name, $matched_content ) {
 
 		$func_open_paren_token = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $stack_ptr + 1 ), null, true );
-		if ( false === $func_open_paren_token
-			|| \T_OPEN_PARENTHESIS !== $this->tokens[ $func_open_paren_token ]['code']
-			|| ! isset( $this->tokens[ $func_open_paren_token ]['parenthesis_closer'] )
-		) {
+		if ( ! isset( $this->tokens[ $func_open_paren_token ]['parenthesis_closer'] ) ) {
 			// Live coding, parse error or not a function call.
 			return;
 		}

--- a/WordPress/Sniffs/WP/I18nSniff.php
+++ b/WordPress/Sniffs/WP/I18nSniff.php
@@ -361,7 +361,7 @@ final class I18nSniff extends AbstractFunctionParameterSniff {
 				continue;
 			}
 
-			if ( 'domain' === $param_name && ! empty( $this->text_domain ) ) {
+			if ( 'domain' === $param_name ) {
 				$this->check_textdomain_matches( $matched_content, $param_name, $param_info );
 			}
 
@@ -543,6 +543,21 @@ final class I18nSniff extends AbstractFunctionParameterSniff {
 	 */
 	private function check_textdomain_matches( $matched_content, $param_name, $param_info ) {
 		$stripped_content = TextStrings::stripQuotes( $param_info['clean'] );
+
+		if ( empty( $this->text_domain ) && '' === $stripped_content ) {
+			$first_non_empty = $this->phpcsFile->findNext( Tokens::$emptyTokens, $param_info['start'], ( $param_info['end'] + 1 ), true );
+
+			$this->phpcsFile->addError(
+				'The passed $domain should never be an empty string. Either pass a text domain or remove the parameter.',
+				$first_non_empty,
+				'EmptyTextDomain'
+			);
+		}
+
+		if ( empty( $this->text_domain ) ) {
+			// Nothing more to do, the other checks all depend on a text domain being known.
+			return;
+		}
 
 		if ( ! \in_array( $stripped_content, $this->text_domain, true ) ) {
 			$first_non_empty = $this->phpcsFile->findNext( Tokens::$emptyTokens, $param_info['start'], ( $param_info['end'] + 1 ), true );

--- a/WordPress/Sniffs/WP/I18nSniff.php
+++ b/WordPress/Sniffs/WP/I18nSniff.php
@@ -669,9 +669,19 @@ final class I18nSniff extends AbstractFunctionParameterSniff {
 			);
 
 			if ( true === $fix ) {
+				$this->phpcsFile->fixer->beginChangeset();
+
 				$fixed_str = preg_replace( $replace_regexes, $replacements, $content, 1 );
 
 				$this->phpcsFile->fixer->replaceToken( $first_non_empty, $fixed_str );
+
+				$i = ( $first_non_empty + 1 );
+				while ( $i <= $param_info['end'] && isset( Tokens::$stringTokens[ $this->tokens[ $i ]['code'] ] ) ) {
+					$this->phpcsFile->fixer->replaceToken( $i, '' );
+					++$i;
+				}
+
+				$this->phpcsFile->fixer->endChangeset();
 			}
 		}
 	}

--- a/WordPress/Sniffs/WP/I18nSniff.php
+++ b/WordPress/Sniffs/WP/I18nSniff.php
@@ -12,9 +12,10 @@ namespace WordPressCS\WordPress\Sniffs\WP;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\BackCompat\Helper;
 use PHPCSUtils\Utils\MessageHelper;
+use PHPCSUtils\Utils\PassedParameters;
 use PHPCSUtils\Utils\TextStrings;
 use XMLReader;
-use WordPressCS\WordPress\AbstractFunctionRestrictionsSniff;
+use WordPressCS\WordPress\AbstractFunctionParameterSniff;
 use WordPressCS\WordPress\Helpers\RulesetPropertyHelper;
 
 /**
@@ -35,8 +36,11 @@ use WordPressCS\WordPress\Helpers\RulesetPropertyHelper;
  *                 `AbstractFunctionRestrictionSniff` class.
  *                 The parent `exclude` property is, however, disabled as it
  *                 would disable the whole sniff.
+ * @since   3.0.0  This class now extends the WordPressCS native
+ *                 `AbstractFunctionParameterSniff` class.
+ *                 The parent `exclude` property is still disabled.
  */
-final class I18nSniff extends AbstractFunctionRestrictionsSniff {
+final class I18nSniff extends AbstractFunctionParameterSniff {
 
 	/**
 	 * These Regexes were originally copied from https://www.php.net/function.sprintf#93552
@@ -86,9 +90,6 @@ final class I18nSniff extends AbstractFunctionRestrictionsSniff {
 
 	/**
 	 * Text domain.
-	 *
-	 * @todo Eventually this should be able to be auto-supplied via looking at $this->phpcsFile->getFilename()
-	 * @link https://youtrack.jetbrains.com/issue/WI-17740
 	 *
 	 * @var string[]|string
 	 */
@@ -152,6 +153,52 @@ final class I18nSniff extends AbstractFunctionRestrictionsSniff {
 	private $text_domain_is_default = false;
 
 	/**
+	 * Parameter specifications for the functions in each group.
+	 *
+	 * {@internal Even when not all parameters will be examined, the parameter list should still
+	 * be complete in the below array to allow for a correct "total parameters" calculation.}
+	 *
+	 * @since 3.0.0
+	 *
+	 * @var array Array of the parameter positions and names.
+	 */
+	private $parameter_specs = array(
+		'simple' => array(
+			1 => 'text',
+			2 => 'domain',
+		),
+		'context' => array(
+			1 => 'text',
+			2 => 'context',
+			3 => 'domain',
+		),
+		'number' => array(
+			1 => 'single',
+			2 => 'plural',
+			3 => 'number',
+			4 => 'domain',
+		),
+		'number_context' => array(
+			1 => 'single',
+			2 => 'plural',
+			3 => 'number',
+			4 => 'context',
+			5 => 'domain',
+		),
+		'noopnumber' => array(
+			1 => 'singular',
+			2 => 'plural',
+			3 => 'domain',
+		),
+		'noopnumber_context' => array(
+			1 => 'singular',
+			2 => 'plural',
+			3 => 'context',
+			4 => 'domain',
+		),
+	);
+
+	/**
 	 * Groups of functions to restrict.
 	 *
 	 * Example: groups => array(
@@ -184,11 +231,11 @@ final class I18nSniff extends AbstractFunctionRestrictionsSniff {
 	 *              whether something is a function call. The logic after that has
 	 *              been split off to the `process_matched_token()` method.
 	 *
-	 * @param int $stack_ptr The position of the current token in the stack.
+	 * @param int $stackPtr The position of the current token in the stack.
 	 *
 	 * @return void
 	 */
-	public function process_token( $stack_ptr ) {
+	public function process_token( $stackPtr ) {
 
 		// Reset defaults.
 		$this->text_domain_contains_default = false;
@@ -217,7 +264,7 @@ final class I18nSniff extends AbstractFunctionRestrictionsSniff {
 		// Prevent exclusion of the i18n group.
 		$this->exclude = array();
 
-		parent::process_token( $stack_ptr );
+		parent::process_token( $stackPtr );
 	}
 
 	/**
@@ -225,400 +272,373 @@ final class I18nSniff extends AbstractFunctionRestrictionsSniff {
 	 *
 	 * @since 1.0.0 Logic split off from the `process_token()` method.
 	 *
-	 * @param int    $stack_ptr       The position of the current token in the stack.
+	 * @param int    $stackPtr        The position of the current token in the stack.
 	 * @param string $group_name      The name of the group which was matched.
 	 * @param string $matched_content The token content (function name) which was matched.
 	 *
-	 * @return int|void Integer stack pointer to skip forward or void to continue
-	 *                  normal file processing.
+	 * @return void
 	 */
-	public function process_matched_token( $stack_ptr, $group_name, $matched_content ) {
+	public function process_matched_token( $stackPtr, $group_name, $matched_content ) {
 
-		$func_open_paren_token = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $stack_ptr + 1 ), null, true );
+		$func_open_paren_token = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true );
 		if ( ! isset( $this->tokens[ $func_open_paren_token ]['parenthesis_closer'] ) ) {
 			// Live coding, parse error or not a function call.
 			return;
 		}
 
 		if ( 'typos' === $group_name && '_' === $matched_content ) {
-			$this->phpcsFile->addError( 'Found single-underscore "_()" function when double-underscore expected.', $stack_ptr, 'SingleUnderscoreGetTextFunction' );
+			$this->phpcsFile->addError( 'Found single-underscore "_()" function when double-underscore expected.', $stackPtr, 'SingleUnderscoreGetTextFunction' );
 			return;
 		}
 
 		if ( \in_array( $matched_content, array( 'translate', 'translate_with_gettext_context' ), true ) ) {
-			$this->phpcsFile->addWarning( 'Use of the "%s()" function is reserved for low-level API usage.', $stack_ptr, 'LowLevelTranslationFunction', array( $matched_content ) );
+			$this->phpcsFile->addWarning( 'Use of the "%s()" function is reserved for low-level API usage.', $stackPtr, 'LowLevelTranslationFunction', array( $matched_content ) );
 		}
 
-		$arguments_tokens = array();
-		$argument_tokens  = array();
-		$tokens           = $this->tokens;
+		parent::process_matched_token( $stackPtr, $group_name, $matched_content );
+	}
 
-		// Look at arguments.
-		for ( $i = ( $func_open_paren_token + 1 ); $i < $this->tokens[ $func_open_paren_token ]['parenthesis_closer']; $i++ ) {
-			$this_token                = $this->tokens[ $i ];
-			$this_token['token_index'] = $i;
-			if ( isset( Tokens::$emptyTokens[ $this_token['code'] ] ) ) {
-				continue;
-			}
-			if ( \T_COMMA === $this_token['code'] ) {
-				$arguments_tokens[] = $argument_tokens;
-				$argument_tokens    = array();
-				continue;
-			}
+	/**
+	 * Process the function if no parameters were found.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @param int    $stackPtr        The position of the current token in the stack.
+	 * @param string $group_name      The name of the group which was matched.
+	 * @param string $matched_content The token content (function name) which was matched.
+	 *
+	 * @return void
+	 */
+	public function process_no_parameters( $stackPtr, $group_name, $matched_content ) {
+		$function_param_specs = $this->parameter_specs[ $this->i18n_functions[ $matched_content ] ];
 
-			// Merge consecutive single or double quoted strings (when they span multiple lines).
-			if ( isset( Tokens::$textStringTokens[ $this_token['code'] ] ) ) {
-				for ( $j = ( $i + 1 ); $j < $this->tokens[ $func_open_paren_token ]['parenthesis_closer']; $j++ ) {
-					if ( $this_token['code'] === $this->tokens[ $j ]['code'] ) {
-						$this_token['content'] .= $this->tokens[ $j ]['content'];
-						$i                      = $j;
-					} else {
-						break;
-					}
-				}
-			}
-			$argument_tokens[] = $this_token;
-
-			// Include everything up to and including the parenthesis_closer if this token has one.
-			if ( ! empty( $this_token['parenthesis_closer'] ) ) {
-				for ( $j = ( $i + 1 ); $j <= $this_token['parenthesis_closer']; $j++ ) {
-					$tokens[ $j ]['token_index'] = $j;
-					$argument_tokens[]           = $tokens[ $j ];
-				}
-				$i = $this_token['parenthesis_closer'];
-			}
-		}
-
-		if ( ! empty( $argument_tokens ) ) {
-			$arguments_tokens[] = $argument_tokens;
-		}
-		unset( $argument_tokens );
-
-		$argument_assertions = array();
-		if ( 'simple' === $this->i18n_functions[ $matched_content ] ) {
-			$argument_assertions[] = array(
-				'arg_name' => 'text',
-				'tokens'   => array_shift( $arguments_tokens ),
+		foreach ( $function_param_specs as $param_name ) {
+			$error_code = MessageHelper::stringToErrorcode( 'MissingArg' . ucfirst( $param_name ) );
+			$this->phpcsFile->addError(
+				'Missing $%s parameter in function call to %s().',
+				$stackPtr,
+				$error_code,
+				array( $param_name, $matched_content )
 			);
-			$argument_assertions[] = array(
-				'arg_name' => 'domain',
-				'tokens'   => array_shift( $arguments_tokens ),
-			);
-		} elseif ( 'context' === $this->i18n_functions[ $matched_content ] ) {
-			$argument_assertions[] = array(
-				'arg_name' => 'text',
-				'tokens'   => array_shift( $arguments_tokens ),
-			);
-			$argument_assertions[] = array(
-				'arg_name' => 'context',
-				'tokens'   => array_shift( $arguments_tokens ),
-			);
-			$argument_assertions[] = array(
-				'arg_name' => 'domain',
-				'tokens'   => array_shift( $arguments_tokens ),
-			);
-		} elseif ( 'number' === $this->i18n_functions[ $matched_content ] ) {
-			$argument_assertions[] = array(
-				'arg_name' => 'single',
-				'tokens'   => array_shift( $arguments_tokens ),
-			);
-			$argument_assertions[] = array(
-				'arg_name' => 'plural',
-				'tokens'   => array_shift( $arguments_tokens ),
-			);
-			array_shift( $arguments_tokens );
-			$argument_assertions[] = array(
-				'arg_name' => 'domain',
-				'tokens'   => array_shift( $arguments_tokens ),
-			);
-		} elseif ( 'number_context' === $this->i18n_functions[ $matched_content ] ) {
-			$argument_assertions[] = array(
-				'arg_name' => 'single',
-				'tokens'   => array_shift( $arguments_tokens ),
-			);
-			$argument_assertions[] = array(
-				'arg_name' => 'plural',
-				'tokens'   => array_shift( $arguments_tokens ),
-			);
-			array_shift( $arguments_tokens );
-			$argument_assertions[] = array(
-				'arg_name' => 'context',
-				'tokens'   => array_shift( $arguments_tokens ),
-			);
-			$argument_assertions[] = array(
-				'arg_name' => 'domain',
-				'tokens'   => array_shift( $arguments_tokens ),
-			);
-		} elseif ( 'noopnumber' === $this->i18n_functions[ $matched_content ] ) {
-			$argument_assertions[] = array(
-				'arg_name' => 'single',
-				'tokens'   => array_shift( $arguments_tokens ),
-			);
-			$argument_assertions[] = array(
-				'arg_name' => 'plural',
-				'tokens'   => array_shift( $arguments_tokens ),
-			);
-			$argument_assertions[] = array(
-				'arg_name' => 'domain',
-				'tokens'   => array_shift( $arguments_tokens ),
-			);
-		} elseif ( 'noopnumber_context' === $this->i18n_functions[ $matched_content ] ) {
-			$argument_assertions[] = array(
-				'arg_name' => 'single',
-				'tokens'   => array_shift( $arguments_tokens ),
-			);
-			$argument_assertions[] = array(
-				'arg_name' => 'plural',
-				'tokens'   => array_shift( $arguments_tokens ),
-			);
-			$argument_assertions[] = array(
-				'arg_name' => 'context',
-				'tokens'   => array_shift( $arguments_tokens ),
-			);
-			$argument_assertions[] = array(
-				'arg_name' => 'domain',
-				'tokens'   => array_shift( $arguments_tokens ),
-			);
-		}
-
-		if ( ! empty( $arguments_tokens ) ) {
-			$this->phpcsFile->addError( 'Too many arguments for function "%s".', $func_open_paren_token, 'TooManyFunctionArgs', array( $matched_content ) );
-		}
-
-		foreach ( $argument_assertions as $argument_assertion_context ) {
-			if ( empty( $argument_assertion_context['tokens'][0] ) ) {
-				$argument_assertion_context['stack_ptr'] = $func_open_paren_token;
-			} else {
-				$argument_assertion_context['stack_ptr'] = $argument_assertion_context['tokens'][0]['token_index'];
-			}
-			$this->check_argument_tokens( $argument_assertion_context );
-		}
-
-		/*
-		 * For _n*() calls, compare the singular and plural strings.
-		 * If either of the arguments is missing, empty or has more than 1 token, skip out.
-		 * An error for that will already have been reported via the `check_argument_tokens()` method.
-		 */
-		if ( false !== strpos( $this->i18n_functions[ $matched_content ], 'number' )
-			&& isset( $argument_assertions[0]['tokens'], $argument_assertions[1]['tokens'] )
-			&& count( $argument_assertions[0]['tokens'] ) === 1
-			&& count( $argument_assertions[1]['tokens'] ) === 1
-		) {
-			$single_context = $argument_assertions[0];
-			$plural_context = $argument_assertions[1];
-
-			$this->compare_single_and_plural_arguments( $stack_ptr, $single_context, $plural_context );
-		}
-
-		if ( true === $this->check_translator_comments ) {
-			$this->check_for_translator_comment( $stack_ptr, $argument_assertions );
 		}
 	}
 
 	/**
-	 * Check if supplied tokens represent a translation text string literal.
+	 * Process the parameters of a matched function.
 	 *
-	 * @param array $context Context (@todo needs better description).
-	 * @return bool
+	 * @since 3.0.0
+	 *
+	 * @param int    $stackPtr        The position of the current token in the stack.
+	 * @param string $group_name      The name of the group which was matched.
+	 * @param string $matched_content The token content (function name) which was matched.
+	 * @param array  $parameters      Array with information about the parameters.
+	 *
+	 * @return void
 	 */
-	protected function check_argument_tokens( $context ) {
-		$stack_ptr = $context['stack_ptr'];
-		$tokens    = $context['tokens'];
-		$arg_name  = $context['arg_name'];
-		$is_error  = empty( $context['warning'] );
-		$content   = isset( $tokens[0] ) ? $tokens[0]['content'] : '';
+	public function process_parameters( $stackPtr, $group_name, $matched_content, $parameters ) {
+		/*
+		 * Retrieve the individual parameters from the array in a way that we know which is which.
+		 */
+		$parameter_details = array();
 
-		if ( empty( $tokens ) || 0 === \count( $tokens ) ) {
-			$code = MessageHelper::stringToErrorcode( 'MissingArg' . ucfirst( $arg_name ) );
-			if ( 'domain' !== $arg_name ) {
-				MessageHelper::addMessage( $this->phpcsFile, 'Missing $%s arg.', $stack_ptr, $is_error, $code, array( $arg_name ) );
+		$function_param_specs = $this->parameter_specs[ $this->i18n_functions[ $matched_content ] ];
+		$expected_args        = count( $function_param_specs );
+
+		foreach ( $function_param_specs as $position => $name ) {
+			if ( 'number' === $name ) {
+				// This sniff does not examine the $number parameter.
+				continue;
+			}
+
+			$parameter_details[ $name ] = PassedParameters::getParameterFromStack( $parameters, $position, $name );
+		}
+
+		/*
+		 * Examine the individual parameters.
+		 */
+		$this->check_argument_count( $stackPtr, $matched_content, $parameters, $expected_args );
+
+		foreach ( $parameter_details as $param_name => $param_info ) {
+			$is_string_literal = $this->check_argument_is_string_literal( $stackPtr, $matched_content, $param_name, $param_info );
+
+			/*
+			 * If the parameter exists, remember whether the argument was a valid string literal.
+			 * This is used in a few places to determine whether the checks which examine a text string should run.
+			 */
+			if ( false !== $param_info ) {
+				$parameter_details[ $param_name ]['is_string_literal'] = $is_string_literal;
+			}
+
+			if ( false === $is_string_literal ) {
+				continue;
+			}
+
+			if ( 'domain' === $param_name && ! empty( $this->text_domain ) ) {
+				$this->check_textdomain_matches( $matched_content, $param_name, $param_info );
+			}
+
+			if ( \in_array( $param_name, array( 'text', 'single', 'singular', 'plural' ), true ) ) {
+				$this->check_placeholders_in_string( $matched_content, $param_name, $param_info );
+				$has_content = $this->check_string_has_translatable_content( $matched_content, $param_name, $param_info );
+				if ( true === $has_content ) {
+					$this->check_string_has_no_html_wrapper( $matched_content, $param_name, $param_info );
+				}
+			}
+		}
+
+		/*
+		 * For _n*() calls, compare the singular and plural strings.
+		 *
+		 * If either of the arguments is missing, empty or has more than 1 token, skip out.
+		 * An error for that will already have been reported via the `check_argument_is_string_literal()` method.
+		 */
+		$single_details = null;
+		if ( isset( $parameter_details['single'] ) ) {
+			$single_details = $parameter_details['single'];
+		} elseif ( isset( $parameter_details['singular'] ) ) {
+			$single_details = $parameter_details['singular'];
+		}
+
+		if ( isset( $single_details, $parameter_details['plural'] )
+			&& false !== $single_details
+			&& false !== $parameter_details['plural']
+			&& true === $single_details['is_string_literal']
+			&& true === $parameter_details['plural']['is_string_literal']
+		) {
+			$this->compare_single_and_plural_arguments( $stackPtr, $single_details, $parameter_details['plural'] );
+		}
+
+		/*
+		 * Check if a translators comments is necessary and if so, if it exists.
+		 */
+		if ( true === $this->check_translator_comments ) {
+			$this->check_for_translator_comment( $stackPtr, $matched_content, $parameter_details );
+		}
+	}
+
+	/**
+	 * Verify that there are no superfluous function arguments.
+	 *
+	 * @since 3.0.0 Check moved from the `process_matched_token()` method to this method.
+	 *
+	 * @param int    $stackPtr        The position of the current token in the stack.
+	 * @param string $matched_content The token content (function name) which was matched.
+	 * @param array  $parameters      The parameters array.
+	 * @param int    $expected_count  The expected number of passed arguments.
+	 *
+	 * @return void
+	 */
+	private function check_argument_count( $stackPtr, $matched_content, $parameters, $expected_count ) {
+		$actual_count = count( $parameters );
+		if ( $actual_count > $expected_count ) {
+			$this->phpcsFile->addError(
+				'Too many parameters passed to function "%s()". Expected: %s parameters, received: %s',
+				$stackPtr,
+				'TooManyFunctionArgs',
+				array( $matched_content, $expected_count, $actual_count )
+			);
+		}
+	}
+
+	/**
+	 * Check if an arbitrary function call parameter is a text string literal suitable for use in the translation functions.
+	 *
+	 * Will also check and warn about missing parameters.
+	 *
+	 * @since 3.0.0 Most of the logic in this method used to be contained in the, now removed, `check_argument_tokens()` method.
+	 *
+	 * @param int         $stackPtr        The position of the current token in the stack.
+	 * @param string      $matched_content The token content (function name) which was matched.
+	 * @param string      $param_name      The name of the parameter being examined.
+	 * @param array|false $param_info      Parameter info array for an individual parameter,
+	 *                                     as received from the PassedParemeters class.
+	 *
+	 * @return bool Whether or not the argument is a string literal.
+	 */
+	private function check_argument_is_string_literal( $stackPtr, $matched_content, $param_name, $param_info ) {
+		/*
+		 * Check if the parameter was supplied.
+		 */
+		if ( false === $param_info || '' === $param_info['clean'] ) {
+			$error_code = MessageHelper::stringToErrorcode( 'MissingArg' . ucfirst( $param_name ) );
+
+			/*
+			 * Special case the text domain parameter, which is allowed to be "missing"
+			 * when set to `default` (= WP Core translation).
+			 */
+			if ( 'domain' === $param_name ) {
+				if ( empty( $this->text_domain ) ) {
+					// If no text domain is passed, presume WP Core.
+					return false;
+				}
+
+				if ( true === $this->text_domain_is_default ) {
+					return false;
+				}
+
+				if ( true === $this->text_domain_contains_default ) {
+					$this->phpcsFile->addWarning(
+						'Missing $%s parameter in function call to %s(). If this text string is supposed to use a WP Core translation, use the "default" text domain.',
+						$stackPtr,
+						$error_code . 'Default',
+						array( $param_name, $matched_content )
+					);
+					return false;
+				}
+			}
+
+			$this->phpcsFile->addError(
+				'Missing $%s parameter in function call to %s().',
+				$stackPtr,
+				$error_code,
+				array( $param_name, $matched_content )
+			);
+
+			return false;
+		}
+
+		/*
+		 * Check if the parameter consists of one singular text string literal.
+		 * Heredoc/nowdocs not allowed. Multi-line single/double quoted strings are allowed.
+		 */
+		$first_non_empty = $this->phpcsFile->findNext( Tokens::$emptyTokens, $param_info['start'], ( $param_info['end'] + 1 ), true );
+		for ( $i = $first_non_empty; $i <= $param_info['end']; $i++ ) {
+			if ( isset( Tokens::$emptyTokens[ $this->tokens[ $i ]['code'] ] ) ) {
+				continue;
+			}
+
+			if ( isset( Tokens::$stringTokens[ $this->tokens[ $i ]['code'] ] ) === false ) {
+				$error_code = MessageHelper::stringToErrorcode( 'NonSingularStringLiteral' . ucfirst( $param_name ) );
+				$this->phpcsFile->addError(
+					'The $%s parameter must be a single text string literal. Found: %s',
+					$first_non_empty,
+					$error_code,
+					array( $param_name, $param_info['clean'] )
+				);
 				return false;
 			}
-
-			// Ok, we're examining a text domain, now deal correctly with the 'default' text domain.
-			if ( true === $this->text_domain_is_default ) {
-				return true;
-			}
-
-			if ( true === $this->text_domain_contains_default ) {
-				$this->phpcsFile->addWarning(
-					'Missing $%s arg. If this text string is supposed to use a WP Core translation, use the "default" text domain.',
-					$stack_ptr,
-					$code . 'Default',
-					array( $arg_name )
-				);
-			} elseif ( ! empty( $this->text_domain ) ) {
-				MessageHelper::addMessage( $this->phpcsFile, 'Missing $%s arg.', $stack_ptr, $is_error, $code, array( $arg_name ) );
-			}
-
-			return false;
 		}
 
-		if ( \count( $tokens ) > 1 ) {
-			$contents = '';
-			foreach ( $tokens as $token ) {
-				$contents .= $token['content'];
-			}
-			$code = MessageHelper::stringToErrorcode( 'NonSingularStringLiteral' . ucfirst( $arg_name ) );
-			MessageHelper::addMessage(
-				$this->phpcsFile,
-				'The $%s arg must be a single string literal, not "%s".',
-				$stack_ptr,
-				$is_error,
-				$code,
-				array( $arg_name, $contents )
-			);
-			return false;
-		}
+		/*
+		 * Make sure the text string does not contain any interpolated variable.
+		 */
+		if ( \T_DOUBLE_QUOTED_STRING === $this->tokens[ $first_non_empty ]['code'] ) {
+			$error_code = MessageHelper::stringToErrorcode( 'InterpolatedVariable' . ucfirst( $param_name ) );
 
-		if ( \in_array( $arg_name, array( 'text', 'single', 'plural' ), true ) ) {
-			$this->check_text( $context );
-		}
-
-		if ( \T_DOUBLE_QUOTED_STRING === $tokens[0]['code'] || \T_HEREDOC === $tokens[0]['code'] ) {
-			$interpolated_variables = TextStrings::getEmbeds( $content );
+			$interpolated_variables = TextStrings::getEmbeds( $param_info['clean'] );
 			foreach ( $interpolated_variables as $interpolated_variable ) {
-				$code = MessageHelper::stringToErrorcode( 'InterpolatedVariable' . ucfirst( $arg_name ) );
-				MessageHelper::addMessage(
-					$this->phpcsFile,
-					'The $%s arg must not contain interpolated variables or expressions. Found "%s".',
-					$stack_ptr,
-					$is_error,
-					$code,
-					array( $arg_name, $interpolated_variable )
+				$this->phpcsFile->addError(
+					'The $%s parameter must not contain interpolated variables or expressions. Found: %s',
+					$first_non_empty,
+					$error_code,
+					array( $param_name, $interpolated_variable )
 				);
 			}
+
 			if ( ! empty( $interpolated_variables ) ) {
 				return false;
 			}
 		}
 
-		if ( isset( Tokens::$textStringTokens[ $tokens[0]['code'] ] ) ) {
-			if ( 'domain' === $arg_name && ! empty( $this->text_domain ) ) {
-				$stripped_content = TextStrings::stripQuotes( $content );
+		return true;
+	}
 
-				if ( ! \in_array( $stripped_content, $this->text_domain, true ) ) {
-					MessageHelper::addMessage(
-						$this->phpcsFile,
-						'Mismatched text domain. Expected \'%s\' but got %s.',
-						$stack_ptr,
-						$is_error,
-						'TextDomainMismatch',
-						array( implode( "' or '", $this->text_domain ), $content )
-					);
-					return false;
-				}
+	/**
+	 * Check the correct text domain is being used.
+	 *
+	 * @since 3.0.0 The logic in this method used to be contained in the, now removed, `check_argument_tokens()` method.
+	 *
+	 * @param string      $matched_content The token content (function name) which was matched.
+	 * @param string      $param_name      The name of the parameter being examined.
+	 * @param array|false $param_info      Parameter info array for an individual parameter,
+	 *                                     as received from the PassedParemeters class.
+	 *
+	 * @return void
+	 */
+	private function check_textdomain_matches( $matched_content, $param_name, $param_info ) {
+		$stripped_content = TextStrings::stripQuotes( $param_info['clean'] );
 
-				if ( true === $this->text_domain_is_default && 'default' === $stripped_content ) {
-					$fixable    = false;
-					$error      = 'No need to supply the text domain when the only accepted text domain is "default".';
-					$error_code = 'SuperfluousDefaultTextDomain';
+		if ( ! \in_array( $stripped_content, $this->text_domain, true ) ) {
+			$first_non_empty = $this->phpcsFile->findNext( Tokens::$emptyTokens, $param_info['start'], ( $param_info['end'] + 1 ), true );
 
-					if ( $tokens[0]['token_index'] === $stack_ptr ) {
-						$prev = $this->phpcsFile->findPrevious( \T_WHITESPACE, ( $stack_ptr - 1 ), null, true );
-						if ( false !== $prev && \T_COMMA === $this->tokens[ $prev ]['code'] ) {
-							$fixable = true;
-						}
-					}
+			$this->phpcsFile->addError(
+				'Mismatched text domain. Expected \'%s\' but got %s.',
+				$first_non_empty,
+				'TextDomainMismatch',
+				array( implode( "' or '", $this->text_domain ), $param_info['clean'] )
+			);
+			return;
+		}
 
-					if ( false === $fixable ) {
-						$this->phpcsFile->addWarning( $error, $stack_ptr, $error_code );
-						return false;
-					}
+		if ( true === $this->text_domain_is_default && 'default' === $stripped_content ) {
+			$fixable    = false;
+			$error      = 'No need to supply the text domain in function call to %s() when the only accepted text domain is "default".';
+			$error_code = 'SuperfluousDefaultTextDomain';
+			$data       = array( $matched_content );
 
-					$fix = $this->phpcsFile->addFixableWarning( $error, $stack_ptr, $error_code );
-					if ( true === $fix ) {
-						// Remove preceeding comma, whitespace and the text domain token.
-						$this->phpcsFile->fixer->beginChangeset();
-						for ( $i = $prev; $i <= $stack_ptr; $i++ ) {
-							$this->phpcsFile->fixer->replaceToken( $i, '' );
-						}
-						$this->phpcsFile->fixer->endChangeset();
-					}
+			$first_non_empty = $this->phpcsFile->findNext( Tokens::$emptyTokens, $param_info['start'], ( $param_info['end'] + 1 ), true );
 
-					return false;
-				}
+			$before_param = $this->phpcsFile->findPrevious( \T_WHITESPACE, ( $first_non_empty - 1 ), null, true );
+			if ( \T_COMMA === $this->tokens[ $before_param ]['code'] ) {
+				$fixable = true;
 			}
 
-			return true;
-		}
+			if ( false === $fixable ) {
+				$this->phpcsFile->addWarning( $error, $first_non_empty, $error_code, $data );
+				return;
+			}
 
-		$code = MessageHelper::stringToErrorcode( 'NonSingularStringLiteral' . ucfirst( $arg_name ) );
-		MessageHelper::addMessage(
-			$this->phpcsFile,
-			'The $%s arg must be a single string literal, not "%s".',
-			$stack_ptr,
-			$is_error,
-			$code,
-			array( $arg_name, $content )
-		);
-		return false;
-	}
-
-	/**
-	 * Check for inconsistencies between single and plural arguments.
-	 *
-	 * @param int   $stack_ptr      The position of the current token in the stack.
-	 * @param array $single_context Single context (@todo needs better description).
-	 * @param array $plural_context Plural context (@todo needs better description).
-	 * @return void
-	 */
-	protected function compare_single_and_plural_arguments( $stack_ptr, $single_context, $plural_context ) {
-		$single_content = $single_context['tokens'][0]['content'];
-		$plural_content = $plural_context['tokens'][0]['content'];
-
-		preg_match_all( self::SPRINTF_PLACEHOLDER_REGEX, $single_content, $single_placeholders );
-		$single_placeholders = $single_placeholders[0];
-
-		preg_match_all( self::SPRINTF_PLACEHOLDER_REGEX, $plural_content, $plural_placeholders );
-		$plural_placeholders = $plural_placeholders[0];
-
-		// English conflates "singular" with "only one", described in the codex:
-		// https://codex.wordpress.org/I18n_for_WordPress_Developers#Plurals .
-		if ( \count( $single_placeholders ) < \count( $plural_placeholders ) ) {
-			$error_string = 'Missing singular placeholder, needed for some languages. See https://codex.wordpress.org/I18n_for_WordPress_Developers#Plurals';
-			$single_index = $single_context['tokens'][0]['token_index'];
-
-			$this->phpcsFile->addError( $error_string, $single_index, 'MissingSingularPlaceholder' );
-		}
-
-		// Reordering is fine, but mismatched placeholders is probably wrong.
-		sort( $single_placeholders );
-		sort( $plural_placeholders );
-
-		if ( $single_placeholders !== $plural_placeholders ) {
-			$this->phpcsFile->addWarning( 'Mismatched placeholders is probably an error', $stack_ptr, 'MismatchedPlaceholders' );
+			$fix = $this->phpcsFile->addFixableWarning( $error, $first_non_empty, $error_code, $data );
+			if ( true === $fix ) {
+				// Remove preceeding comma, whitespace and the text domain token.
+				$this->phpcsFile->fixer->beginChangeset();
+				for ( $i = $before_param; $i <= $first_non_empty; $i++ ) {
+					$this->phpcsFile->fixer->replaceToken( $i, '' );
+				}
+				$this->phpcsFile->fixer->endChangeset();
+			}
 		}
 	}
 
 	/**
-	 * Check the string itself for problems.
+	 * Check the placeholders used in translatable text for common problems.
 	 *
-	 * @param array $context Context (@todo needs better description).
+	 * @since 3.0.0 The logic in this method used to be contained in the, now removed, `check_text()` method.
+	 *
+	 * @param string      $matched_content The token content (function name) which was matched.
+	 * @param string      $param_name      The name of the parameter being examined.
+	 * @param array|false $param_info      Parameter info array for an individual parameter,
+	 *                                     as received from the PassedParemeters class.
+	 *
 	 * @return void
 	 */
-	protected function check_text( $context ) {
-		$stack_ptr = $context['stack_ptr'];
-		$arg_name  = $context['arg_name'];
-		$content   = $context['tokens'][0]['content'];
-		$is_error  = empty( $context['warning'] );
+	private function check_placeholders_in_string( $matched_content, $param_name, $param_info ) {
+		$content = $param_info['clean'];
 
 		// UnorderedPlaceholders: Check for multiple unordered placeholders.
 		$unordered_matches_count = preg_match_all( self::UNORDERED_SPRINTF_PLACEHOLDER_REGEX, $content, $unordered_matches );
 		$unordered_matches       = $unordered_matches[0];
 		$all_matches_count       = preg_match_all( self::SPRINTF_PLACEHOLDER_REGEX, $content, $all_matches );
 
-		if ( $unordered_matches_count > 0 && $unordered_matches_count !== $all_matches_count && $all_matches_count > 1 ) {
-			$code = MessageHelper::stringToErrorcode( 'MixedOrderedPlaceholders' . ucfirst( $arg_name ) );
-			$this->phpcsFile->addError(
-				'Multiple placeholders should be ordered. Mix of ordered and non-ordered placeholders found. Found: %s.',
-				$stack_ptr,
-				$code,
-				array( implode( ', ', $all_matches[0] ) )
-			);
+		if ( $unordered_matches_count > 0
+			&& $unordered_matches_count !== $all_matches_count
+			&& $all_matches_count > 1
+		) {
+			$first_non_empty = $this->phpcsFile->findNext( Tokens::$emptyTokens, $param_info['start'], ( $param_info['end'] + 1 ), true );
+			$error_code      = MessageHelper::stringToErrorcode( 'MixedOrderedPlaceholders' . ucfirst( $param_name ) );
 
-		} elseif ( $unordered_matches_count >= 2 ) {
-			$code = MessageHelper::stringToErrorcode( 'UnorderedPlaceholders' . ucfirst( $arg_name ) );
+			$this->phpcsFile->addError(
+				'Multiple placeholders in translatable strings should be ordered. Mix of ordered and non-ordered placeholders found. Found: "%s" in %s.',
+				$first_non_empty,
+				$error_code,
+				array( implode( ', ', $all_matches[0] ), $param_info['clean'] )
+			);
+			return;
+		}
+
+		if ( $unordered_matches_count >= 2 ) {
+			$first_non_empty = $this->phpcsFile->findNext( Tokens::$emptyTokens, $param_info['start'], ( $param_info['end'] + 1 ), true );
+			$error_code      = MessageHelper::stringToErrorcode( 'UnorderedPlaceholders' . ucfirst( $param_name ) );
 
 			$suggestions     = array();
 			$replace_regexes = array();
@@ -628,48 +648,79 @@ final class I18nSniff extends AbstractFunctionRestrictionsSniff {
 				$to_insert        .= ( '"' !== $content[0] ) ? '$' : '\$';
 				$suggestions[ $i ] = substr_replace( $unordered_matches[ $i ], $to_insert, 1, 0 );
 
-				// Prepare the strings for use a regex.
+				// Prepare the strings for use in a regex.
 				$replace_regexes[ $i ] = '`\Q' . $unordered_matches[ $i ] . '\E`';
-				// Note: the initial \\ is a literal \, the four \ in the replacement translate to also to a literal \.
+				// Note: the initial \\ is a literal \, the four \ in the replacement translate also to a literal \.
 				$replacements[ $i ] = str_replace( '\\', '\\\\', $suggestions[ $i ] );
 				// Note: the $ needs escaping to prevent numeric sequences after the $ being interpreted as match replacements.
 				$replacements[ $i ] = str_replace( '$', '\\$', $replacements[ $i ] );
 			}
 
-			$fix = MessageHelper::addFixableMessage(
-				$this->phpcsFile,
-				'Multiple placeholders should be ordered. Expected \'%s\', but got %s.',
-				$stack_ptr,
-				$is_error,
-				$code,
-				array( implode( ', ', $suggestions ), implode( ', ', $unordered_matches ) )
+			$fix = $this->phpcsFile->addFixableError(
+				'Multiple placeholders in translatable strings should be ordered. Expected "%s", but got "%s" in %s.',
+				$first_non_empty,
+				$error_code,
+				array( implode( ', ', $suggestions ), implode( ', ', $unordered_matches ), $param_info['clean'] )
 			);
 
 			if ( true === $fix ) {
 				$fixed_str = preg_replace( $replace_regexes, $replacements, $content, 1 );
 
-				$this->phpcsFile->fixer->replaceToken( $stack_ptr, $fixed_str );
+				$this->phpcsFile->fixer->replaceToken( $first_non_empty, $fixed_str );
 			}
 		}
+	}
 
-		/*
-		 * NoEmptyStrings.
-		 *
-		 * Strip placeholders and surrounding quotes.
-		 */
-		$content_without_quotes  = trim( TextStrings::stripQuotes( $content ) );
+	/**
+	 * Check if a parameter which is supposed to hold translatable text actually has translatable text.
+	 *
+	 * @since 3.0.0 The logic in this method used to be contained in the, now removed, `check_text()` method.
+	 *
+	 * @param string      $matched_content The token content (function name) which was matched.
+	 * @param string      $param_name      The name of the parameter being examined.
+	 * @param array|false $param_info      Parameter info array for an individual parameter,
+	 *                                     as received from the PassedParemeters class.
+	 *
+	 * @return bool Whether or not the text string has translatable content.
+	 */
+	private function check_string_has_translatable_content( $matched_content, $param_name, $param_info ) {
+		// Strip placeholders and surrounding quotes.
+		$content_without_quotes  = trim( TextStrings::stripQuotes( $param_info['clean'] ) );
 		$non_placeholder_content = preg_replace( self::SPRINTF_PLACEHOLDER_REGEX, '', $content_without_quotes );
 
 		if ( '' === $non_placeholder_content ) {
-			$this->phpcsFile->addError( 'Strings should have translatable content', $stack_ptr, 'NoEmptyStrings' );
-			return;
+			$first_non_empty = $this->phpcsFile->findNext( Tokens::$emptyTokens, $param_info['start'], ( $param_info['end'] + 1 ), true );
+
+			$this->phpcsFile->addError(
+				'The $%s text string should have translatable content. Found: %s',
+				$first_non_empty,
+				'NoEmptyStrings',
+				array( $param_name, $param_info['clean'] )
+			);
+			return false;
 		}
 
-		/*
-		 * NoHtmlWrappedStrings
-		 *
-		 * Strip surrounding quotes.
-		 */
+		return true;
+	}
+
+	/**
+	 * Ensure that a translatable text string is not wrapped in HTML code.
+	 *
+	 * If the text is wrapped in HTML, the HTML should be moved out of the translatable text string.
+	 *
+	 * @since 3.0.0 The logic in this method used to be contained in the, now removed, `check_text()` method.
+	 *
+	 * @param string      $matched_content The token content (function name) which was matched.
+	 * @param string      $param_name      The name of the parameter being examined.
+	 * @param array|false $param_info      Parameter info array for an individual parameter,
+	 *                                     as received from the PassedParemeters class.
+	 *
+	 * @return void
+	 */
+	private function check_string_has_no_html_wrapper( $matched_content, $param_name, $param_info ) {
+		// Strip surrounding quotes.
+		$content_without_quotes = trim( TextStrings::stripQuotes( $param_info['clean'] ) );
+
 		$reader = new XMLReader();
 		$reader->XML( $content_without_quotes, 'UTF-8', \LIBXML_NOERROR | \LIBXML_ERR_NONE | \LIBXML_NOWARNING );
 
@@ -696,106 +747,169 @@ final class I18nSniff extends AbstractFunctionRestrictionsSniff {
 
 		// Does the entire string only consist of this HTML node?
 		if ( $reader->readOuterXml() === $content_without_quotes ) {
-			$this->phpcsFile->addWarning( 'Strings should not be wrapped in HTML', $stack_ptr, 'NoHtmlWrappedStrings' );
+			$first_non_empty = $this->phpcsFile->findNext( Tokens::$emptyTokens, $param_info['start'], ( $param_info['end'] + 1 ), true );
+
+			$this->phpcsFile->addWarning(
+				'Translatable string should not be wrapped in HTML. Found: %s',
+				$first_non_empty,
+				'NoHtmlWrappedStrings',
+				array( $param_info['clean'] )
+			);
+		}
+	}
+
+	/**
+	 * Check for inconsistencies in the placeholders between single and plural form of the translatable text string.
+	 *
+	 * @since 3.0.0 - The parameter names and expected format for the $param_info_single
+	 *                and the $param_info_plural parameters has changed.
+	 *              - The method visibility has been changed from `protected` to `private`.
+	 *
+	 * @param int   $stackPtr          The position of the function call token in the stack.
+	 * @param array $param_info_single Parameter info array for the `$single` parameter,
+	 *                                 as received from the PassedParemeters class.
+	 * @param array $param_info_plural Parameter info array for the `$plural` parameter,
+	 *                                 as received from the PassedParemeters class.
+	 *
+	 * @return void
+	 */
+	private function compare_single_and_plural_arguments( $stackPtr, $param_info_single, $param_info_plural ) {
+		$single_content = $param_info_single['clean'];
+		$plural_content = $param_info_plural['clean'];
+
+		preg_match_all( self::SPRINTF_PLACEHOLDER_REGEX, $single_content, $single_placeholders );
+		$single_placeholders = $single_placeholders[0];
+
+		preg_match_all( self::SPRINTF_PLACEHOLDER_REGEX, $plural_content, $plural_placeholders );
+		$plural_placeholders = $plural_placeholders[0];
+
+		// English conflates "singular" with "only one", described in the codex:
+		// https://codex.wordpress.org/I18n_for_WordPress_Developers#Plurals .
+		if ( \count( $single_placeholders ) < \count( $plural_placeholders ) ) {
+			$error_string           = 'Missing singular placeholder, needed for some languages. See https://codex.wordpress.org/I18n_for_WordPress_Developers#Plurals';
+			$first_non_empty_single = $this->phpcsFile->findNext( Tokens::$emptyTokens, $param_info_single['start'], ( $param_info_single['end'] + 1 ), true );
+
+			$this->phpcsFile->addError( $error_string, $first_non_empty_single, 'MissingSingularPlaceholder' );
+			return;
+		}
+
+		// Reordering is fine, but mismatched placeholders is probably wrong.
+		sort( $single_placeholders, \SORT_NATURAL );
+		sort( $plural_placeholders, \SORT_NATURAL );
+
+		if ( $single_placeholders !== $plural_placeholders ) {
+			$this->phpcsFile->addWarning( 'Mismatched placeholders is probably an error', $stackPtr, 'MismatchedPlaceholders' );
 		}
 	}
 
 	/**
 	 * Check for the presence of a translators comment if one of the text strings contains a placeholder.
 	 *
-	 * @param int   $stack_ptr The position of the gettext call token in the stack.
-	 * @param array $args      The function arguments.
+	 * @since 3.0.0 - The parameter names and expected format for the $parameters parameter has changed.
+	 *              - The method visibility has been changed from `protected` to `private`.
+	 *
+	 * @param int    $stackPtr        The position of the gettext call token in the stack.
+	 * @param string $matched_content The token content (function name) which was matched.
+	 * @param array  $parameters      Array with information about the parameters.
+	 *
 	 * @return void
 	 */
-	protected function check_for_translator_comment( $stack_ptr, $args ) {
-		foreach ( $args as $arg ) {
-			if ( false === \in_array( $arg['arg_name'], array( 'text', 'single', 'plural' ), true ) ) {
+	private function check_for_translator_comment( $stackPtr, $matched_content, $parameters ) {
+		$needs_translators_comment = false;
+
+		foreach ( $parameters as $param_name => $param_info ) {
+			if ( false === \in_array( $param_name, array( 'text', 'single', 'singular', 'plural' ), true ) ) {
 				continue;
 			}
 
-			if ( empty( $arg['tokens'] ) ) {
+			if ( false === $param_info || false === $param_info['is_string_literal'] ) {
 				continue;
 			}
 
-			foreach ( $arg['tokens'] as $token ) {
-				if ( empty( $token['content'] ) ) {
-					continue;
-				}
-
-				if ( preg_match( self::SPRINTF_PLACEHOLDER_REGEX, $token['content'], $placeholders ) < 1 ) {
-					// No placeholders found.
-					continue;
-				}
-
-				$previous_comment = $this->phpcsFile->findPrevious( Tokens::$commentTokens, ( $stack_ptr - 1 ) );
-
-				if ( false !== $previous_comment ) {
-					/*
-					 * Check that the comment is either on the line before the gettext call or
-					 * if it's not, that there is only whitespace between.
-					 */
-					$correctly_placed = false;
-
-					if ( ( $this->tokens[ $previous_comment ]['line'] + 1 ) === $this->tokens[ $stack_ptr ]['line'] ) {
-						$correctly_placed = true;
-					} else {
-						$next_non_whitespace = $this->phpcsFile->findNext( \T_WHITESPACE, ( $previous_comment + 1 ), $stack_ptr, true );
-						if ( false === $next_non_whitespace || $this->tokens[ $next_non_whitespace ]['line'] === $this->tokens[ $stack_ptr ]['line'] ) {
-							// No non-whitespace found or next non-whitespace is on same line as gettext call.
-							$correctly_placed = true;
-						}
-						unset( $next_non_whitespace );
-					}
-
-					/*
-					 * Check that the comment starts with 'translators:'.
-					 */
-					if ( true === $correctly_placed ) {
-
-						if ( \T_COMMENT === $this->tokens[ $previous_comment ]['code'] ) {
-							$comment_text = trim( $this->tokens[ $previous_comment ]['content'] );
-
-							// If it's multi-line /* */ comment, collect all the parts.
-							if ( '*/' === substr( $comment_text, -2 ) && '/*' !== substr( $comment_text, 0, 2 ) ) {
-								for ( $i = ( $previous_comment - 1 ); 0 <= $i; $i-- ) {
-									if ( \T_COMMENT !== $this->tokens[ $i ]['code'] ) {
-										break;
-									}
-
-									$comment_text = trim( $this->tokens[ $i ]['content'] ) . $comment_text;
-								}
-							}
-
-							if ( true === $this->is_translators_comment( $comment_text ) ) {
-								// Comment is ok.
-								return;
-							}
-						} elseif ( \T_DOC_COMMENT_CLOSE_TAG === $this->tokens[ $previous_comment ]['code'] ) {
-							// If it's docblock comment (wrong style) make sure that it's a translators comment.
-							$db_start      = $this->phpcsFile->findPrevious( \T_DOC_COMMENT_OPEN_TAG, ( $previous_comment - 1 ) );
-							$db_first_text = $this->phpcsFile->findNext( \T_DOC_COMMENT_STRING, ( $db_start + 1 ), $previous_comment );
-
-							if ( true === $this->is_translators_comment( $this->tokens[ $db_first_text ]['content'] ) ) {
-								$this->phpcsFile->addWarning(
-									'A "translators:" comment must be a "/* */" style comment. Docblock comments will not be picked up by the tools to generate a ".pot" file.',
-									$stack_ptr,
-									'TranslatorsCommentWrongStyle'
-								);
-								return;
-							}
-						}
-					}
-				}
-
-				// Found placeholders but no translators comment.
-				$this->phpcsFile->addWarning(
-					'A gettext call containing placeholders was found, but was not accompanied by a "translators:" comment on the line above to clarify the meaning of the placeholders.',
-					$stack_ptr,
-					'MissingTranslatorsComment'
-				);
-				return;
+			if ( preg_match( self::SPRINTF_PLACEHOLDER_REGEX, $param_info['clean'], $placeholders ) === 1 ) {
+				$needs_translators_comment = true;
+				break;
 			}
 		}
+
+		if ( false === $needs_translators_comment ) {
+			// No text string with placeholders found, no translation comment needed.
+			return;
+		}
+
+		$previous_comment = $this->phpcsFile->findPrevious( Tokens::$commentTokens, ( $stackPtr - 1 ) );
+
+		if ( false !== $previous_comment ) {
+			/*
+			 * Check that the comment is either on the line before the gettext call or
+			 * if it's not, that there is only whitespace between.
+			 */
+			$correctly_placed = false;
+
+			if ( ( $this->tokens[ $previous_comment ]['line'] + 1 ) === $this->tokens[ $stackPtr ]['line'] ) {
+				$correctly_placed = true;
+			} else {
+				$next_non_whitespace = $this->phpcsFile->findNext( \T_WHITESPACE, ( $previous_comment + 1 ), $stackPtr, true );
+				if ( false === $next_non_whitespace || $this->tokens[ $next_non_whitespace ]['line'] === $this->tokens[ $stackPtr ]['line'] ) {
+					// No non-whitespace found or next non-whitespace is on same line as gettext call.
+					$correctly_placed = true;
+				}
+				unset( $next_non_whitespace );
+			}
+
+			/*
+			 * Check that the comment starts with 'translators:'.
+			 */
+			if ( true === $correctly_placed ) {
+				if ( \T_COMMENT === $this->tokens[ $previous_comment ]['code'] ) {
+					$comment_text = trim( $this->tokens[ $previous_comment ]['content'] );
+
+					// If it's multi-line /* */ comment, collect all the parts.
+					if ( '*/' === substr( $comment_text, -2 ) && '/*' !== substr( $comment_text, 0, 2 ) ) {
+						for ( $i = ( $previous_comment - 1 ); 0 <= $i; $i-- ) {
+							if ( \T_COMMENT !== $this->tokens[ $i ]['code'] ) {
+								break;
+							}
+
+							$comment_text = trim( $this->tokens[ $i ]['content'] ) . $comment_text;
+						}
+					}
+
+					if ( true === $this->is_translators_comment( $comment_text ) ) {
+						// Comment is ok.
+						return;
+					}
+				}
+
+				if ( \T_DOC_COMMENT_CLOSE_TAG === $this->tokens[ $previous_comment ]['code'] ) {
+					// If it's docblock comment (wrong style) make sure that it's a translators comment.
+					if ( isset( $this->tokens[ $previous_comment ]['comment_opener'] ) ) {
+						$db_start = $this->tokens[ $previous_comment ]['comment_opener'];
+					} else {
+						$db_start = $this->phpcsFile->findPrevious( \T_DOC_COMMENT_OPEN_TAG, ( $previous_comment - 1 ) );
+					}
+
+					$db_first_text = $this->phpcsFile->findNext( \T_DOC_COMMENT_STRING, ( $db_start + 1 ), $previous_comment );
+
+					if ( true === $this->is_translators_comment( $this->tokens[ $db_first_text ]['content'] ) ) {
+						$this->phpcsFile->addWarning(
+							'A "translators:" comment must be a "/* */" style comment. Docblock comments will not be picked up by the tools to generate a ".pot" file.',
+							$stackPtr,
+							'TranslatorsCommentWrongStyle'
+						);
+						return;
+					}
+				}
+			}
+		}
+
+		// Found placeholders but no translators comment.
+		$this->phpcsFile->addWarning(
+			'A function call to %s() with texts containing placeholders was found, but was not accompanied by a "translators:" comment on the line above to clarify the meaning of the placeholders.',
+			$stackPtr,
+			'MissingTranslatorsComment',
+			array( $matched_content )
+		);
 	}
 
 	/**
@@ -804,6 +918,7 @@ final class I18nSniff extends AbstractFunctionRestrictionsSniff {
 	 * @since 0.11.0
 	 *
 	 * @param string $content Comment string content.
+	 *
 	 * @return bool
 	 */
 	private function is_translators_comment( $content ) {
@@ -812,5 +927,4 @@ final class I18nSniff extends AbstractFunctionRestrictionsSniff {
 		}
 		return false;
 	}
-
 }

--- a/WordPress/Tests/WP/I18nUnitTest.1.inc
+++ b/WordPress/Tests/WP/I18nUnitTest.1.inc
@@ -1,6 +1,6 @@
 <?php
 
-// phpcs:set WordPress.WP.I18n check_translator_comments false
+// phpcs:disable WordPress.WP.I18n.MissingTranslatorsComment -- Translator comment issues are tested in test case file 2.
 
 __( 'string' ); // OK - no text domain known, so not checked.
 __( 'string', 'something' ); // OK - no text domain known, so not checked.
@@ -302,4 +302,4 @@ _n_noop( domain: 'default' /*comment*/, singular: 'translate me', plural: 'trans
 _nx_noop( singular: 'translate me', domain /*comment*/: 'default', plural: 'translate me', context: 'context', ); // Bad: superfluous domain.
 
 // phpcs:set WordPress.WP.I18n text_domain[]
-// phpcs:set WordPress.WP.I18n check_translator_comments true
+// phpcs:enable WordPress.WP.I18n.MissingTranslatorsComment

--- a/WordPress/Tests/WP/I18nUnitTest.1.inc
+++ b/WordPress/Tests/WP/I18nUnitTest.1.inc
@@ -243,5 +243,46 @@ _n_noop( 'I have %d cat, %d dog and %d canaries.', 'I have %d cats, %d dog and c
 _n_noop( 'I have %1$d cat, %2$d dog and %3$d canaries.', 'I have %1$d cats, %2$d dog and canaries.' ); // Bad, mismatched numbered placeholders count.
 _n_noop( 'I have %1$d cat, %2$d dog and %2$d canaries.', 'I have %1$d cats, %2$d dog and canaries.' ); // Bad, mismatched numbered placeholders count.
 
+/*
+ * Safeguard support for PHP 8.0+ named parameters.
+ * Each of these function calls uses named parameters with an unconventional param order to test this properly.
+ */
+// phpcs:set WordPress.WP.I18n text_domain[] my-slug
+translate( domain: 'my-slug', text: 'translate me', extra: 'default' ); // Bad: too many arguments + use of translate().
+__( domain: 'my-slug' ); // Bad: missing $text argument.
+__( single: 'translate me', domain: 'my-slug' ); // Bad: missing $text argument (invalid 'single' named arg).
+esc_attr__(
+	domain: 'my-slug',
+	text: 'translate
+me multi line', // OK, multi-line text string.
+);
+esc_html__(
+	domain: PLUGIN_TEXTDOMAIN, // Bad: not single text string literal.
+	text: 'translate ' . 'me', // Bad: not single text string literal.
+);
+_e(
+	domain: 'my-slug',
+	text: $translateMe, // Bad: not single text string literal.
+);
+esc_attr_e(
+	domain: 'my-slug',
+	text: "translate
+$me multi line", // Bad: interpolated variable found.
+);
+esc_html_e(
+	domain: 'different-slug', // Bad: wrong text domain.
+	text: 'translate me',
+);
+esc_html_x(
+	context: 'context',
+	domain: 'my-slug',
+	text: 'trans %s late %1$s me', // Bad: mixing ordered and non-ordered placeholders.
+);
+_x( context: 'context', text: 'translate %s me %s', domain:  'my-slug' ); // Bad: multiple placeholders, but no ordering.
+_ex( domain: 'my-slug', text: '%s', context: 'context', ); // Bad: no translatable content.
+esc_attr_x( domain: 'my-slug', context: 'context', text: '<div>translate me</div>', ); // Bad: wrapped in HTML.
+_n( number: $i, domain: 'my-slug', single: 'translate me', plural: 'translate %s me' ); // Bad: missing singular placeholder.
+_nx( number: $i, domain: 'my-slug', plural: 'translate %s me', single: 'translate %1$s me', context: 'context', ); // Bad: mismatch between single/plural placeholders.
+
 // phpcs:set WordPress.WP.I18n text_domain[]
 // phpcs:set WordPress.WP.I18n check_translator_comments true

--- a/WordPress/Tests/WP/I18nUnitTest.1.inc
+++ b/WordPress/Tests/WP/I18nUnitTest.1.inc
@@ -284,5 +284,11 @@ esc_attr_x( domain: 'my-slug', context: 'context', text: '<div>translate me</div
 _n( number: $i, domain: 'my-slug', single: 'translate me', plural: 'translate %s me' ); // Bad: missing singular placeholder.
 _nx( number: $i, domain: 'my-slug', plural: 'translate %s me', single: 'translate %1$s me', context: 'context', ); // Bad: mismatch between single/plural placeholders.
 
+// Safeguard that the SuperfluousDefaultTextDomain fixer handles trailing commas correctly.
+// Note: if the original code contained a trailing comma, it is fine for the fixed code to also contain a trailing comma.
+// phpcs:set WordPress.WP.I18n text_domain[] default
+__( 'translate me', 'default', ); // Bad: superfluous domain (positional with trailing comma).
+__( 'translate me', 'default' /*comment*/, ); // Bad: superfluous domain (positional with trailing comma and comment).
+
 // phpcs:set WordPress.WP.I18n text_domain[]
 // phpcs:set WordPress.WP.I18n check_translator_comments true

--- a/WordPress/Tests/WP/I18nUnitTest.1.inc
+++ b/WordPress/Tests/WP/I18nUnitTest.1.inc
@@ -290,5 +290,16 @@ _nx( number: $i, domain: 'my-slug', plural: 'translate %s me', single: 'translat
 __( 'translate me', 'default', ); // Bad: superfluous domain (positional with trailing comma).
 __( 'translate me', 'default' /*comment*/, ); // Bad: superfluous domain (positional with trailing comma and comment).
 
+// Safeguard handling of named params by the SuperfluousDefaultTextDomain fixer.
+__( text: 'translate me', domain: 'default' ); // Bad: superfluous domain.
+__( text: 'translate me', domain: 'default', ); // Bad: superfluous domain (with trailing comma).
+_n_noop( domain: 'default', singular: 'translate me', plural: 'translate me', ); // Bad: superfluous domain.
+_nx_noop( singular: 'translate me', domain: 'default' /*comment*/, plural: 'translate me', context: 'context', ); // Bad: superfluous domain.
+
+// These should not be auto-fixable as we don't want to remove the comment.
+__( text: 'translate me', domain: /*comment*/ 'default' ); // Bad: superfluous domain.
+_n_noop( domain: 'default' /*comment*/, singular: 'translate me', plural: 'translate me', ); // Bad: superfluous domain.
+_nx_noop( singular: 'translate me', domain /*comment*/: 'default', plural: 'translate me', context: 'context', ); // Bad: superfluous domain.
+
 // phpcs:set WordPress.WP.I18n text_domain[]
 // phpcs:set WordPress.WP.I18n check_translator_comments true

--- a/WordPress/Tests/WP/I18nUnitTest.1.inc
+++ b/WordPress/Tests/WP/I18nUnitTest.1.inc
@@ -215,13 +215,13 @@ __( '<b><i>Foo</b></i>', 'my-slug' );
 __( '<b><i>Foo</b></i></b>', 'my-slug' );
 __( '<foo>Foo</bar>', 'my-slug' );
 
-// phpcs:set WordPress.WP.I18n text_domain[]
-// phpcs:set WordPress.WP.I18n check_translator_comments true
-
-// Test handling of more complex embedded variables and expressions.
+// Test handling of more complex embedded variables and expressions. All of these should throw an error.
 __( "${foo}", 'my-slug' );
 __( "{$foo['bar']}", 'my-slug' );
 __( "{$foo->bar()}", 'my-slug' );
 __( "{$foo['bar']->baz()()}", 'my-slug' );
 __( "${foo->bar}", 'my-slug' );
 __( "${foo["${bar['baz']}"]}", 'my-slug' );
+
+// phpcs:set WordPress.WP.I18n text_domain[]
+// phpcs:set WordPress.WP.I18n check_translator_comments true

--- a/WordPress/Tests/WP/I18nUnitTest.1.inc
+++ b/WordPress/Tests/WP/I18nUnitTest.1.inc
@@ -223,5 +223,25 @@ __( "{$foo['bar']->baz()()}", 'my-slug' );
 __( "${foo->bar}", 'my-slug' );
 __( "${foo["${bar['baz']}"]}", 'my-slug' );
 
+// Safeguard defensive coding.
+__( /* comment */, 'my-slug' ); // Bad, missing first param (parse error).
+
+// phpcs:set WordPress.WP.I18n text_domain[] default
+
+// Safeguard that a comment after a "default" text domain is not removed.
+__( 'String default text domain.', 'default' /*comment*/ ); // Warning, text domain can be omitted.
+
+// Test mismatched placeholders.
+_n_noop( 'I have %1$d cat and %2$d dog.' ); // Bad, missing $plural argument, ignore for single/plural placeholder check.
+_n_noop( 'I have %1$d cat and %2$d dog.', $plural ); // Bad, non singular string $plural argument, ignore for single/plural placeholder check.
+_n_noop( 'I have %1$d cat and %2$d dog.', $plural . $text ); // Bad, non singular string $plural argument, ignore for single/plural placeholder check.
+
+_n_noop( 'I have %1$d cat and %2$d dog.', 'I have %1$d cats and %2$d dog.' ); // Ok.
+_n_noop( 'I have %2$d cat and %1$d dog.', 'I have %1$d cats and %2$d dog.' ); // Ok, or at least not something we flag.
+_n_noop( 'I have %1$d cat and %3$d dog.', 'I have %1$d cats and %2$d dog.' ); // Bad, different placeholders used in single vs plural text.
+_n_noop( 'I have %d cat, %d dog and %d canaries.', 'I have %d cats, %d dog and canaries.' ); // Bad, mismatched placeholders count.
+_n_noop( 'I have %1$d cat, %2$d dog and %3$d canaries.', 'I have %1$d cats, %2$d dog and canaries.' ); // Bad, mismatched numbered placeholders count.
+_n_noop( 'I have %1$d cat, %2$d dog and %2$d canaries.', 'I have %1$d cats, %2$d dog and canaries.' ); // Bad, mismatched numbered placeholders count.
+
 // phpcs:set WordPress.WP.I18n text_domain[]
 // phpcs:set WordPress.WP.I18n check_translator_comments true

--- a/WordPress/Tests/WP/I18nUnitTest.1.inc
+++ b/WordPress/Tests/WP/I18nUnitTest.1.inc
@@ -307,5 +307,11 @@ _nx( 'I have
 %d cats and %d dogs.', $number, 'Not
 really.' ); // Bad, multiple arguments should be numbered.
 
+// Show an error when the text domain is an empty string.
+esc_html_e( 'foo', '' ); // Bad: text domain mismatch.
+
+// Issue #1948 - Show an error when the text domain is an empty string and no text domain has been passed.
 // phpcs:set WordPress.WP.I18n text_domain[]
+esc_html_e( 'foo', '' ); // Bad: text-domain can not be empty.
+
 // phpcs:enable WordPress.WP.I18n.MissingTranslatorsComment

--- a/WordPress/Tests/WP/I18nUnitTest.1.inc
+++ b/WordPress/Tests/WP/I18nUnitTest.1.inc
@@ -301,5 +301,11 @@ __( text: 'translate me', domain: /*comment*/ 'default' ); // Bad: superfluous d
 _n_noop( domain: 'default' /*comment*/, singular: 'translate me', plural: 'translate me', ); // Bad: superfluous domain.
 _nx_noop( singular: 'translate me', domain /*comment*/: 'default', plural: 'translate me', context: 'context', ); // Bad: superfluous domain.
 
+// Safeguard bug fix: replacing placeholders in multi-line text strings.
+_nx( 'I have
+%d cat and %d dog.', 'I have
+%d cats and %d dogs.', $number, 'Not
+really.' ); // Bad, multiple arguments should be numbered.
+
 // phpcs:set WordPress.WP.I18n text_domain[]
 // phpcs:enable WordPress.WP.I18n.MissingTranslatorsComment

--- a/WordPress/Tests/WP/I18nUnitTest.1.inc.fixed
+++ b/WordPress/Tests/WP/I18nUnitTest.1.inc.fixed
@@ -284,5 +284,11 @@ esc_attr_x( domain: 'my-slug', context: 'context', text: '<div>translate me</div
 _n( number: $i, domain: 'my-slug', single: 'translate me', plural: 'translate %s me' ); // Bad: missing singular placeholder.
 _nx( number: $i, domain: 'my-slug', plural: 'translate %s me', single: 'translate %1$s me', context: 'context', ); // Bad: mismatch between single/plural placeholders.
 
+// Safeguard that the SuperfluousDefaultTextDomain fixer handles trailing commas correctly.
+// Note: if the original code contained a trailing comma, it is fine for the fixed code to also contain a trailing comma.
+// phpcs:set WordPress.WP.I18n text_domain[] default
+__( 'translate me', ); // Bad: superfluous domain (positional with trailing comma).
+__( 'translate me' /*comment*/, ); // Bad: superfluous domain (positional with trailing comma and comment).
+
 // phpcs:set WordPress.WP.I18n text_domain[]
 // phpcs:set WordPress.WP.I18n check_translator_comments true

--- a/WordPress/Tests/WP/I18nUnitTest.1.inc.fixed
+++ b/WordPress/Tests/WP/I18nUnitTest.1.inc.fixed
@@ -1,6 +1,6 @@
 <?php
 
-// phpcs:set WordPress.WP.I18n check_translator_comments false
+// phpcs:disable WordPress.WP.I18n.MissingTranslatorsComment -- Translator comment issues are tested in test case file 2.
 
 __( 'string' ); // OK - no text domain known, so not checked.
 __( 'string', 'something' ); // OK - no text domain known, so not checked.
@@ -302,4 +302,4 @@ _n_noop( domain: 'default' /*comment*/, singular: 'translate me', plural: 'trans
 _nx_noop( singular: 'translate me', domain /*comment*/: 'default', plural: 'translate me', context: 'context', ); // Bad: superfluous domain.
 
 // phpcs:set WordPress.WP.I18n text_domain[]
-// phpcs:set WordPress.WP.I18n check_translator_comments true
+// phpcs:enable WordPress.WP.I18n.MissingTranslatorsComment

--- a/WordPress/Tests/WP/I18nUnitTest.1.inc.fixed
+++ b/WordPress/Tests/WP/I18nUnitTest.1.inc.fixed
@@ -307,5 +307,11 @@ _nx( 'I have
 %1$d cats and %2$d dogs.', $number, 'Not
 really.' ); // Bad, multiple arguments should be numbered.
 
+// Show an error when the text domain is an empty string.
+esc_html_e( 'foo', '' ); // Bad: text domain mismatch.
+
+// Issue #1948 - Show an error when the text domain is an empty string and no text domain has been passed.
 // phpcs:set WordPress.WP.I18n text_domain[]
+esc_html_e( 'foo', '' ); // Bad: text-domain can not be empty.
+
 // phpcs:enable WordPress.WP.I18n.MissingTranslatorsComment

--- a/WordPress/Tests/WP/I18nUnitTest.1.inc.fixed
+++ b/WordPress/Tests/WP/I18nUnitTest.1.inc.fixed
@@ -301,5 +301,11 @@ __( text: 'translate me', domain: /*comment*/ 'default' ); // Bad: superfluous d
 _n_noop( domain: 'default' /*comment*/, singular: 'translate me', plural: 'translate me', ); // Bad: superfluous domain.
 _nx_noop( singular: 'translate me', domain /*comment*/: 'default', plural: 'translate me', context: 'context', ); // Bad: superfluous domain.
 
+// Safeguard bug fix: replacing placeholders in multi-line text strings.
+_nx( 'I have
+%1$d cat and %2$d dog.', 'I have
+%1$d cats and %2$d dogs.', $number, 'Not
+really.' ); // Bad, multiple arguments should be numbered.
+
 // phpcs:set WordPress.WP.I18n text_domain[]
 // phpcs:enable WordPress.WP.I18n.MissingTranslatorsComment

--- a/WordPress/Tests/WP/I18nUnitTest.1.inc.fixed
+++ b/WordPress/Tests/WP/I18nUnitTest.1.inc.fixed
@@ -243,5 +243,46 @@ _n_noop( 'I have %1$d cat, %2$d dog and %3$d canaries.', 'I have %1$d cats, %2$d
 _n_noop( 'I have %1$d cat, %2$d dog and %3$d canaries.', 'I have %1$d cats, %2$d dog and canaries.' ); // Bad, mismatched numbered placeholders count.
 _n_noop( 'I have %1$d cat, %2$d dog and %2$d canaries.', 'I have %1$d cats, %2$d dog and canaries.' ); // Bad, mismatched numbered placeholders count.
 
+/*
+ * Safeguard support for PHP 8.0+ named parameters.
+ * Each of these function calls uses named parameters with an unconventional param order to test this properly.
+ */
+// phpcs:set WordPress.WP.I18n text_domain[] my-slug
+translate( domain: 'my-slug', text: 'translate me', extra: 'default' ); // Bad: too many arguments + use of translate().
+__( domain: 'my-slug' ); // Bad: missing $text argument.
+__( single: 'translate me', domain: 'my-slug' ); // Bad: missing $text argument (invalid 'single' named arg).
+esc_attr__(
+	domain: 'my-slug',
+	text: 'translate
+me multi line', // OK, multi-line text string.
+);
+esc_html__(
+	domain: PLUGIN_TEXTDOMAIN, // Bad: not single text string literal.
+	text: 'translate ' . 'me', // Bad: not single text string literal.
+);
+_e(
+	domain: 'my-slug',
+	text: $translateMe, // Bad: not single text string literal.
+);
+esc_attr_e(
+	domain: 'my-slug',
+	text: "translate
+$me multi line", // Bad: interpolated variable found.
+);
+esc_html_e(
+	domain: 'different-slug', // Bad: wrong text domain.
+	text: 'translate me',
+);
+esc_html_x(
+	context: 'context',
+	domain: 'my-slug',
+	text: 'trans %s late %1$s me', // Bad: mixing ordered and non-ordered placeholders.
+);
+_x( context: 'context', text: 'translate %1$s me %2$s', domain:  'my-slug' ); // Bad: multiple placeholders, but no ordering.
+_ex( domain: 'my-slug', text: '%s', context: 'context', ); // Bad: no translatable content.
+esc_attr_x( domain: 'my-slug', context: 'context', text: '<div>translate me</div>', ); // Bad: wrapped in HTML.
+_n( number: $i, domain: 'my-slug', single: 'translate me', plural: 'translate %s me' ); // Bad: missing singular placeholder.
+_nx( number: $i, domain: 'my-slug', plural: 'translate %s me', single: 'translate %1$s me', context: 'context', ); // Bad: mismatch between single/plural placeholders.
+
 // phpcs:set WordPress.WP.I18n text_domain[]
 // phpcs:set WordPress.WP.I18n check_translator_comments true

--- a/WordPress/Tests/WP/I18nUnitTest.1.inc.fixed
+++ b/WordPress/Tests/WP/I18nUnitTest.1.inc.fixed
@@ -215,13 +215,13 @@ __( '<b><i>Foo</b></i>', 'my-slug' );
 __( '<b><i>Foo</b></i></b>', 'my-slug' );
 __( '<foo>Foo</bar>', 'my-slug' );
 
-// phpcs:set WordPress.WP.I18n text_domain[]
-// phpcs:set WordPress.WP.I18n check_translator_comments true
-
-// Test handling of more complex embedded variables and expressions.
+// Test handling of more complex embedded variables and expressions. All of these should throw an error.
 __( "${foo}", 'my-slug' );
 __( "{$foo['bar']}", 'my-slug' );
 __( "{$foo->bar()}", 'my-slug' );
 __( "{$foo['bar']->baz()()}", 'my-slug' );
 __( "${foo->bar}", 'my-slug' );
 __( "${foo["${bar['baz']}"]}", 'my-slug' );
+
+// phpcs:set WordPress.WP.I18n text_domain[]
+// phpcs:set WordPress.WP.I18n check_translator_comments true

--- a/WordPress/Tests/WP/I18nUnitTest.1.inc.fixed
+++ b/WordPress/Tests/WP/I18nUnitTest.1.inc.fixed
@@ -223,5 +223,25 @@ __( "{$foo['bar']->baz()()}", 'my-slug' );
 __( "${foo->bar}", 'my-slug' );
 __( "${foo["${bar['baz']}"]}", 'my-slug' );
 
+// Safeguard defensive coding.
+__( /* comment */, 'my-slug' ); // Bad, missing first param (parse error).
+
+// phpcs:set WordPress.WP.I18n text_domain[] default
+
+// Safeguard that a comment after a "default" text domain is not removed.
+__( 'String default text domain.' /*comment*/ ); // Warning, text domain can be omitted.
+
+// Test mismatched placeholders.
+_n_noop( 'I have %1$d cat and %2$d dog.' ); // Bad, missing $plural argument, ignore for single/plural placeholder check.
+_n_noop( 'I have %1$d cat and %2$d dog.', $plural ); // Bad, non singular string $plural argument, ignore for single/plural placeholder check.
+_n_noop( 'I have %1$d cat and %2$d dog.', $plural . $text ); // Bad, non singular string $plural argument, ignore for single/plural placeholder check.
+
+_n_noop( 'I have %1$d cat and %2$d dog.', 'I have %1$d cats and %2$d dog.' ); // Ok.
+_n_noop( 'I have %2$d cat and %1$d dog.', 'I have %1$d cats and %2$d dog.' ); // Ok, or at least not something we flag.
+_n_noop( 'I have %1$d cat and %3$d dog.', 'I have %1$d cats and %2$d dog.' ); // Bad, different placeholders used in single vs plural text.
+_n_noop( 'I have %1$d cat, %2$d dog and %3$d canaries.', 'I have %1$d cats, %2$d dog and canaries.' ); // Bad, mismatched placeholders count.
+_n_noop( 'I have %1$d cat, %2$d dog and %3$d canaries.', 'I have %1$d cats, %2$d dog and canaries.' ); // Bad, mismatched numbered placeholders count.
+_n_noop( 'I have %1$d cat, %2$d dog and %2$d canaries.', 'I have %1$d cats, %2$d dog and canaries.' ); // Bad, mismatched numbered placeholders count.
+
 // phpcs:set WordPress.WP.I18n text_domain[]
 // phpcs:set WordPress.WP.I18n check_translator_comments true

--- a/WordPress/Tests/WP/I18nUnitTest.1.inc.fixed
+++ b/WordPress/Tests/WP/I18nUnitTest.1.inc.fixed
@@ -290,5 +290,16 @@ _nx( number: $i, domain: 'my-slug', plural: 'translate %s me', single: 'translat
 __( 'translate me', ); // Bad: superfluous domain (positional with trailing comma).
 __( 'translate me' /*comment*/, ); // Bad: superfluous domain (positional with trailing comma and comment).
 
+// Safeguard handling of named params by the SuperfluousDefaultTextDomain fixer.
+__( text: 'translate me' ); // Bad: superfluous domain.
+__( text: 'translate me', ); // Bad: superfluous domain (with trailing comma).
+_n_noop( singular: 'translate me', plural: 'translate me', ); // Bad: superfluous domain.
+_nx_noop( singular: 'translate me' /*comment*/, plural: 'translate me', context: 'context', ); // Bad: superfluous domain.
+
+// These should not be auto-fixable as we don't want to remove the comment.
+__( text: 'translate me', domain: /*comment*/ 'default' ); // Bad: superfluous domain.
+_n_noop( domain: 'default' /*comment*/, singular: 'translate me', plural: 'translate me', ); // Bad: superfluous domain.
+_nx_noop( singular: 'translate me', domain /*comment*/: 'default', plural: 'translate me', context: 'context', ); // Bad: superfluous domain.
+
 // phpcs:set WordPress.WP.I18n text_domain[]
 // phpcs:set WordPress.WP.I18n check_translator_comments true

--- a/WordPress/Tests/WP/I18nUnitTest.2.inc
+++ b/WordPress/Tests/WP/I18nUnitTest.2.inc
@@ -107,4 +107,7 @@ _e(); // Bad.
 // phpcs:ignore Standard.Category.Sniff -- testing that the PHPCS annotations are handled correctly.
 printf( __( 'There are %1$d monkeys in the %2$s', 'my-slug' ), intval( $number ), esc_html( $string ) ); // Bad.
 
+__( $notStringLiteral, 'my-slug' ); // Ignore for translators comment, $text not single string literal.
+__( 'text %s' . 'more text', 'my-slug' ); // Ignore for translators comment, $text not single string literal.
+
 // phpcs:set WordPress.WP.I18n text_domain[]

--- a/WordPress/Tests/WP/I18nUnitTest.2.inc
+++ b/WordPress/Tests/WP/I18nUnitTest.2.inc
@@ -110,4 +110,19 @@ printf( __( 'There are %1$d monkeys in the %2$s', 'my-slug' ), intval( $number )
 __( $notStringLiteral, 'my-slug' ); // Ignore for translators comment, $text not single string literal.
 __( 'text %s' . 'more text', 'my-slug' ); // Ignore for translators comment, $text not single string literal.
 
+
+/*
+ * Safeguard support for PHP 8.0+ named parameters.
+ */
+/* translators: %d: number of cats. */
+_n_noop( domain: 'my-slug', singular: 'I have %d cat.', plural: "I have %d cats.", ); // OK.
+
+esc_attr_e( domain: 'my-slug', translate: 'Text to translate to %1$d languages.' ); // Bad, missing $text param, missing translators comment is ignored.
+
+_n_noop(  // Bad, missing translators comment.
+	domain: 'my-slug',
+	plural: "I have %d cats.",
+	singular: 'I have %d cat.',
+);
+
 // phpcs:set WordPress.WP.I18n text_domain[]

--- a/WordPress/Tests/WP/I18nUnitTest.3.inc
+++ b/WordPress/Tests/WP/I18nUnitTest.3.inc
@@ -19,3 +19,9 @@ __( 'string', "something-$domain" ); // Bad, shouldn't use variable for domain.
 
 __( 'string', 'something-else' ); // Bad, text domain mismatch.
 __( 'string', "something-else" ); // Bad, text domain mismatch.
+
+/*
+ * Safeguard support for PHP 8.0+ named parameters.
+ */
+__( domain: 'something', text: 'string', ); // OK.
+__( domain: 'something-else', text: 'string', ); // Bad, text domain mismatch.

--- a/WordPress/Tests/WP/I18nUnitTest.php
+++ b/WordPress/Tests/WP/I18nUnitTest.php
@@ -142,6 +142,8 @@ final class I18nUnitTest extends AbstractSniffUnitTest {
 					281 => 1,
 					282 => 1,
 					284 => 1,
+					305 => 1,
+					306 => 1,
 				);
 
 			case 'I18nUnitTest.2.inc':

--- a/WordPress/Tests/WP/I18nUnitTest.php
+++ b/WordPress/Tests/WP/I18nUnitTest.php
@@ -125,11 +125,18 @@ final class I18nUnitTest extends AbstractSniffUnitTest {
 					222 => 1,
 					223 => 1,
 					224 => 1,
+					227 => 1,
+					235 => 1,
+					236 => 1,
+					237 => 1,
+					242 => 2,
 				);
 
 			case 'I18nUnitTest.2.inc':
 				return array(
 					104 => 2,
+					110 => 1,
+					111 => 1,
 				);
 
 			case 'I18nUnitTest.3.inc':
@@ -163,10 +170,6 @@ final class I18nUnitTest extends AbstractSniffUnitTest {
 				return array(
 					69  => 1,
 					70  => 1,
-					100 => 1,
-					101 => 1,
-					102 => 1,
-					103 => 1,
 					154 => 1,
 					158 => 1,
 					159 => 1,
@@ -176,6 +179,11 @@ final class I18nUnitTest extends AbstractSniffUnitTest {
 					194 => 1,
 					198 => 1,
 					199 => 1,
+					232 => 1,
+					241 => 1,
+					242 => 1,
+					243 => 1,
+					244 => 1,
 				);
 
 			case 'I18nUnitTest.2.inc':

--- a/WordPress/Tests/WP/I18nUnitTest.php
+++ b/WordPress/Tests/WP/I18nUnitTest.php
@@ -201,6 +201,8 @@ final class I18nUnitTest extends AbstractSniffUnitTest {
 					251 => 1,
 					283 => 1,
 					285 => 1,
+					290 => 1,
+					291 => 1,
 				);
 
 			case 'I18nUnitTest.2.inc':

--- a/WordPress/Tests/WP/I18nUnitTest.php
+++ b/WordPress/Tests/WP/I18nUnitTest.php
@@ -130,6 +130,18 @@ final class I18nUnitTest extends AbstractSniffUnitTest {
 					236 => 1,
 					237 => 1,
 					242 => 2,
+					251 => 1,
+					252 => 1,
+					253 => 1,
+					260 => 1,
+					261 => 1,
+					265 => 1,
+					269 => 1,
+					273 => 1,
+					279 => 1,
+					281 => 1,
+					282 => 1,
+					284 => 1,
 				);
 
 			case 'I18nUnitTest.2.inc':
@@ -137,6 +149,7 @@ final class I18nUnitTest extends AbstractSniffUnitTest {
 					104 => 2,
 					110 => 1,
 					111 => 1,
+					120 => 1,
 				);
 
 			case 'I18nUnitTest.3.inc':
@@ -151,6 +164,7 @@ final class I18nUnitTest extends AbstractSniffUnitTest {
 					18 => 1,
 					20 => 1,
 					21 => 1,
+					27 => 1,
 				);
 
 			default:
@@ -184,6 +198,9 @@ final class I18nUnitTest extends AbstractSniffUnitTest {
 					242 => 1,
 					243 => 1,
 					244 => 1,
+					251 => 1,
+					283 => 1,
+					285 => 1,
 				);
 
 			case 'I18nUnitTest.2.inc':
@@ -195,6 +212,7 @@ final class I18nUnitTest extends AbstractSniffUnitTest {
 					74  => 1,
 					85  => 1,
 					108 => 1,
+					122 => 1,
 				);
 
 			default:

--- a/WordPress/Tests/WP/I18nUnitTest.php
+++ b/WordPress/Tests/WP/I18nUnitTest.php
@@ -119,12 +119,12 @@ final class I18nUnitTest extends AbstractSniffUnitTest {
 					178 => 1,
 					181 => 3,
 					184 => 1,
+					219 => 1,
+					220 => 1,
+					221 => 1,
 					222 => 1,
 					223 => 1,
 					224 => 1,
-					225 => 1,
-					226 => 1,
-					227 => 1,
 				);
 
 			case 'I18nUnitTest.2.inc':

--- a/WordPress/Tests/WP/I18nUnitTest.php
+++ b/WordPress/Tests/WP/I18nUnitTest.php
@@ -203,6 +203,13 @@ final class I18nUnitTest extends AbstractSniffUnitTest {
 					285 => 1,
 					290 => 1,
 					291 => 1,
+					294 => 1,
+					295 => 1,
+					296 => 1,
+					297 => 1,
+					300 => 1,
+					301 => 1,
+					302 => 1,
 				);
 
 			case 'I18nUnitTest.2.inc':

--- a/WordPress/Tests/WP/I18nUnitTest.php
+++ b/WordPress/Tests/WP/I18nUnitTest.php
@@ -144,6 +144,8 @@ final class I18nUnitTest extends AbstractSniffUnitTest {
 					284 => 1,
 					305 => 1,
 					306 => 1,
+					311 => 1,
+					315 => 1,
 				);
 
 			case 'I18nUnitTest.2.inc':


### PR DESCRIPTION
### WP/I18n: minor code simplification

The `AbstractFunctionRestrictionsSniff` already checks for a next token and verifies that token is an open parenthesis, this doesn't need to be duplicated.

### WP/I18n: fix property reset in tests

Some new tests were added _after_ the property reset at the end of the test case file.

This commit moves the reset to the end of the file again.

### WP/I18n: complete refactor of the sniff

As things were, the `WordPress.WP.I18n` sniff was based on the `AbstractFunctionRestrictionsSniff` class and used legacy custom code to parse the function call to parameters.

In this refactor, the parent sniff is switched to the `AbstractFunctionParameterSniff` class, which uses the PHPCSUtils `PassedParameters` class to parse the function call parameters.

Making this change will allow for supporting function calls using named parameters as supported since PHP 8.0.

As the code in the sniff needed significant changes to account for the difference in the array format containing parameter information, all code in the sniff has been reviewed and in a lot of places, rewritten.

The new code is more modular, has much lower cognitive and cyclomatic complexity and should be easier to read, understand and adjust when changes to the sniff are needed in the future.

Having said that, I have tried to keep the _functional_ changes to a minimum while doing this refactor.
I _have_ addressed some logic errors and low hanging fruit, like making the error messages more informative, but other than that, this refactor does not contain significant functional changes and all error codes remain the same as before.

Notes on the refactor:
* The sniff previously contained some logic for toggling messages from error to warning `$is_error = empty( $context['warning'] );`.
    This logic has been removed as the `'warning'` array key was never set or changed anyway.
* The `check_argument_tokens()` method has been split and is replaced by the `check_argument_is_string_literal()` and the `check_textdomain_matches()` methods.
* In contrast to the behaviour previously in the `check_argument_tokens()` method, the `check_argument_is_string_literal()` method will consistently return a boolean value indicating whether or not the parameter examined is a string literal.
* The `check_text()` method has been split and is replaced by the `check_placeholders_in_string()`, `check_string_has_translatable_content()` and the `check_string_has_no_html_wrapper()` methods.
* The `check_textdomain_matches()`, `check_placeholders_in_string()`, `check_string_has_translatable_content()`, `check_string_has_no_html_wrapper()` and the `compare_single_and_plural_arguments()` checks will now only be run if the parameter being examined consists of a text string literal.
    In other words, these will only run when there are only one or more `T_CONSTANT_ENCAPSED_STRING` tokens (single line and multi-line string supported) as in all other cases, examining the _contents_ of the tokens will be unreliable and is likely to result in false positives.
    It looks like this was always the intention, but was previously not always executed correctly.
    Case in point: if the parameter consisted of one non-empty token, even though that token was not a string literal, the `compare_single_and_plural_arguments()` check would previously still be executed.
    Along the same line, the checks previously contained in the `check_text()` method were previously only executed when the parameter had exactly one functional token. I.e. they were previously not run on multi-line text strings, but they were run on non-text strings, like a `T_VARIABLE` token.
* Take note: the above also means that the (partial) support for providing certain texts as heredocs/nowdocs has been removed.
    If tests would show that heredoc/nowdocs _are_ supported by the `pot` file generators, this should be brought back, but as it was, the support for heredocs/nowdocs in the sniff was incomplete anyhow, so better to not support these at all.
* The logic within the `compare_single_and_plural_arguments()` check has also been adjusted to not throw the `MismatchedPlaceholders` error when the `MissingSingularPlaceholder` is already being thrown.
    While we shouldn't be hiding one error behind another, this is not one of those cases and the `MismatchedPlaceholders` error would be unsolvable until the `MissingSingularPlaceholder` is solved anyway.
* The `check_for_translator_comment()` will now only examine parameters for placeholders if the parameter passed is a single string literal.
    Includes a couple of extra tests to verify.

Additionally, this refactor includes the following other changes:
* In error messages referring to a parameter name, the correct distinction between `$single` and `$singular` is now made.
    Previously, those error messages would reference the `$singular` parameter in the `_n_noop()` and `_nx_noop()` functions as if it were called `$single`. This incorrect parameter name becomes confusing when named parameters are taken into account.
* The error message for the `TooManyFunctionArgs` error code will now be thrown on the function name token instead of on the function call parenthesis opener.
* The error message for the `MissingArg*[Default]` error codes will now be thrown on the function name token instead of on the function call parenthesis opener.
* The error message for the `TooManyFunctionArgs` error code has been updated to be more informative.
    Old: `Too many arguments for function "%s".`
    New: `Too many parameters passed to function "%s()". Expected: %s parameters, received: %s`
* The error message for the `MissingArg*[Default]` error code has been updated to be more informative.
    Old: `Missing $%s arg. [...]`
    New: `Missing $%s parameter in function call to %s(). [...]`
* The error message for the `NonSingularStringLiteral*` error code has been updated to be more informative.
    Old: `The $%s arg must be a single string literal, not "%s".`
    New: `The $%s parameter must be a single text string literal. Found: %s`
* The error message for the `InterpolatedVariable*` error codes has been updated to be more informative.
    Old: `The $%s arg must not contain interpolated variables or expressions. Found "%s".`
    New: `The $%s parameter must not contain interpolated variables or expressions. Found: %s`
* The error message for the `SuperfluousDefaultTextDomain` error code has been updated to be more informative.
    Old: `No need to supply the text domain when the only accepted text domain is "default".`
    New: `No need to supply the text domain in function call to %s() when the only accepted text domain is "default".`
* The error messages for the `MixedOrderedPlaceholders*` and `UnorderedPlaceholders*` error codes now use quotes around values in the error messages more consistently.
* The error message for the `MixedOrderedPlaceholders*` error codes has been updated to be more informative.
    Old: `Multiple placeholders should be ordered. Mix of ordered and non-ordered placeholders found. Found: %s.`
    New: `Multiple placeholders in translatable strings should be ordered. Mix of ordered and non-ordered placeholders found. Found: "%s" in %s.` (where the second %s is the complete parameter contents)
* The error message for the `UnorderedPlaceholders*` error codes has been updated to be more informative.
    Old: `Multiple placeholders should be ordered. Expected "%s", but got "%s".`
    New: `Multiple placeholders in translatable strings should be ordered. Expected "%s", but got "%s" in %s.` (where the third %s is the complete parameter contents)
* The error message for the `NoEmptyStrings` error code has been updated to be more informative.
    Old: `Strings should have translatable content`
    New: `The $%s text string should have translatable content. Found: %s`
    => This may read a little awkward for the `$text` parameter. Suggestions for further improvement welcome.
* The error message for the `NoHtmlWrappedStrings` error code has been updated to be more informative.
    Old: `Strings should not be wrapped in HTML`
    New: `Translatable string should not be wrapped in HTML. Found: %s`
* Also note that the placeholders found will be sorted using "natural sort" now for the `MismatchedPlaceholders` error, which should make the error message more readable for those text strings with lots of placeholders.
* The error message for the MissingTranslatorsCommenterror code has been updated to be more informative.
    Old: `A gettext call containing placeholders was found, but was not accompanied by a "translators:" comment on the line above to clarify the meaning of the placeholders.`
    New: `A function call to %s() with texts containing placeholders was found, but was not accompanied by a "translators:" comment on the line above to clarify the meaning of the placeholders.`

Extra tests have been added to safeguard the following situations which were previously mostly accounted for, but not safeguarded:
* Ensuring that a missing parameter will be recognized and flagged correctly with `MissingArg*[Default]`, even when there is a placeholder comment in the "parameter space".
* Ensuring that the `SuperfluousDefaultTextDomain` fixer does not remove any potential comments _after_ the `'default'` text domain.
* The `MismatchedPlaceholders` check which did not have dedicated tests until now.

### WP/I18n: add tests with PHP 8.0+ named parameters

The changes made in the refactor (previous commit) means that function calls using named parameters, as supported since PHP 8.0, should now be handled correctly by the sniff.

This commit adds unit tests to the sniff to verify and safeguard this.

### WP/I18n: add tests with PHP 7.3+ trailing commas in function calls

The `SuperfluousDefaultTextDomain` fixer already handled this correctly. This commit just adds some tests to safeguard this.

### WP/I18n: fix SuperfluousDefaultTextDomain auto-fix code to allow for named params

The auto-fixer for the `SuperfluousDefaultTextDomain` warning attempts to remove a complete parameter, though it will bow out from auto-fixing when there is a comment in the tokens which would be removed.

This auto-fixer code and the code to determine whether an auto-fix is possible, now needs adjusting to allow for function calls with named parameters as otherwise the fixer could cause parse errors.
* The parameter label and the `:` also needs to be removed.
* If the named parameter is the first parameter, there will not be a preceding comma, but we will need to remove the comma behind it.
* The range of tokens which needs to be checked for comments to determine whether the error is auto-fixable needs to be expanded.

This commit makes those changes.

Includes additional unit tests to safeguard the fixes.

### WP/I18n: remove the public check_translator_comments property

The `$check_translator_comments` property was introduced in WPCS `0.11.0` via PR #742 mostly to make our own lives easier managing the test case files.
It allowed the pre-existing test case file `1` to remain largely unchanged, while the errors for translators comments were tested in a new test case file `2`.

At the time, the ability to use modular ignore annotations, i.e. `// phpcs:disable Sniffcode`, did not exist yet.

As those now _do_ exist and the minimum supported PHPCS version is beyond the version in which support for the modular ignore annotations was introduced, we can use those instead in the test case files and no longer need the property.

For end-users, the use of the property has always been discouraged as they could exclude the error codes in their ruleset instead, so the impact of this change for end-users is expected to be minimal.

The removal of the property should be annotated in the wiki when it is being updated for the release of WPCS 3.0.0. Related #1917.

### WP/I18n: bug fix - fixer for UnorderedPlaceholders* could mangle text string

As things were, the fixer for the `UnorderedPlaceholders*` error, would replace the first non-empty token in the parameter. While this is fine in the majority of cases, this would lead to a mangled text string in the `fixed` file for multi-line text strings.

Fixed now.

Includes unit test safeguarding the fix.

### WP/I18n: new error: passing empty string as text domain

Issue #1948 flagged an issue which, while rare, should still be flagged.

The default value for the `$domain` parameter for nearly all translation functions is (currently) `'default'`, with the exceptions being `_n_noop()` and `_nx_noop()`, where the default value is `null`.

If a function call would pass an empty string as the `$domain`, this would previously already be flagged if the end-user had set one or more valid `text_domain`s in their ruleset.

However, if no `text_domain` was set in the ruleset, this would not be flagged by the sniff and as an empty string would overrule the default value for the functions, in effect, the text string would become untranslatable as there is no text domain and the functions would no longer fall back to the WP native `'default'` text domain.

I haven't checked if/when these default values were changed in Core, but that shouldn't really matter anyway as, as things currently are, passing an empty text string as the `$domain` is problematic and should be flagged.

Fixed now.
The behaviour for when a  valid `text_domain` was set in the ruleset remains unchanged.

Includes unit test.

Fixes #1948