### PR TITLE
Move is_token_namespaced() utility method to dedicated ContextHelper + minor simplifications

### DIFF
--- a/WordPress/AbstractFunctionRestrictionsSniff.php
+++ b/WordPress/AbstractFunctionRestrictionsSniff.php
@@ -224,7 +224,7 @@ abstract class AbstractFunctionRestrictionsSniff extends Sniff {
 			return false;
 		}
 
-		if ( $this->is_token_namespaced( $stackPtr ) === true ) {
+		if ( ContextHelper::is_token_namespaced( $this->phpcsFile, $stackPtr ) === true ) {
 			return false;
 		}
 

--- a/WordPress/Helpers/ContextHelper.php
+++ b/WordPress/Helpers/ContextHelper.php
@@ -48,4 +48,44 @@ final class ContextHelper {
 
 		return isset( Collections::objectOperators()[ $tokens[ $before ]['code'] ] );
 	}
+
+	/**
+	 * Check if a particular token is prefixed with a namespace.
+	 *
+	 * @internal This will give a false positive if the file is not namespaced and the token is prefixed
+	 * with `namespace\`.
+	 *
+	 * @since 2.1.0
+	 * @since 3.0.0 - Moved from the Sniff class to this class.
+	 *              - The method visibility was changed from `protected` to `public static`.
+	 *
+	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+	 * @param int                         $stackPtr  The index of the token in the stack.
+	 *
+	 * @return bool
+	 */
+	public static function is_token_namespaced( File $phpcsFile, $stackPtr ) {
+		$prev = $phpcsFile->findPrevious( Tokens::$emptyTokens, ( $stackPtr - 1 ), null, true, null, true );
+		if ( false === $prev ) {
+			return false;
+		}
+
+		$tokens = $phpcsFile->getTokens();
+		if ( \T_NS_SEPARATOR !== $tokens[ $prev ]['code'] ) {
+			return false;
+		}
+
+		$before_prev = $phpcsFile->findPrevious( Tokens::$emptyTokens, ( $prev - 1 ), null, true, null, true );
+		if ( false === $before_prev ) {
+			return false;
+		}
+
+		if ( \T_STRING !== $tokens[ $before_prev ]['code']
+			&& \T_NAMESPACE !== $tokens[ $before_prev ]['code']
+		) {
+			return false;
+		}
+
+		return true;
+	}
 }

