### PR TITLE
Move is_class_object_call() utility method to dedicated `ContextHelper` + support nullsafe object operator

### DIFF
--- a/WordPress/AbstractFunctionRestrictionsSniff.php
+++ b/WordPress/AbstractFunctionRestrictionsSniff.php
@@ -11,6 +11,7 @@ namespace WordPressCS\WordPress;
 
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\Utils\MessageHelper;
+use WordPressCS\WordPress\Helpers\ContextHelper;
 use WordPressCS\WordPress\Helpers\RulesetPropertyHelper;
 use WordPressCS\WordPress\Sniff;
 
@@ -219,7 +220,7 @@ abstract class AbstractFunctionRestrictionsSniff extends Sniff {
 		}
 
 		// Exclude function definitions, class methods, and namespaced calls.
-		if ( $this->is_class_object_call( $stackPtr ) === true ) {
+		if ( ContextHelper::has_object_operator_before( $this->phpcsFile, $stackPtr ) === true ) {
 			return false;
 		}
 

--- a/WordPress/Helpers/ContextHelper.php
+++ b/WordPress/Helpers/ContextHelper.php
@@ -11,6 +11,7 @@ namespace WordPressCS\WordPress\Helpers;
 
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Tokens\Collections;
 
 /**
  * Helper utilities for checking the context in which a token is used.
@@ -42,18 +43,9 @@ final class ContextHelper {
 	 * @return bool
 	 */
 	public static function has_object_operator_before( File $phpcsFile, $stackPtr ) {
-		$before = $phpcsFile->findPrevious( Tokens::$emptyTokens, ( $stackPtr - 1 ), null, true, null, true );
-		if ( false === $before ) {
-			return false;
-		}
-
 		$tokens = $phpcsFile->getTokens();
-		if ( \T_OBJECT_OPERATOR !== $tokens[ $before ]['code']
-			&& \T_DOUBLE_COLON !== $tokens[ $before ]['code']
-		) {
-			return false;
-		}
+		$before = $phpcsFile->findPrevious( Tokens::$emptyTokens, ( $stackPtr - 1 ), null, true );
 
-		return true;
+		return isset( Collections::objectOperators()[ $tokens[ $before ]['code'] ] );
 	}
 }

--- a/WordPress/Helpers/ContextHelper.php
+++ b/WordPress/Helpers/ContextHelper.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPressCS\WordPress\Helpers;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+
+/**
+ * Helper utilities for checking the context in which a token is used.
+ *
+ * ---------------------------------------------------------------------------------------------
+ * This class is only intended for internal use by WordPressCS and is not part of the public API.
+ * This also means that it has no promise of backward compatibility. Use at your own risk.
+ * ---------------------------------------------------------------------------------------------
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @since   3.0.0 The methods in this class were previously contained in the
+ *                `WordPressCS\WordPress\Sniff` class and have been moved here.
+ */
+final class ContextHelper {
+
+	/**
+	 * Check if a particular token acts - statically or non-statically - on an object.
+	 *
+	 * @internal Note: this may still mistake a namespaced function imported via a `use` statement for
+	 * a global function!
+	 *
+	 * @since 2.1.0
+	 * @since 3.0.0 - Moved from the Sniff class to this class.
+	 *              - The method visibility was changed from `protected` to `public static`.
+	 *
+	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+	 * @param int                         $stackPtr  The index of the token in the stack.
+	 *
+	 * @return bool
+	 */
+	public static function has_object_operator_before( File $phpcsFile, $stackPtr ) {
+		$before = $phpcsFile->findPrevious( Tokens::$emptyTokens, ( $stackPtr - 1 ), null, true, null, true );
+		if ( false === $before ) {
+			return false;
+		}
+
+		$tokens = $phpcsFile->getTokens();
+		if ( \T_OBJECT_OPERATOR !== $tokens[ $before ]['code']
+			&& \T_DOUBLE_COLON !== $tokens[ $before ]['code']
+		) {
+			return false;
+		}
+
+		return true;
+	}
+}

