### PR TITLE
Composer: up the minimum PHPCS version to 3.7.2

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -36,7 +36,7 @@ When you introduce new `public` sniff properties, or your sniff extends a class 
 
 ## Pre-requisites
 * WordPress-Coding-Standards
-* PHP_CodeSniffer 3.7.1 or higher
+* PHP_CodeSniffer 3.7.2 or higher
 * PHPUnit 4.x, 5.x, 6.x or 7.x
 
 The WordPress Coding Standards use the `PHP_CodeSniffer` native unit test suite for unit testing the sniffs.

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ This project is a collection of [PHP_CodeSniffer](https://github.com/squizlabs/P
 
 ### Requirements
 
-The WordPress Coding Standards require PHP 5.4 or higher and [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) version **3.7.1** or higher.
+The WordPress Coding Standards require PHP 5.4 or higher and [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) version **3.7.2** or higher.
 
 ### Composer
 

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
 	"require": {
 		"php": ">=5.4",
 		"ext-filter": "*",
-		"squizlabs/php_codesniffer": "^3.7.1",
+		"squizlabs/php_codesniffer": "^3.7.2",
 		"phpcsstandards/phpcsutils": "^1.0",
 		"phpcsstandards/phpcsextra": "^1.0"
 	},


### PR DESCRIPTION
Follow up on #2090 and #2058 and as discussed in #2214.

This updates the minimum PHPCS version from `3.7.1` to `3.7.2`.

Note: no changes are needed anymore to the GH workflows after the change merged with PR #2215

Ref: https://github.com/squizlabs/PHP_CodeSniffer/releases/tag/3.7.2