### PR TITLE
Tests: allow for recording code coverage + add `@covers` tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
-vendor
+vendor/
 composer.lock
+build/
 phpunit.xml
 phpcs.xml
 .phpcs.xml

--- a/WordPress/Tests/Arrays/ArrayDeclarationSpacingUnitTest.php
+++ b/WordPress/Tests/Arrays/ArrayDeclarationSpacingUnitTest.php
@@ -18,6 +18,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since   0.11.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
+ *
+ * @covers \WordPressCS\WordPress\Sniffs\Arrays\ArrayDeclarationSpacingSniff
  */
 final class ArrayDeclarationSpacingUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPress/Tests/Arrays/ArrayIndentationUnitTest.php
+++ b/WordPress/Tests/Arrays/ArrayIndentationUnitTest.php
@@ -18,6 +18,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since   0.12.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
+ *
+ * @covers \WordPressCS\WordPress\Sniffs\Arrays\ArrayIndentationSniff
  */
 final class ArrayIndentationUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPress/Tests/Arrays/ArrayKeySpacingRestrictionsUnitTest.php
+++ b/WordPress/Tests/Arrays/ArrayKeySpacingRestrictionsUnitTest.php
@@ -18,6 +18,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since   0.3.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
+ *
+ * @covers \WordPressCS\WordPress\Sniffs\Arrays\ArrayKeySpacingRestrictionsSniff
  */
 final class ArrayKeySpacingRestrictionsUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPress/Tests/Arrays/CommaAfterArrayItemUnitTest.php
+++ b/WordPress/Tests/Arrays/CommaAfterArrayItemUnitTest.php
@@ -18,6 +18,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since   0.12.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
+ *
+ * @covers \WordPressCS\WordPress\Sniffs\Arrays\CommaAfterArrayItemSniff
  */
 final class CommaAfterArrayItemUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPress/Tests/Arrays/MultipleStatementAlignmentUnitTest.php
+++ b/WordPress/Tests/Arrays/MultipleStatementAlignmentUnitTest.php
@@ -21,6 +21,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @package WPCS\WordPressCodingStandards
  *
  * @since   0.14.0
+ *
+ * @covers \WordPressCS\WordPress\Sniffs\Arrays\MultipleStatementAlignmentSniff
  */
 final class MultipleStatementAlignmentUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPress/Tests/CodeAnalysis/AssignmentInTernaryConditionUnitTest.php
+++ b/WordPress/Tests/CodeAnalysis/AssignmentInTernaryConditionUnitTest.php
@@ -17,6 +17,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @package WPCS\WordPressCodingStandards
  *
  * @since   0.14.0
+ *
+ * @covers \WordPressCS\WordPress\Sniffs\CodeAnalysis\AssignmentInTernaryConditionSniff
  */
 final class AssignmentInTernaryConditionUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPress/Tests/CodeAnalysis/EscapedNotTranslatedUnitTest.php
+++ b/WordPress/Tests/CodeAnalysis/EscapedNotTranslatedUnitTest.php
@@ -17,6 +17,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @package WPCS\WordPressCodingStandards
  *
  * @since   2.2.0
+ *
+ * @covers \WordPressCS\WordPress\Sniffs\CodeAnalysis\EscapedNotTranslatedSniff
  */
 final class EscapedNotTranslatedUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPress/Tests/DB/DirectDatabaseQueryUnitTest.php
+++ b/WordPress/Tests/DB/DirectDatabaseQueryUnitTest.php
@@ -20,6 +20,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @since   0.13.0 Class name changed: this class is now namespaced.
  * @since   1.0.0  This sniff has been moved from the `VIP` category to the `DB` category.
  *