--- a/WordPress/Helpers/ContextHelper.php
+++ b/WordPress/Helpers/ContextHelper.php
@@ -65,21 +65,14 @@ final class ContextHelper {
 	 * @return bool
 	 */
 	public static function is_token_namespaced( File $phpcsFile, $stackPtr ) {
-		$prev = $phpcsFile->findPrevious( Tokens::$emptyTokens, ( $stackPtr - 1 ), null, true, null, true );
-		if ( false === $prev ) {
-			return false;
-		}
-
 		$tokens = $phpcsFile->getTokens();
+		$prev   = $phpcsFile->findPrevious( Tokens::$emptyTokens, ( $stackPtr - 1 ), null, true );
+
 		if ( \T_NS_SEPARATOR !== $tokens[ $prev ]['code'] ) {
 			return false;
 		}
 
-		$before_prev = $phpcsFile->findPrevious( Tokens::$emptyTokens, ( $prev - 1 ), null, true, null, true );
-		if ( false === $before_prev ) {
-			return false;
-		}
-
+		$before_prev = $phpcsFile->findPrevious( Tokens::$emptyTokens, ( $prev - 1 ), null, true );
 		if ( \T_STRING !== $tokens[ $before_prev ]['code']
 			&& \T_NAMESPACE !== $tokens[ $before_prev ]['code']
 		) {

--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -509,43 +509,6 @@ abstract class Sniff implements PHPCS_Sniff {
 	}
 
 	/**
-	 * Check if a particular token is prefixed with a namespace.
-	 *
-	 * @internal This will give a false positive if the file is not namespaced and the token is prefixed
-	 * with `namespace\`.
-	 *
-	 * @since 2.1.0
-	 *
-	 * @param int $stackPtr The index of the token in the stack.
-	 *
-	 * @return bool
-	 */
-	protected function is_token_namespaced( $stackPtr ) {
-		$prev = $this->phpcsFile->findPrevious( Tokens::$emptyTokens, ( $stackPtr - 1 ), null, true, null, true );
-
-		if ( false === $prev ) {
-			return false;
-		}
-
-		if ( \T_NS_SEPARATOR !== $this->tokens[ $prev ]['code'] ) {
-			return false;
-		}
-
-		$before_prev = $this->phpcsFile->findPrevious( Tokens::$emptyTokens, ( $prev - 1 ), null, true, null, true );
-		if ( false === $before_prev ) {
-			return false;
-		}
-
-		if ( \T_STRING !== $this->tokens[ $before_prev ]['code']
-			&& \T_NAMESPACE !== $this->tokens[ $before_prev ]['code']
-		) {
-			return false;
-		}
-
-		return true;
-	}
-
-	/**
 	 * Check if a token is (part of) a parameter for a function call to a select list of functions.
 	 *
 	 * This is useful, for instance, when trying to determine the context a variable is used in.
@@ -614,7 +577,7 @@ abstract class Sniff implements PHPCS_Sniff {
 				continue;
 			}
 
-			if ( $this->is_token_namespaced( $prev_non_empty ) === true ) {
+			if ( ContextHelper::is_token_namespaced( $this->phpcsFile, $prev_non_empty ) === true ) {
 				continue;
 			}
 
@@ -1004,7 +967,7 @@ abstract class Sniff implements PHPCS_Sniff {
 						continue 2;
 					}
 
-					if ( $this->is_token_namespaced( $i ) === true ) {
+					if ( ContextHelper::is_token_namespaced( $this->phpcsFile, $i ) === true ) {
 						// Namespaced function call.
 						continue 2;
 					}
@@ -1180,7 +1143,7 @@ abstract class Sniff implements PHPCS_Sniff {
 			return false;
 		}
 
-		if ( $this->is_token_namespaced( $stackPtr ) === true ) {
+		if ( ContextHelper::is_token_namespaced( $this->phpcsFile, $stackPtr ) === true ) {
 			// Namespaced constant of the same name.
 			return false;
 		}

--- a/WordPress/Sniffs/Security/NonceVerificationSniff.php
+++ b/WordPress/Sniffs/Security/NonceVerificationSniff.php
@@ -274,7 +274,7 @@ class NonceVerificationSniff extends Sniff {
 					continue;
 				}
 
-				if ( $this->is_token_namespaced( $i ) === true ) {
+				if ( ContextHelper::is_token_namespaced( $this->phpcsFile, $i ) === true ) {
 					continue;
 				}
 

--- a/WordPress/Sniffs/WP/DiscouragedConstantsSniff.php
+++ b/WordPress/Sniffs/WP/DiscouragedConstantsSniff.php
@@ -9,13 +9,14 @@
 
 namespace WordPressCS\WordPress\Sniffs\WP;
 
-use WordPressCS\WordPress\AbstractFunctionParameterSniff;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\MessageHelper;
 use PHPCSUtils\Utils\PassedParameters;
 use PHPCSUtils\Utils\Scopes;
 use PHPCSUtils\Utils\TextStrings;
+use WordPressCS\WordPress\AbstractFunctionParameterSniff;
+use WordPressCS\WordPress\Helpers\ContextHelper;
 
 /**
  * Warns against usage of discouraged WP CONSTANTS and recommends alternatives.
@@ -140,7 +141,7 @@ final class DiscouragedConstantsSniff extends AbstractFunctionParameterSniff {
 			return;
 		}
 
-		if ( $this->is_token_namespaced( $stackPtr ) === true ) {
+		if ( ContextHelper::is_token_namespaced( $this->phpcsFile, $stackPtr ) === true ) {
 			// Namespaced constant of the same name.
 			return;
 		}

--- a/WordPress/Tests/WP/DiscouragedFunctionsUnitTest.inc
+++ b/WordPress/Tests/WP/DiscouragedFunctionsUnitTest.inc
@@ -11,3 +11,10 @@ wp_reset_query(); // Warning, use wp_reset_postdata instead.
 $obj->query_posts(); // OK, not the global function.
 MyClass::wp_reset_query(); // OK, not the global function.
 $obj?->query_posts(); // OK, not the global function.
+
+// Ensure the sniff doesn't act on namespaced calls.
+MyNamespace\query_posts(); // OK, not the global function.
+namespace\query_posts(); // OK, not the global function.
+
+// ... but does act on fully qualified function calls.
+\query_posts(); // Warning.

--- a/WordPress/Tests/WP/DiscouragedFunctionsUnitTest.php
+++ b/WordPress/Tests/WP/DiscouragedFunctionsUnitTest.php
@@ -21,6 +21,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \WordPressCS\WordPress\AbstractFunctionRestrictionsSniff
  * @covers \WordPressCS\WordPress\Helpers\ContextHelper::has_object_operator_before
+ * @covers \WordPressCS\WordPress\Helpers\ContextHelper::is_token_namespaced
  * @covers \WordPressCS\WordPress\Sniffs\WP\DiscouragedFunctionsSniff
  */
 final class DiscouragedFunctionsUnitTest extends AbstractSniffUnitTest {
@@ -41,8 +42,9 @@ final class DiscouragedFunctionsUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getWarningList() {
 		return array(
-			3 => 1,
-			4 => 1,
+			3  => 1,
+			4  => 1,
+			20 => 1,
 		);
 	}
 }


### PR DESCRIPTION
_Next one in the series_

### Move is_token_namespaced() utility method to dedicated ContextHelper

The `is_token_namespaced()` utility method is only used by a small set of sniffs, so is better placed in a dedicated class.

This commit moves the `is_token_namespaced()` method to the new `WordPressCS\WordPress\Helpers\ContextHelper` class and starts using that class in the relevant sniffs.

Related to #1465

This method is tested via the `WordPress.WP.DiscouragedFunctions` sniff.

### ContextHelper::is_token_namespaced(): minor simplifications

* A non-inline HTML token will always have another non-empty token before it, if nothing else, the PHP open tag, so checking if `$prev` is `false` is redundant.
* Same for the second time this is done, as the same applies for the `T_NS_SEPARATOR` token.