--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -16,6 +16,7 @@ use PHPCSUtils\Utils\Lists;
 use PHPCSUtils\Utils\PassedParameters;
 use PHPCSUtils\Utils\Scopes;
 use PHPCSUtils\Utils\TextStrings;
+use WordPressCS\WordPress\Helpers\ContextHelper;
 use WordPressCS\WordPress\Helpers\VariableHelper;
 
 /**
@@ -508,34 +509,6 @@ abstract class Sniff implements PHPCS_Sniff {
 	}
 
 	/**
-	 * Check if a particular token is a (static or non-static) call to a class method or property.
-	 *
-	 * @internal Note: this may still mistake a namespaced function imported via a `use` statement for
-	 * a global function!
-	 *
-	 * @since 2.1.0
-	 *
-	 * @param int $stackPtr The index of the token in the stack.
-	 *
-	 * @return bool
-	 */
-	protected function is_class_object_call( $stackPtr ) {
-		$before = $this->phpcsFile->findPrevious( Tokens::$emptyTokens, ( $stackPtr - 1 ), null, true, null, true );
-
-		if ( false === $before ) {
-			return false;
-		}
-
-		if ( \T_OBJECT_OPERATOR !== $this->tokens[ $before ]['code']
-			&& \T_DOUBLE_COLON !== $this->tokens[ $before ]['code']
-		) {
-			return false;
-		}
-
-		return true;
-	}
-
-	/**
 	 * Check if a particular token is prefixed with a namespace.
 	 *
 	 * @internal This will give a false positive if the file is not namespaced and the token is prefixed
@@ -637,7 +610,7 @@ abstract class Sniff implements PHPCS_Sniff {
 			/*
 			 * Now, make sure it is a global function.
 			 */
