### PR TITLE
README: make it clear that the current stable version (v2.3.0) does not work on PHP8

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ This project is a collection of [PHP_CodeSniffer](https://github.com/squizlabs/P
 
 ### Requirements
 
-The WordPress Coding Standards require PHP 5.4 or higher and [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) version **3.7.2** or higher.
+The WordPress Coding Standards require PHP 5.4 or higher and [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) version **3.7.2** or higher. The current stable release does not work on PHP 8, and for the moment we recommend that you use PHP 7.4.
 
 ### Composer
 


### PR DESCRIPTION
I attempted to install PHPCS and WPCS on a new machine running PHP 8.0.28 today, and spent quite a bit of time researching why it wasn't working and what the appropriate remedy was.

Specifically I ran into this bug: https://github.com/WordPress/WordPress-Coding-Standards/issues/1967 and it doesn't appear that the fix for this will be released until v3.0.0.

In the meantime, it would be kind to developers if the project makes it clear upfront that PHP8 is not supported, and recommends PHP 7.4 instead.