+ * @covers \WordPressCS\WordPress\Helpers\RulesetPropertyHelper
  * @covers \WordPressCS\WordPress\Sniffs\DB\DirectDatabaseQuerySniff
  */
 final class DirectDatabaseQueryUnitTest extends AbstractSniffUnitTest {

--- a/WordPress/Tests/DB/DirectDatabaseQueryUnitTest.php
+++ b/WordPress/Tests/DB/DirectDatabaseQueryUnitTest.php
@@ -19,6 +19,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @since   0.3.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
  * @since   1.0.0  This sniff has been moved from the `VIP` category to the `DB` category.
+ *
+ * @covers \WordPressCS\WordPress\Sniffs\DB\DirectDatabaseQuerySniff
  */
 final class DirectDatabaseQueryUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPress/Tests/DB/PreparedSQLPlaceholdersUnitTest.php
+++ b/WordPress/Tests/DB/PreparedSQLPlaceholdersUnitTest.php
@@ -17,6 +17,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @package WPCS\WordPressCodingStandards
  *
  * @since   0.14.0
+ *
+ * @covers \WordPressCS\WordPress\Sniffs\DB\PreparedSQLPlaceholdersSniff
  */
 final class PreparedSQLPlaceholdersUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPress/Tests/DB/PreparedSQLUnitTest.php
+++ b/WordPress/Tests/DB/PreparedSQLUnitTest.php
@@ -19,6 +19,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @since   0.8.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
  * @since   1.0.0  This sniff has been moved from the `WP` category to the `DB` category.
+ *
+ * @covers \WordPressCS\WordPress\Sniffs\DB\PreparedSQLSniff
  */
 final class PreparedSQLUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPress/Tests/DB/PreparedSQLUnitTest.php
+++ b/WordPress/Tests/DB/PreparedSQLUnitTest.php
@@ -20,6 +20,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @since   0.13.0 Class name changed: this class is now namespaced.
  * @since   1.0.0  This sniff has been moved from the `WP` category to the `DB` category.
  *
+ * @covers \WordPressCS\WordPress\Helpers\WPDBTrait
  * @covers \WordPressCS\WordPress\Sniffs\DB\PreparedSQLSniff
  */
 final class PreparedSQLUnitTest extends AbstractSniffUnitTest {

--- a/WordPress/Tests/DB/RestrictedClassesUnitTest.php
+++ b/WordPress/Tests/DB/RestrictedClassesUnitTest.php
@@ -21,6 +21,7 @@ use WordPressCS\WordPress\AbstractFunctionRestrictionsSniff;
  * @since   0.13.0 Class name changed: this class is now namespaced.
  * @since   3.0.0  Renamed the fixtures to create compatibility with PHPCS 4.x/PHPUnit >=8.
  *
+ * @covers \WordPressCS\WordPress\Helpers\RulesetPropertyHelper
  * @covers \WordPressCS\WordPress\Sniffs\DB\RestrictedClassesSniff
  */
 final class RestrictedClassesUnitTest extends AbstractSniffUnitTest {

--- a/WordPress/Tests/DB/RestrictedClassesUnitTest.php
+++ b/WordPress/Tests/DB/RestrictedClassesUnitTest.php
@@ -20,6 +20,8 @@ use WordPressCS\WordPress\AbstractFunctionRestrictionsSniff;
  * @since   0.10.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
  * @since   3.0.0  Renamed the fixtures to create compatibility with PHPCS 4.x/PHPUnit >=8.
+ *
+ * @covers \WordPressCS\WordPress\Sniffs\DB\RestrictedClassesSniff
  */
 final class RestrictedClassesUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPress/Tests/DB/RestrictedClassesUnitTest.php
+++ b/WordPress/Tests/DB/RestrictedClassesUnitTest.php
@@ -21,6 +21,7 @@ use WordPressCS\WordPress\AbstractFunctionRestrictionsSniff;
  * @since   0.13.0 Class name changed: this class is now namespaced.
  * @since   3.0.0  Renamed the fixtures to create compatibility with PHPCS 4.x/PHPUnit >=8.
  *
+ * @covers \WordPressCS\WordPress\AbstractClassRestrictionsSniff
  * @covers \WordPressCS\WordPress\Helpers\RulesetPropertyHelper
  * @covers \WordPressCS\WordPress\Sniffs\DB\RestrictedClassesSniff
  */

--- a/WordPress/Tests/DB/RestrictedFunctionsUnitTest.php
+++ b/WordPress/Tests/DB/RestrictedFunctionsUnitTest.php
@@ -18,6 +18,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since   0.10.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
+ *
+ * @covers \WordPressCS\WordPress\Sniffs\DB\RestrictedFunctionsSniff
  */
 final class RestrictedFunctionsUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPress/Tests/DB/SlowDBQueryUnitTest.php
+++ b/WordPress/Tests/DB/SlowDBQueryUnitTest.php
@@ -20,6 +20,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @since   0.13.0 Class name changed: this class is now namespaced.
  * @since   1.0.0  This sniff has been moved from the `VIP` category to the `DB` category.
  *
+ * @covers \WordPressCS\WordPress\AbstractArrayAssignmentRestrictionsSniff
  * @covers \WordPressCS\WordPress\Sniffs\DB\SlowDBQuerySniff
  */
 final class SlowDBQueryUnitTest extends AbstractSniffUnitTest {

--- a/WordPress/Tests/DB/SlowDBQueryUnitTest.php
+++ b/WordPress/Tests/DB/SlowDBQueryUnitTest.php
@@ -19,6 +19,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @since   0.3.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
  * @since   1.0.0  This sniff has been moved from the `VIP` category to the `DB` category.
+ *
+ * @covers \WordPressCS\WordPress\Sniffs\DB\SlowDBQuerySniff
  */
 final class SlowDBQueryUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPress/Tests/DateTime/CurrentTimeTimestampUnitTest.php
+++ b/WordPress/Tests/DateTime/CurrentTimeTimestampUnitTest.php
@@ -17,6 +17,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @package WPCS\WordPressCodingStandards
  *
  * @since   2.2.0
+ *
+ * @covers \WordPressCS\WordPress\Sniffs\DateTime\CurrentTimeTimestampSniff
  */
 final class CurrentTimeTimestampUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPress/Tests/DateTime/RestrictedFunctionsUnitTest.php
+++ b/WordPress/Tests/DateTime/RestrictedFunctionsUnitTest.php
@@ -17,6 +17,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @package WPCS\WordPressCodingStandards
  *
  * @since   2.2.0
+ *
+ * @covers \WordPressCS\WordPress\Sniffs\DateTime\RestrictedFunctionsSniff
  */
 final class RestrictedFunctionsUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPress/Tests/Files/FileNameUnitTest.php
+++ b/WordPress/Tests/Files/FileNameUnitTest.php
@@ -19,6 +19,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @since   2013-06-11
  * @since   0.11.0     Actually added tests ;-)
  * @since   0.13.0     Class name changed: this class is now namespaced.
+ *
+ * @covers \WordPressCS\WordPress\Sniffs\Files\FileNameSniff
  */
 final class FileNameUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.php
+++ b/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.php
@@ -18,6 +18,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since   0.12.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
+ *
+ * @covers \WordPressCS\WordPress\Sniffs\NamingConventions\PrefixAllGlobalsSniff
  */
 final class PrefixAllGlobalsUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.php
+++ b/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.php
@@ -19,6 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @since   0.12.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
  *
+ * @covers \WordPressCS\WordPress\Helpers\IsUnitTestTrait
  * @covers \WordPressCS\WordPress\Sniffs\NamingConventions\PrefixAllGlobalsSniff
  */
 final class PrefixAllGlobalsUnitTest extends AbstractSniffUnitTest {

--- a/WordPress/Tests/NamingConventions/ValidFunctionNameUnitTest.php
+++ b/WordPress/Tests/NamingConventions/ValidFunctionNameUnitTest.php
@@ -19,6 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @since   2013-06-11
  * @since   0.13.0     Class name changed: this class is now namespaced.
  *
+ * @covers \WordPressCS\WordPress\Helpers\DeprecationHelper
  * @covers \WordPressCS\WordPress\Sniffs\NamingConventions\ValidFunctionNameSniff
  */
 final class ValidFunctionNameUnitTest extends AbstractSniffUnitTest {

--- a/WordPress/Tests/NamingConventions/ValidFunctionNameUnitTest.php
+++ b/WordPress/Tests/NamingConventions/ValidFunctionNameUnitTest.php
@@ -18,6 +18,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since   2013-06-11
  * @since   0.13.0     Class name changed: this class is now namespaced.
+ *
+ * @covers \WordPressCS\WordPress\Sniffs\NamingConventions\ValidFunctionNameSniff
  */
 final class ValidFunctionNameUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPress/Tests/NamingConventions/ValidHookNameUnitTest.php
+++ b/WordPress/Tests/NamingConventions/ValidHookNameUnitTest.php
@@ -18,6 +18,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since   0.10.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
+ *
+ * @covers \WordPressCS\WordPress\Sniffs\NamingConventions\ValidHookNameSniff
  */
 final class ValidHookNameUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPress/Tests/NamingConventions/ValidHookNameUnitTest.php
+++ b/WordPress/Tests/NamingConventions/ValidHookNameUnitTest.php
@@ -19,6 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @since   0.10.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
  *
+ * @covers \WordPressCS\WordPress\Helpers\WPHookHelper
  * @covers \WordPressCS\WordPress\Sniffs\NamingConventions\ValidHookNameSniff
  */
 final class ValidHookNameUnitTest extends AbstractSniffUnitTest {

--- a/WordPress/Tests/NamingConventions/ValidPostTypeSlugUnitTest.php
+++ b/WordPress/Tests/NamingConventions/ValidPostTypeSlugUnitTest.php
@@ -17,6 +17,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @package WPCS\WordPressCodingStandards
  *
  * @since   2.2.0
+ *
+ * @covers \WordPressCS\WordPress\Sniffs\NamingConventions\ValidPostTypeSlugSniff
  */
 final class ValidPostTypeSlugUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPress/Tests/NamingConventions/ValidVariableNameUnitTest.php
+++ b/WordPress/Tests/NamingConventions/ValidVariableNameUnitTest.php
@@ -18,6 +18,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since   0.9.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
+ *
+ * @covers \WordPressCS\WordPress\Sniffs\NamingConventions\ValidVariableNameSniff
  */
 final class ValidVariableNameUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPress/Tests/NamingConventions/ValidVariableNameUnitTest.php
+++ b/WordPress/Tests/NamingConventions/ValidVariableNameUnitTest.php
@@ -19,6 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @since   0.9.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
  *
+ * @covers \WordPressCS\WordPress\Helpers\SnakeCaseHelper
  * @covers \WordPressCS\WordPress\Sniffs\NamingConventions\ValidVariableNameSniff
  */
 final class ValidVariableNameUnitTest extends AbstractSniffUnitTest {

--- a/WordPress/Tests/PHP/DevelopmentFunctionsUnitTest.php
+++ b/WordPress/Tests/PHP/DevelopmentFunctionsUnitTest.php
@@ -18,6 +18,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since   0.11.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
+ *
+ * @covers \WordPressCS\WordPress\Sniffs\PHP\DevelopmentFunctionsSniff
  */
 final class DevelopmentFunctionsUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPress/Tests/PHP/DiscouragedPHPFunctionsUnitTest.php
+++ b/WordPress/Tests/PHP/DiscouragedPHPFunctionsUnitTest.php
@@ -18,6 +18,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since   0.11.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
+ *
+ * @covers \WordPressCS\WordPress\Sniffs\PHP\DiscouragedPHPFunctionsSniff
  */
 final class DiscouragedPHPFunctionsUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPress/Tests/PHP/DontExtractUnitTest.php
+++ b/WordPress/Tests/PHP/DontExtractUnitTest.php
@@ -19,6 +19,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @since   0.10.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
  * @since   1.0.0  This sniff has been moved from the `Functions` category to the `PHP` category.
+ *
+ * @covers \WordPressCS\WordPress\Sniffs\PHP\DontExtractSniff
  */
 final class DontExtractUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPress/Tests/PHP/IniSetUnitTest.php
+++ b/WordPress/Tests/PHP/IniSetUnitTest.php
@@ -17,6 +17,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @package WPCS\WordPressCodingStandards
  *
  * @since 2.1.0
+ *
+ * @covers \WordPressCS\WordPress\Sniffs\PHP\IniSetSniff
  */
 final class IniSetUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPress/Tests/PHP/NoSilencedErrorsUnitTest.php
+++ b/WordPress/Tests/PHP/NoSilencedErrorsUnitTest.php
@@ -17,6 +17,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @package WPCS\WordPressCodingStandards
  *
  * @since   1.1.0
+ *
+ * @covers \WordPressCS\WordPress\Sniffs\PHP\NoSilencedErrorsSniff
  */
 final class NoSilencedErrorsUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPress/Tests/PHP/POSIXFunctionsUnitTest.php
+++ b/WordPress/Tests/PHP/POSIXFunctionsUnitTest.php
@@ -18,6 +18,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since   0.10.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
+ *
+ * @covers \WordPressCS\WordPress\Sniffs\PHP\POSIXFunctionsSniff
  */
 final class POSIXFunctionsUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPress/Tests/PHP/PregQuoteDelimiterUnitTest.php
+++ b/WordPress/Tests/PHP/PregQuoteDelimiterUnitTest.php
@@ -17,6 +17,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @package WPCS\WordPressCodingStandards
  *
  * @since   1.0.0
+ *
+ * @covers \WordPressCS\WordPress\Sniffs\PHP\PregQuoteDelimiterSniff
  */
 final class PregQuoteDelimiterUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPress/Tests/PHP/RestrictedPHPFunctionsUnitTest.php
+++ b/WordPress/Tests/PHP/RestrictedPHPFunctionsUnitTest.php
@@ -17,6 +17,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @package WPCS\WordPressCodingStandards
  *
  * @since   0.14.0
+ *
+ * @covers \WordPressCS\WordPress\Sniffs\PHP\RestrictedPHPFunctionsSniff
  */
 final class RestrictedPHPFunctionsUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPress/Tests/PHP/StrictInArrayUnitTest.php
+++ b/WordPress/Tests/PHP/StrictInArrayUnitTest.php
@@ -18,6 +18,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since   0.9.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
+ *
+ * @covers \WordPressCS\WordPress\Sniffs\PHP\StrictInArraySniff
  */
 final class StrictInArrayUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPress/Tests/PHP/StrictInArrayUnitTest.php
+++ b/WordPress/Tests/PHP/StrictInArrayUnitTest.php
@@ -19,6 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @since   0.9.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
  *
+ * @covers \WordPressCS\WordPress\AbstractFunctionParameterSniff
  * @covers \WordPressCS\WordPress\Sniffs\PHP\StrictInArraySniff
  */
 final class StrictInArrayUnitTest extends AbstractSniffUnitTest {

--- a/WordPress/Tests/PHP/TypeCastsUnitTest.php
+++ b/WordPress/Tests/PHP/TypeCastsUnitTest.php
@@ -17,6 +17,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @package WPCS\WordPressCodingStandards
  *
  * @since 1.2.0
+ *
+ * @covers \WordPressCS\WordPress\Sniffs\PHP\TypeCastsSniff
  */
 final class TypeCastsUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPress/Tests/PHP/YodaConditionsUnitTest.php
+++ b/WordPress/Tests/PHP/YodaConditionsUnitTest.php
@@ -18,6 +18,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since   0.3.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
+ *
+ * @covers \WordPressCS\WordPress\Sniffs\PHP\YodaConditionsSniff
  */
 final class YodaConditionsUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPress/Tests/Security/EscapeOutputUnitTest.php
+++ b/WordPress/Tests/Security/EscapeOutputUnitTest.php
@@ -19,6 +19,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @since   2013-06-11
  * @since   0.13.0     Class name changed: this class is now namespaced.
  * @since   1.0.0      This sniff has been moved from the `XSS` category to the `Security` category.
+ *
+ * @covers \WordPressCS\WordPress\Sniffs\Security\EscapeOutputSniff
  */
 final class EscapeOutputUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPress/Tests/Security/NonceVerificationUnitTest.php
+++ b/WordPress/Tests/Security/NonceVerificationUnitTest.php
@@ -19,6 +19,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @since   0.5.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
  * @since   1.0.0  This sniff has been moved from the `CSRF` category to the `Security` category.
+ *
+ * @covers \WordPressCS\WordPress\Sniffs\Security\NonceVerificationSniff
  */
 final class NonceVerificationUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPress/Tests/Security/PluginMenuSlugUnitTest.php
+++ b/WordPress/Tests/Security/PluginMenuSlugUnitTest.php
@@ -19,6 +19,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @since   0.3.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
  * @since   1.0.0  This sniff has been moved from the `VIP` category to the `Security` category.
+ *
+ * @covers \WordPressCS\WordPress\Sniffs\Security\PluginMenuSlugSniff
  */
 final class PluginMenuSlugUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPress/Tests/Security/SafeRedirectUnitTest.php
+++ b/WordPress/Tests/Security/SafeRedirectUnitTest.php
@@ -17,6 +17,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @package WPCS\WordPressCodingStandards
  *
  * @since   1.0.0
+ *
+ * @covers \WordPressCS\WordPress\Sniffs\Security\SafeRedirectSniff
  */
 final class SafeRedirectUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPress/Tests/Security/ValidatedSanitizedInputUnitTest.php
+++ b/WordPress/Tests/Security/ValidatedSanitizedInputUnitTest.php
@@ -19,6 +19,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @since   0.3.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
  * @since   1.0.0  This sniff has been moved from the `VIP` category to the `Security` category.
+ *
+ * @covers \WordPressCS\WordPress\Sniffs\Security\ValidatedSanitizedInputSniff
  */
 final class ValidatedSanitizedInputUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPress/Tests/Security/ValidatedSanitizedInputUnitTest.php
+++ b/WordPress/Tests/Security/ValidatedSanitizedInputUnitTest.php
@@ -20,6 +20,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @since   0.13.0 Class name changed: this class is now namespaced.
  * @since   1.0.0  This sniff has been moved from the `VIP` category to the `Security` category.
  *
+ * @covers \WordPressCS\WordPress\Helpers\VariableHelper
  * @covers \WordPressCS\WordPress\Sniffs\Security\ValidatedSanitizedInputSniff
  */
 final class ValidatedSanitizedInputUnitTest extends AbstractSniffUnitTest {

--- a/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.php
+++ b/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.php
@@ -18,6 +18,8 @@ use PHPCSUtils\BackCompat\Helper;
  * @package WPCS\WordPressCodingStandards
  *
  * @since   1.2.0
+ *
+ * @covers \WordPressCS\WordPress\Sniffs\Utils\I18nTextDomainFixerSniff
  */
 final class I18nTextDomainFixerUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPress/Tests/WP/AlternativeFunctionsUnitTest.php
+++ b/WordPress/Tests/WP/AlternativeFunctionsUnitTest.php
@@ -18,6 +18,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since   0.11.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
+ *
+ * @covers \WordPressCS\WordPress\Sniffs\WP\AlternativeFunctionsSniff
  */
 final class AlternativeFunctionsUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPress/Tests/WP/AlternativeFunctionsUnitTest.php
+++ b/WordPress/Tests/WP/AlternativeFunctionsUnitTest.php
@@ -19,6 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @since   0.11.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
  *
+ * @covers \WordPressCS\WordPress\Helpers\MinimumWPVersionTrait
  * @covers \WordPressCS\WordPress\Sniffs\WP\AlternativeFunctionsSniff
  */
 final class AlternativeFunctionsUnitTest extends AbstractSniffUnitTest {

--- a/WordPress/Tests/WP/CapabilitiesUnitTest.php
+++ b/WordPress/Tests/WP/CapabilitiesUnitTest.php
@@ -17,6 +17,8 @@ use PHPCSUtils\BackCompat\Helper;
  *
  * @package WPCS\WordPressCodingStandards
  * @since   3.0.0
+ *
+ * @covers \WordPressCS\WordPress\Sniffs\WP\CapabilitiesSniff
  */
 final class CapabilitiesUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPress/Tests/WP/CapitalPDangitUnitTest.php
+++ b/WordPress/Tests/WP/CapitalPDangitUnitTest.php
@@ -18,6 +18,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since   0.12.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
+ *
+ * @covers \WordPressCS\WordPress\Sniffs\WP\CapitalPDangitSniff
  */
 final class CapitalPDangitUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPress/Tests/WP/ClassNameCaseUnitTest.php
+++ b/WordPress/Tests/WP/ClassNameCaseUnitTest.php
@@ -17,6 +17,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @package WPCS\WordPressCodingStandards
  *
  * @since 3.0.0
+ *
+ * @covers \WordPressCS\WordPress\Sniffs\WP\ClassNameCaseSniff
  */
 final class ClassNameCaseUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPress/Tests/WP/CronIntervalUnitTest.php
+++ b/WordPress/Tests/WP/CronIntervalUnitTest.php
@@ -19,6 +19,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @since   0.3.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
  * @since   1.0.0  This sniff has been moved from the `VIP` category to the `WP` category.
+ *
+ * @covers \WordPressCS\WordPress\Sniffs\WP\CronIntervalSniff
  */
 final class CronIntervalUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPress/Tests/WP/DeprecatedClassesUnitTest.php
+++ b/WordPress/Tests/WP/DeprecatedClassesUnitTest.php
@@ -18,6 +18,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since   0.12.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
+ *
+ * @covers \WordPressCS\WordPress\Sniffs\WP\DeprecatedClassesSniff
  */
 final class DeprecatedClassesUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPress/Tests/WP/DeprecatedFunctionsUnitTest.php
+++ b/WordPress/Tests/WP/DeprecatedFunctionsUnitTest.php
@@ -18,6 +18,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since   0.11.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
+ *
+ * @covers \WordPressCS\WordPress\Sniffs\WP\DeprecatedFunctionsSniff
  */
 final class DeprecatedFunctionsUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPress/Tests/WP/DeprecatedParameterValuesUnitTest.php
+++ b/WordPress/Tests/WP/DeprecatedParameterValuesUnitTest.php
@@ -17,6 +17,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @package WPCS\WordPressCodingStandards
  *
  * @since   1.0.0
+ *
+ * @covers \WordPressCS\WordPress\Sniffs\WP\DeprecatedParameterValuesSniff
  */
 final class DeprecatedParameterValuesUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPress/Tests/WP/DeprecatedParametersUnitTest.php
+++ b/WordPress/Tests/WP/DeprecatedParametersUnitTest.php
@@ -18,6 +18,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since   0.12.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
+ *
+ * @covers \WordPressCS\WordPress\Sniffs\WP\DeprecatedParametersSniff
  */
 final class DeprecatedParametersUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPress/Tests/WP/DiscouragedConstantsUnitTest.php
+++ b/WordPress/Tests/WP/DiscouragedConstantsUnitTest.php
@@ -16,6 +16,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @package WPCS\WordPressCodingStandards
  * @since   0.14.0
+ *
+ * @covers \WordPressCS\WordPress\Sniffs\WP\DiscouragedConstantsSniff
  */
 final class DiscouragedConstantsUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPress/Tests/WP/DiscouragedFunctionsUnitTest.php
+++ b/WordPress/Tests/WP/DiscouragedFunctionsUnitTest.php
@@ -18,6 +18,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since   0.11.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
+ *
+ * @covers \WordPressCS\WordPress\Sniffs\WP\DiscouragedFunctionsSniff
  */
 final class DiscouragedFunctionsUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPress/Tests/WP/DiscouragedFunctionsUnitTest.php
+++ b/WordPress/Tests/WP/DiscouragedFunctionsUnitTest.php
@@ -19,6 +19,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @since   0.11.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
  *
+ * @covers \WordPressCS\WordPress\AbstractFunctionRestrictionsSniff
  * @covers \WordPressCS\WordPress\Sniffs\WP\DiscouragedFunctionsSniff
  */
 final class DiscouragedFunctionsUnitTest extends AbstractSniffUnitTest {

--- a/WordPress/Tests/WP/EnqueuedResourceParametersUnitTest.php
+++ b/WordPress/Tests/WP/EnqueuedResourceParametersUnitTest.php
@@ -17,6 +17,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @package WPCS\WordPressCodingStandards
  *
  * @since   1.0.0
+ *
+ * @covers \WordPressCS\WordPress\Sniffs\WP\EnqueuedResourceParametersSniff
  */
 final class EnqueuedResourceParametersUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPress/Tests/WP/EnqueuedResourcesUnitTest.php
+++ b/WordPress/Tests/WP/EnqueuedResourcesUnitTest.php
@@ -18,6 +18,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since   0.3.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
+ *
+ * @covers \WordPressCS\WordPress\Sniffs\WP\EnqueuedResourcesSniff
  */
 final class EnqueuedResourcesUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPress/Tests/WP/GlobalVariablesOverrideUnitTest.php
+++ b/WordPress/Tests/WP/GlobalVariablesOverrideUnitTest.php
@@ -20,6 +20,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @since   0.13.0 Class name changed: this class is now namespaced.
  * @since   1.0.0  This sniff has been moved from the `Variables` category to the `WP`
  *                 category and renamed from `GlobalVariables` to `GlobalVariablesOverride`.
+ *
+ * @covers \WordPressCS\WordPress\Sniffs\WP\GlobalVariablesOverrideSniff
  */
 final class GlobalVariablesOverrideUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPress/Tests/WP/GlobalVariablesOverrideUnitTest.php
+++ b/WordPress/Tests/WP/GlobalVariablesOverrideUnitTest.php
@@ -21,6 +21,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @since   1.0.0  This sniff has been moved from the `Variables` category to the `WP`
  *                 category and renamed from `GlobalVariables` to `GlobalVariablesOverride`.
  *
+ * @covers \WordPressCS\WordPress\Helpers\WPGlobalVariablesHelper
  * @covers \WordPressCS\WordPress\Sniffs\WP\GlobalVariablesOverrideSniff
  */
 final class GlobalVariablesOverrideUnitTest extends AbstractSniffUnitTest {

--- a/WordPress/Tests/WP/I18nUnitTest.php
+++ b/WordPress/Tests/WP/I18nUnitTest.php
@@ -18,6 +18,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since   0.10.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
+ *
+ * @covers \WordPressCS\WordPress\Sniffs\WP\I18nSniff
  */
 final class I18nUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPress/Tests/WP/PostsPerPageUnitTest.php
+++ b/WordPress/Tests/WP/PostsPerPageUnitTest.php
@@ -21,6 +21,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @since   1.0.0  This sniff has been split into two, with the check for high pagination
  *                 limit being part of the WP category, and the check for pagination
  *                 disabling being part of the VIP category.
+ *
+ * @covers \WordPressCS\WordPress\Sniffs\WP\PostsPerPageSniff
  */
 final class PostsPerPageUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPress/Tests/WP/PostsPerPageUnitTest.php
+++ b/WordPress/Tests/WP/PostsPerPageUnitTest.php
@@ -22,6 +22,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *                 limit being part of the WP category, and the check for pagination
  *                 disabling being part of the VIP category.
  *
+ * @covers \WordPressCS\WordPress\AbstractArrayAssignmentRestrictionsSniff
  * @covers \WordPressCS\WordPress\Sniffs\WP\PostsPerPageSniff
  */
 final class PostsPerPageUnitTest extends AbstractSniffUnitTest {

--- a/WordPress/Tests/WhiteSpace/CastStructureSpacingUnitTest.php
+++ b/WordPress/Tests/WhiteSpace/CastStructureSpacingUnitTest.php
@@ -18,6 +18,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since   0.3.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
+ *
+ * @covers \WordPressCS\WordPress\Sniffs\WhiteSpace\CastStructureSpacingSniff
  */
 final class CastStructureSpacingUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.php
+++ b/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.php
@@ -18,6 +18,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @since   2013-06-11
  * @since   0.13.0     Class name changed: this class is now namespaced.
+ *
+ * @covers \WordPressCS\WordPress\Sniffs\WhiteSpace\ControlStructureSpacingSniff
  */
 final class ControlStructureSpacingUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPress/Tests/WhiteSpace/ObjectOperatorSpacingUnitTest.php
+++ b/WordPress/Tests/WhiteSpace/ObjectOperatorSpacingUnitTest.php
@@ -17,6 +17,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @package WPCS\WordPressCodingStandards
  *
  * @since 3.0.0
+ *
+ * @covers \WordPressCS\WordPress\Sniffs\WhiteSpace\ObjectOperatorSpacingSniff
  */
 final class ObjectOperatorSpacingUnitTest extends AbstractSniffUnitTest {
 

--- a/WordPress/Tests/WhiteSpace/OperatorSpacingUnitTest.php
+++ b/WordPress/Tests/WhiteSpace/OperatorSpacingUnitTest.php
@@ -20,6 +20,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @since   0.12.0     Now only tests the WPCS specific addition of T_BOOLEAN_NOT.
  *                     The rest of the sniff is unit tested upstream.
  * @since   0.13.0     Class name changed: this class is now namespaced.
+ *
+ * @covers \WordPressCS\WordPress\Sniffs\WhiteSpace\OperatorSpacingSniff
  */
 final class OperatorSpacingUnitTest extends AbstractSniffUnitTest {
 

--- a/composer.json
+++ b/composer.json
@@ -48,6 +48,9 @@
 			"@php ./vendor/squizlabs/php_codesniffer/bin/phpcbf"
 		],
 		"run-tests": [
+			"@php ./vendor/phpunit/phpunit/phpunit --filter WordPress ./vendor/squizlabs/php_codesniffer/tests/AllTests.php --no-coverage"
+		],
+		"coverage": [
 			"@php ./vendor/phpunit/phpunit/phpunit --filter WordPress ./vendor/squizlabs/php_codesniffer/tests/AllTests.php"
 		],
 		"check-complete": [
@@ -67,7 +70,8 @@
 		"lint": "Lint PHP files against parse errors.",
 		"check-cs": "Run the PHPCS script against the entire codebase.",
 		"fix-cs": "Run the PHPCBF script to fix all the autofixable violations on the codebase.",
-		"run-tests": "Run all the unit tests for the WordPress Coding Standards sniffs.",
+		"run-tests": "Run all the unit tests for the WordPress Coding Standards sniffs without code coverage.",
+		"coverage": "Run all the unit tests for the WordPress Coding Standards sniffs with code coverage.",
 		"check-complete": "Check if all the sniffs have tests.",
 		"check-complete-strict": "Check if all the sniffs have unit tests and XML documentation.",
 		"check-all": "Run all checks (lint, phpcs, feature completeness) and tests."

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -5,12 +5,31 @@
 	backupGlobals="true"
 	bootstrap="./Tests/bootstrap.php"
 	beStrictAboutTestsThatDoNotTestAnything="false"
-	colors="true">
+	colors="true"
+	forceCoversAnnotation="true">
 
 	<testsuites>
 		<testsuite name="WordPress">
 			<directory suffix="UnitTest.php">./WordPress/Tests/</directory>
 		</testsuite>
 	</testsuites>
+
+	<filter>
+		<whitelist addUncoveredFilesFromWhitelist="true" processUncoveredFilesFromWhitelist="false">
+			<file>./WordPress/Sniff.php</file>
+			<file>./WordPress/PHPCSHelper.php</file>
+			<file>./WordPress/AbstractArrayAssignmentRestrictionsSniff.php</file>
+			<file>./WordPress/AbstractClassRestrictionsSniff.php</file>
+			<file>./WordPress/AbstractFunctionParameterSniff.php</file>
+			<file>./WordPress/AbstractFunctionRestrictionsSniff.php</file>
+			<directory>./WordPress/Sniffs/</directory>
+			<directory>./WordPress/Helpers/</directory>
+		</whitelist>
+	</filter>
+
+	<logging>
+		<log type="coverage-text" target="php://stdout" showUncoveredFiles="true"/>
+		<log type="coverage-clover" target="build/logs/clover.xml"/>
+	</logging>
 
 </phpunit>


### PR DESCRIPTION
### Tests: allow for recording code coverage + add `@covers` tags

... to all unit test files, as well as enable strict coverage recording.

Includes:
* PHPUnit config: add code coverage configuration.
    By default, when there is a code coverage configuration and Xdebug is enabled, code coverage will be generated.
    Note: generating code coverage is slow.
* Git ignore the `build` directory as created by PHPUnit to store the log files (as set up in the config file).
* Composer: add coverage script and adjust the test script.
    * When running the "normal" `run-tests`, no code coverage will be created.
    * To run the tests with code coverage, the new `coverage` script has been added.

When running PHPUnit locally, I'd recommend copying the `phpunit.xml.dist` file to `phpunit.xml` and replacing the `clover` logging with the following to allow for locally using the HTML report:
```xml
        <log type="coverage-html" target="./build/coverage-html/"/>
```

Note: this commit does not set up code coverage checking for PRs via an external service like Coveralls or CodeCov, though I imagine we could set this up in the future as the WP organisation already has a CodeCov account (we'd need to check if we can or need permission).

### Tests: add `@covers` tags for Helpers

As the `Helpers` in WPCS do not have dedicated tests, but are tested via the sniffs using them, I'm adding `@covers` tags for these to select sniffs.

At a later point in time, we can revisit whether or not to add dedicated tests for the Helpers.

### Tests: add `@covers` tags for abstract base sniff classes

As the abstract sniff base classes in WPCS do not have dedicated tests, but are tested via the sniffs using them, I'm adding `@covers` tags for these to select sniffs.

As the majority of these will at some point in the future be replaced by (fully tested) abstracts from PHPCSUtils, I'm not concerned with adding dedicated tests for these, so this will do until they are deprecated/removed.