### PR TITLE
GH Actions: various changes

### DIFF
--- a/.github/workflows/basic-qa.yml
+++ b/.github/workflows/basic-qa.yml
@@ -120,6 +120,7 @@ jobs:
       - name: Install Composer dependencies
         uses: ramsey/composer-install@v2
         with:
+          composer-options: --no-dev
           # Bust the cache at least once a month - output format: YYYY-MM.
           custom-cache-suffix: $(date -u "+%Y-%m")
 

--- a/.github/workflows/basic-qa.yml
+++ b/.github/workflows/basic-qa.yml
@@ -98,7 +98,7 @@ jobs:
     strategy:
       matrix:
         php: [ 'latest' ]
-        phpcs_version: [ '3.7.1', 'dev-master' ]
+        phpcs_version: [ 'lowest', 'dev-master' ]
 
     name: "Ruleset test: PHP ${{ matrix.php }} on PHPCS ${{ matrix.phpcs_version }}"
 
@@ -114,7 +114,8 @@ jobs:
           ini-values: error_reporting = E_ALL & ~E_DEPRECATED
           coverage: none
 
-      - name: Set PHPCS version
+      - name: "Set PHPCS version (master)"
+        if: ${{ matrix.phpcs_version != 'lowest' }}
         run: composer require squizlabs/php_codesniffer:"${{ matrix.phpcs_version }}" --no-update --no-scripts --no-interaction
 
       - name: Install Composer dependencies
@@ -123,6 +124,10 @@ jobs:
           composer-options: --no-dev
           # Bust the cache at least once a month - output format: YYYY-MM.
           custom-cache-suffix: $(date -u "+%Y-%m")
+
+      - name: "Set PHPCS version (lowest)"
+        if: ${{ matrix.phpcs_version == 'lowest' }}
+        run: composer update squizlabs/php_codesniffer --prefer-lowest --ignore-platform-req=php+ --no-scripts --no-interaction
 
       - name: Test the WordPress-Core ruleset
         run: $(pwd)/vendor/bin/phpcs -ps ./Tests/RulesetCheck/class-ruleset-test.inc --standard=WordPress-Core

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -69,7 +69,7 @@ jobs:
         if: ${{ matrix.php >= 8.0 || matrix.php == 'latest' }}
         uses: ramsey/composer-install@v2
         with:
-          composer-options: --ignore-platform-reqs
+          composer-options: --ignore-platform-req=php+
           custom-cache-suffix: $(date -u "+%Y-%m")
 
       - name: Lint PHP files against parse errors

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       matrix:
         php: [ '5.4', 'latest' ]
-        phpcs_version: [ '3.7.1', 'dev-master' ]
+        phpcs_version: [ 'lowest', 'dev-master' ]
 
     name: QTest - PHP ${{ matrix.php }} on PHPCS ${{ matrix.phpcs_version }}
 
@@ -50,7 +50,8 @@ jobs:
           ini-values: ${{ steps.set_ini.outputs.PHP_INI }}
           coverage: none
 
-      - name: Set PHPCS version
+      - name: "Set PHPCS version (master)"
+        if: ${{ matrix.phpcs_version != 'lowest' }}
         run: composer require squizlabs/php_codesniffer:"${{ matrix.phpcs_version }}" --no-update --no-scripts --no-interaction
 
       - name: Install Composer dependencies (PHP < 8.0 )
@@ -66,6 +67,10 @@ jobs:
         with:
           composer-options: --ignore-platform-req=php+
           custom-cache-suffix: $(date -u "+%Y-%m")
+
+      - name: "Set PHPCS version (lowest)"
+        if: ${{ matrix.phpcs_version == 'lowest' }}
+        run: composer update squizlabs/php_codesniffer --prefer-lowest --ignore-platform-req=php+ --no-scripts --no-interaction
 
       - name: Lint PHP files against parse errors
         if: ${{ matrix.phpcs_version == 'dev-master' }}

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -24,12 +24,7 @@ jobs:
     strategy:
       matrix:
         php: [ '5.4', 'latest' ]
