### PR TITLE
Move `is_in_function_call()` utility method to dedicated `ContextHelper`

### DIFF
--- a/WordPress/Sniffs/Security/NonceVerificationSniff.php
+++ b/WordPress/Sniffs/Security/NonceVerificationSniff.php
@@ -204,7 +204,7 @@ class NonceVerificationSniff extends Sniff {
 			|| $this->is_in_type_test( $stackPtr )
 			|| VariableHelper::is_comparison( $this->phpcsFile, $stackPtr )
 			|| $this->is_in_array_comparison( $stackPtr )
-			|| $this->is_in_function_call( $stackPtr, $this->unslashingFunctions ) !== false
+			|| ContextHelper::is_in_function_call( $this->phpcsFile, $stackPtr, $this->unslashingFunctions ) !== false
 			|| $this->is_only_sanitized( $stackPtr )
 		) {
 			$allow_nonce_after = true;

--- a/WordPress/Sniffs/WP/CapitalPDangitSniff.php
+++ b/WordPress/Sniffs/WP/CapitalPDangitSniff.php
@@ -13,6 +13,7 @@ use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\ObjectDeclarations;
 use PHPCSUtils\Utils\Namespaces;
+use WordPressCS\WordPress\Helpers\ContextHelper;
 use WordPressCS\WordPress\Sniff;
 
 /**
@@ -209,7 +210,7 @@ final class CapitalPDangitSniff extends Sniff {
 		}
 
 		// Ignore constant declarations via define().
-		if ( $this->is_in_function_call( $stackPtr, array( 'define' => true ), true, true ) ) {
+		if ( ContextHelper::is_in_function_call( $this->phpcsFile, $stackPtr, array( 'define' => true ), true, true ) ) {
 			return;
 		}
 

--- a/WordPress/Sniffs/WP/CronIntervalSniff.php
+++ b/WordPress/Sniffs/WP/CronIntervalSniff.php
@@ -9,7 +9,6 @@
 
 namespace WordPressCS\WordPress\Sniffs\WP;
 
-use WordPressCS\WordPress\Sniff;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\Arrays;
@@ -17,6 +16,8 @@ use PHPCSUtils\Utils\FunctionDeclarations;
 use PHPCSUtils\Utils\Numbers;
 use PHPCSUtils\Utils\PassedParameters;
 use PHPCSUtils\Utils\TextStrings;
+use WordPressCS\WordPress\Helpers\ContextHelper;
+use WordPressCS\WordPress\Sniff;
 
 /**
  * Flag cron schedules less than 15 minutes.
@@ -94,7 +95,7 @@ final class CronIntervalSniff extends Sniff {
 		}
 
 		// Check if the text was found within a function call to add_filter().
-		$functionPtr = $this->is_in_function_call( $stackPtr, $this->valid_functions );
+		$functionPtr = ContextHelper::is_in_function_call( $this->phpcsFile, $stackPtr, $this->valid_functions );
 		if ( false === $functionPtr ) {
 			return;
 		}

--- a/WordPress/Tests/Security/NonceVerificationUnitTest.inc
+++ b/WordPress/Tests/Security/NonceVerificationUnitTest.inc
@@ -301,3 +301,15 @@ function function_containing_nested_closure() {
 	};
 }
 
+// Tests specifically for the ContextHelper::is_in_function_call().
+function disallow_custom_unslash_before_noncecheck_via_method() {
+	$var = MyClass::stripslashes_from_strings_only( $_POST['foo'] ); // Bad.
+	wp_verify_nonce( $var );
+	echo $var;
+}
+
+function disallow_custom_unslash_before_noncecheck_via_namespaced_function() {
+	$var = MyNamespace\stripslashes_from_strings_only( $_POST['foo'] ); // Bad.
+	wp_verify_nonce( $var );
+	echo $var;
+}

--- a/WordPress/Tests/Security/NonceVerificationUnitTest.php
+++ b/WordPress/Tests/Security/NonceVerificationUnitTest.php
@@ -20,6 +20,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @since   0.13.0 Class name changed: this class is now namespaced.
  * @since   1.0.0  This sniff has been moved from the `CSRF` category to the `Security` category.
  *
+ * @covers \WordPressCS\WordPress\Helpers\ContextHelper::is_in_function_call
  * @covers \WordPressCS\WordPress\Sniffs\Security\NonceVerificationSniff
  */
 final class NonceVerificationUnitTest extends AbstractSniffUnitTest {
@@ -56,6 +57,8 @@ final class NonceVerificationUnitTest extends AbstractSniffUnitTest {
 			202 => 1,
 			252 => 1,
 			269 => 1,
+			306 => 1,
+			312 => 1,
 		);
 	}
 


### PR DESCRIPTION
The `is_in_function_call()` utility method is only used by a small set of sniffs, so is better placed in a dedicated class.

This commit moves the `is_in_function_call()` method to the new `WordPressCS\WordPress\Helpers\ContextHelper` class and starts using that class in the relevant sniffs.

Includes adding a type declaration for the `$valid_functions` parameter.

Related to #1465

This method will be tested via the `WordPress.Security.NonceVerification` sniff (via pre-existing and a few new tests).