### PR TITLE
Tests: improve code coverage

### DIFF
--- a/WordPress/Tests/CodeAnalysis/AssignmentInTernaryConditionUnitTest.inc
+++ b/WordPress/Tests/CodeAnalysis/AssignmentInTernaryConditionUnitTest.inc
@@ -55,3 +55,7 @@ $mode = ( $a->prop = 'on' ) ? 'on' : 'off'; // Bad.
 
 // Safeguard recognition of PHP 7.4+ null coalesce equals.
 $mode = ( $a ??= 'on' ) ? 'on' : 'off';
+
+// Live coding/parse error.
+// This has to be the last test in the file.
+$var = $a = $foo ) ? 'on' : 'off';

--- a/WordPress/Tests/DB/PreparedSQLUnitTest.1.inc
+++ b/WordPress/Tests/DB/PreparedSQLUnitTest.1.inc
@@ -135,5 +135,13 @@ $wpdb->query( $wpdb->prepare( 'SELECT * FROM ' . $notwpdb?->posts . " WHERE post
 $wpdb->query( "SELECT * FROM $wpdb->posts WHERE value = " . 10_000 . ";" ); // OK.
 $wpdb->query( "SELECT * FROM $wpdb->posts WHERE value = " . 0o34 . ";" ); // OK.
 
+// Not a method call.
+$wpdb = new WPDB();
+$foo = $wpdb->propertyAccess;
+echo $wpdb::CONSTANT_NAME;
+
+// Not an identifyable method call.
+$wpdb->{$methodName}('query');
+
 // Don't throw an error during live coding.
 wpdb::prepare( "SELECT * FROM $wpdb->posts

--- a/WordPress/Tests/DB/PreparedSQLUnitTest.2.inc
+++ b/WordPress/Tests/DB/PreparedSQLUnitTest.2.inc
@@ -7,3 +7,7 @@ $wpdb->query( <<<EOT
 		WHERE ID = {$foo};
 	EOT
 ); // Bad.
+
+// Live coding.
+// This needs to be the last test in a file.
+$wpdb->

--- a/WordPress/Tests/Files/FileNameUnitTest.php
+++ b/WordPress/Tests/Files/FileNameUnitTest.php
@@ -65,6 +65,7 @@ final class FileNameUnitTest extends AbstractSniffUnitTest {
 		'partial-file-disable.inc'                   => 1,
 		'rule-disable.inc'                           => 0,
 		'wordpress-disable.inc'                      => 0,
+		'disable-non-matching-enable.inc'            => 0,
 
 		/*
 		 * In /FileNameUnitTests/TestFiles.

--- a/WordPress/Tests/Files/FileNameUnitTests/PHPCSAnnotations/disable-non-matching-enable.inc
+++ b/WordPress/Tests/Files/FileNameUnitTests/PHPCSAnnotations/disable-non-matching-enable.inc
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @phpcs:disable WordPress
+ */
+
+class My_Class {}
+
+// phpcs:enable PSR2
+
+// phpcs:enable WordPress.Category
+
+// phpcs:enable WordPress.Files.NotFileNameSniff

--- a/WordPress/Tests/WP/CapitalPDangitUnitTest.1.inc
+++ b/WordPress/Tests/WP/CapitalPDangitUnitTest.1.inc
@@ -228,3 +228,6 @@ enum My_Wordpress_Enum {} // Bad.
  */
 namespace My\Class\WordPress;
 echo Some\Enum\WordPress::ENUM_CONSTANT;
+
+// Safeguard that the sniff doesn't act on anonymous classes.
+$anon = new class() {};

--- a/WordPress/Tests/WP/CapitalPDangitUnitTest.1.inc.fixed
+++ b/WordPress/Tests/WP/CapitalPDangitUnitTest.1.inc.fixed
@@ -228,3 +228,6 @@ enum My_Wordpress_Enum {} // Bad.
  */
 namespace My\Class\WordPress;
 echo Some\Enum\WordPress::ENUM_CONSTANT;
+
+// Safeguard that the sniff doesn't act on anonymous classes.
+$anon = new class() {};

--- a/WordPress/Tests/WP/DeprecatedParameterValuesUnitTest.inc
+++ b/WordPress/Tests/WP/DeprecatedParameterValuesUnitTest.inc
@@ -49,3 +49,6 @@ get_option(default: $default, option: 'comment_whitelist');
 update_option('blacklist_keys', $value);
 update_option('comment_whitelist', $value);
 update_option(autoload: true, value: $value, option: 'blacklist_keys');
+
+// Live coding/parse error.
+get_bloginfo( show: /*to do*/, );


### PR DESCRIPTION
### WPDBTrait: add some extra tests

... to cover some previously uncovered code paths/code patterns.

### CodeAnalysis/AssignmentInTernaryCondition: add extra test

... for parse error edge case / to cover some previously uncovered code paths/code patterns.

### Files/FileName: add some extra tests

... to cover some previously uncovered code paths/code patterns.

### WP/CapitalPDangit: add extra test

... for an edge case / to cover some previously uncovered code paths/code patterns.

### WP/DeprecatedParameterValues: add extra test

... for an edge case / to cover some previously uncovered code paths/code patterns.