-			if ( $this->is_class_object_call( $prev_non_empty ) === true ) {
+			if ( ContextHelper::has_object_operator_before( $this->phpcsFile, $prev_non_empty ) === true ) {
 				continue;
 			}
 
@@ -1026,7 +999,7 @@ abstract class Sniff implements PHPCS_Sniff {
 						continue 2;
 					}
 
-					if ( $this->is_class_object_call( $i ) === true ) {
+					if ( ContextHelper::has_object_operator_before( $this->phpcsFile, $i ) === true ) {
 						// Method call.
 						continue 2;
 					}

--- a/WordPress/Sniffs/Security/NonceVerificationSniff.php
+++ b/WordPress/Sniffs/Security/NonceVerificationSniff.php
@@ -11,6 +11,7 @@ namespace WordPressCS\WordPress\Sniffs\Security;
 
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\Utils\MessageHelper;
+use WordPressCS\WordPress\Helpers\ContextHelper;
 use WordPressCS\WordPress\Helpers\RulesetPropertyHelper;
 use WordPressCS\WordPress\Helpers\VariableHelper;
 use WordPressCS\WordPress\Sniff;
@@ -269,7 +270,7 @@ class NonceVerificationSniff extends Sniff {
 				/*
 				 * Now, make sure it is a call to a global function.
 				 */
-				if ( $this->is_class_object_call( $i ) === true ) {
+				if ( ContextHelper::has_object_operator_before( $this->phpcsFile, $i ) === true ) {
 					continue;
 				}
 

--- a/WordPress/Sniffs/WP/GlobalVariablesOverrideSniff.php
+++ b/WordPress/Sniffs/WP/GlobalVariablesOverrideSniff.php
@@ -17,6 +17,7 @@ use PHPCSUtils\Utils\Lists;
 use PHPCSUtils\Utils\Parentheses;
 use PHPCSUtils\Utils\Scopes;
 use PHPCSUtils\Utils\TextStrings;
+use WordPressCS\WordPress\Helpers\ContextHelper;
 use WordPressCS\WordPress\Helpers\IsUnitTestTrait;
 use WordPressCS\WordPress\Helpers\VariableHelper;
 use WordPressCS\WordPress\Helpers\WPGlobalVariablesHelper;
@@ -393,7 +394,7 @@ final class GlobalVariablesOverrideSniff extends Sniff {
 			}
 
 			// Don't throw false positives for static class properties.
-			if ( $this->is_class_object_call( $ptr ) === true ) {
+			if ( ContextHelper::has_object_operator_before( $this->phpcsFile, $ptr ) === true ) {
 				continue;
 			}
 

--- a/WordPress/Tests/WP/DiscouragedFunctionsUnitTest.inc
+++ b/WordPress/Tests/WP/DiscouragedFunctionsUnitTest.inc
@@ -1,5 +1,12 @@
 <?php
 
 query_posts(); // Warning, use WP_Query instead.
-
 wp_reset_query(); // Warning, use wp_reset_postdata instead.
+
+/*
+ * Tests which are more specifically for the AbstractFunctionRestrictionsSniff class and Helper methods.
+ */
+
+// Ensure the sniff doesn't act on methods calls.
+$obj->query_posts(); // OK, not the global function.
+MyClass::wp_reset_query(); // OK, not the global function.

--- a/WordPress/Tests/WP/DiscouragedFunctionsUnitTest.inc
+++ b/WordPress/Tests/WP/DiscouragedFunctionsUnitTest.inc
@@ -10,3 +10,4 @@ wp_reset_query(); // Warning, use wp_reset_postdata instead.
 // Ensure the sniff doesn't act on methods calls.
 $obj->query_posts(); // OK, not the global function.
 MyClass::wp_reset_query(); // OK, not the global function.
+$obj?->query_posts(); // OK, not the global function.

--- a/WordPress/Tests/WP/DiscouragedFunctionsUnitTest.php
+++ b/WordPress/Tests/WP/DiscouragedFunctionsUnitTest.php
@@ -20,6 +20,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @since   0.13.0 Class name changed: this class is now namespaced.
  *
  * @covers \WordPressCS\WordPress\AbstractFunctionRestrictionsSniff
+ * @covers \WordPressCS\WordPress\Helpers\ContextHelper::has_object_operator_before
  * @covers \WordPressCS\WordPress\Sniffs\WP\DiscouragedFunctionsSniff
  */
 final class DiscouragedFunctionsUnitTest extends AbstractSniffUnitTest {
@@ -41,8 +42,7 @@ final class DiscouragedFunctionsUnitTest extends AbstractSniffUnitTest {
 	public function getWarningList() {
 		return array(
 			3 => 1,
-			5 => 1,
+			4 => 1,
 		);
 	}
-
 }


### PR DESCRIPTION
_Note: this PR is part of a series moving various method to this new `ContextHelper` class. Pulling each bit separately to allow for easier reviewing._

### Move is_class_object_call() utility method to dedicated `ContextHelper`

The `is_class_object_call()` utility method is only used by a small set of sniffs, so is better placed in a dedicated class.

This commit moves the `is_class_object_call()` method to the new `WordPressCS\WordPress\Helpers\ContextHelper` class and starts using that class in the relevant sniffs.

The method has also been renamed to `has_object_operator_before()` as it doesn't actually check if something is a (method) _call_, just that something OO (method, constant, property) is being accessed.

Related to #1465

This method is tested via the `WordPress.WP.DiscouragedFunctions` sniff.

### ContextHelper::has_object_operator_before(): simplify/use PHPCSUtils/support PHP 8.0 nullsafe object operator

* A non-inline HTML token will always have another non-empty token before it, if nothing else, the PHP open tag, so checking if `$before` is `false` is redundant.
* Implement use of the `Collections::objectOperators()` token group, which includes the PHP 8.0+ nullsafe object operator.

_Note: this automatically adds support for the nullsafe object operator to all sniffs using this method, either directly or indirectly._

Includes test via the `WordPress.WP.DiscouragedFunctions` sniff.