-        phpcs_version: [ 'dev-master' ]
-        include:
-          - php: '7.3'
-            phpcs_version: '3.7.1'
-          - php: '5.4'
-            phpcs_version: '3.7.1'
+        phpcs_version: [ '3.7.1', 'dev-master' ]
 
     name: QTest - PHP ${{ matrix.php }} on PHPCS ${{ matrix.phpcs_version }}
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -75,7 +75,7 @@ jobs:
         if: ${{ matrix.php >= 8.0 }}
         uses: ramsey/composer-install@v2
         with:
-          composer-options: --ignore-platform-reqs
+          composer-options: --ignore-platform-req=php+
           custom-cache-suffix: $(date -u "+%Y-%m")
 
       - name: Lint PHP files against parse errors

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         php: [ '5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3' ]
-        phpcs_version: [ '3.7.1', 'dev-master' ]
+        phpcs_version: [ 'lowest', 'dev-master' ]
         extensions: [ '' ]
 
         include:
@@ -61,7 +61,8 @@ jobs:
           coverage: none
           tools: cs2pr
 
-      - name: Set PHPCS version
+      - name: "Set PHPCS version (master)"
+        if: ${{ matrix.phpcs_version != 'lowest' }}
         run: composer require squizlabs/php_codesniffer:"${{ matrix.phpcs_version }}" --no-update --no-scripts --no-interaction
 
       - name: Install Composer dependencies (PHP < 8.0 )
@@ -77,6 +78,10 @@ jobs:
         with:
           composer-options: --ignore-platform-req=php+
           custom-cache-suffix: $(date -u "+%Y-%m")
+
+      - name: "Set PHPCS version (lowest)"
+        if: ${{ matrix.phpcs_version == 'lowest' }}
+        run: composer update squizlabs/php_codesniffer --prefer-lowest --ignore-platform-req=php+ --no-scripts --no-interaction
 
       - name: Lint PHP files against parse errors
         if: ${{ matrix.phpcs_version == 'dev-master' }}


### PR DESCRIPTION
**_This is a prelim PR before updating the PHPCS version to allow for simplifying the management of the protected branches_**

**Note**:
**The protected branch settings will need an update before this PR becomes mergable, but after this, it shouldn't need updating that often anymore.
Once this PR has received approvals, I will update the required statuses and merge the PR myself.**

### GH Actions: minor tweak to composer install

Since Composer 2.2, we can be more specific about which platform requirements should be ignored.

This change ensures that only the "high" end of a PHP requirement will be ignored and no other platform requirements are ignored.

Ref: https://blog.packagist.com/composer-2-2/#-ignore-platform-req-improvements

### GH Actions/quicktest: simplify the matrix

The `include` section was set up in Travis (and transferred to GH Actions) as the _lowest_ supported PHPCS version at that time, wasn't compatible with the highest supported PHP version (yet).

As that is no longer the case, we can now bring this back to a simplified matrix for the Quick Test and just test against high/low PHP with high/low PHPCS.

### GH Actions/ruleset-test: minimize the install

Given that:
* The ruleset test doesn't need PHPUnit to run.
* The ruleset test is run on PHP `latest`, which conflicts with our highest supported PHPUnit version.
* And the Composer install is run without `--ignore-platform-*` resulting in PHPUnit 5.2.7 being installed (last PHPUnit version which didn't have a PHP requirement)

I propose to install with `--no-dev` for the ruleset test.

While this doesn't necessarily remove the "conflict", it should still make the Composer install faster and at least won't create a cache with a completely incorrect PHPUnit version.

### GH Actions: tweak the way the PHPCS versions are set

As things were, whenever the minimum PHPCS version would be changed, the branch protection settings for both the `master` and the `develop` branch would need to be updated and all "required builds" referencing the old PHPCS version would need to be removed, while new "required builds" would need to be added referencing the new minimum PHPCS version.

This was a fiddly process and time-consuming.

The change proposed in this commit takes advantage of the Composer `--prefer-lowest` setting to achieve the same without a hard-coded PHPCS version in the build name, which means that once the branch protection settings have been updated for this PR, they shouldn't need updating anymore for future PHPCS version bumps.