### PR TITLE
Move `is_in_type_test()` utility method to dedicated `ContextHelper`

### DIFF
--- a/WordPress/Helpers/ContextHelper.php
+++ b/WordPress/Helpers/ContextHelper.php
@@ -28,6 +28,40 @@ use PHPCSUtils\Tokens\Collections;
 final class ContextHelper {
 
 	/**
+	 * List of PHP native functions to test the type of a variable.
+	 *
+	 * Using these functions is safe in combination with superglobals without
+	 * unslashing or sanitization.
+	 *
+	 * They should, however, not be regarded as unslashing or sanitization functions.
+	 *
+	 * @since 2.1.0
+	 * @since 3.0.0 - Moved from the Sniff class to this class.
+	 *              - The property visibility was changed from `protected` to `private static`.
+	 *
+	 * @var array
+	 */
+	private static $typeTestFunctions = array(
+		'is_array'     => true,
+		'is_bool'      => true,
+		'is_callable'  => true,
+		'is_countable' => true,
+		'is_double'    => true,
+		'is_float'     => true,
+		'is_int'       => true,
+		'is_integer'   => true,
+		'is_iterable'  => true,
+		'is_long'      => true,
+		'is_null'      => true,
+		'is_numeric'   => true,
+		'is_object'    => true,
+		'is_real'      => true,
+		'is_resource'  => true,
+		'is_scalar'    => true,
+		'is_string'    => true,
+	);
+
+	/**
 	 * Check if a particular token acts - statically or non-statically - on an object.
 	 *
 	 * @internal Note: this may still mistake a namespaced function imported via a `use` statement for
@@ -162,5 +196,26 @@ final class ContextHelper {
 		}
 
 		return false;
+	}
+
+	/**
+	 * Check if a token is inside of an is_...() statement.
+	 *
+	 * @since 2.1.0
+	 * @since 3.0.0 - Moved from the Sniff class to this class.
+	 *              - The method visibility was changed from `protected` to `public static`.
+	 *
+	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+	 * @param int                         $stackPtr  The index of the token in the stack.
+	 *
+	 * @return bool Whether the token is being type tested.
+	 */
+	public static function is_in_type_test( File $phpcsFile, $stackPtr ) {
+		/*
+		 * Casting the potential integer stack pointer return value to boolean here is fine.
+		 * The return can never be `0` as there will always be a PHP open tag before the
+		 * function call.
+		 */
+		return (bool) self::is_in_function_call( $phpcsFile, $stackPtr, self::$typeTestFunctions );
 	}
 }

--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -250,38 +250,6 @@ abstract class Sniff implements PHPCS_Sniff {
 	);
 
 	/**
-	 * List of PHP native functions to test the type of a variable.
-	 *
-	 * Using these functions is safe in combination with superglobals without
-	 * unslashing or sanitization.
-	 *
-	 * They should, however, not be regarded as unslashing or sanitization functions.
-	 *
-	 * @since 2.1.0
-	 *
-	 * @var array
-	 */
-	protected $typeTestFunctions = array(
-		'is_array'     => true,
-		'is_bool'      => true,
-		'is_callable'  => true,
-		'is_countable' => true,
-		'is_double'    => true,
-		'is_float'     => true,
-		'is_int'       => true,
-		'is_integer'   => true,
-		'is_iterable'  => true,
-		'is_long'      => true,
-		'is_null'      => true,
-		'is_numeric'   => true,
-		'is_object'    => true,
-		'is_real'      => true,
-		'is_resource'  => true,
-		'is_scalar'    => true,
-		'is_string'    => true,
-	);
-
-	/**
 	 * Token which when they preceed code indicate the value is safely casted.
 	 *
 	 * @since 1.1.0
@@ -506,24 +474,6 @@ abstract class Sniff implements PHPCS_Sniff {
 		}
 
 		return false;
-	}
-
-	/**
-	 * Check if a token is inside of an is_...() statement.
-	 *
-	 * @since 2.1.0
-	 *
-	 * @param int $stackPtr The index of the token in the stack.
-	 *
-	 * @return bool Whether the token is being type tested.
-	 */
-	protected function is_in_type_test( $stackPtr ) {
-		/*
-		 * Casting the potential integer stack pointer return value to boolean here is fine.
-		 * The return can never be `0` as there will always be a PHP open tag before the
-		 * function call.
-		 */
-		return (bool) ContextHelper::is_in_function_call( $this->phpcsFile, $stackPtr, $this->typeTestFunctions );
 	}
 
 	/**

--- a/WordPress/Sniffs/Security/NonceVerificationSniff.php
+++ b/WordPress/Sniffs/Security/NonceVerificationSniff.php
@@ -201,7 +201,7 @@ class NonceVerificationSniff extends Sniff {
 
 		$allow_nonce_after = false;
 		if ( $this->is_in_isset_or_empty( $stackPtr )
-			|| $this->is_in_type_test( $stackPtr )
+			|| ContextHelper::is_in_type_test( $this->phpcsFile, $stackPtr )
 			|| VariableHelper::is_comparison( $this->phpcsFile, $stackPtr )
 			|| $this->is_in_array_comparison( $stackPtr )
 			|| ContextHelper::is_in_function_call( $this->phpcsFile, $stackPtr, $this->unslashingFunctions ) !== false

--- a/WordPress/Sniffs/Security/ValidatedSanitizedInputSniff.php
+++ b/WordPress/Sniffs/Security/ValidatedSanitizedInputSniff.php
@@ -11,6 +11,7 @@ namespace WordPressCS\WordPress\Sniffs\Security;
 
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\Utils\TextStrings;
+use WordPressCS\WordPress\Helpers\ContextHelper;
 use WordPressCS\WordPress\Helpers\RulesetPropertyHelper;
 use WordPressCS\WordPress\Helpers\VariableHelper;
 use WordPressCS\WordPress\Sniff;
@@ -177,7 +178,7 @@ class ValidatedSanitizedInputSniff extends Sniff {
 		}
 
 		// If this variable is being tested with one of the `is_..()` functions, sanitization isn't needed.
-		if ( $this->is_in_type_test( $stackPtr ) ) {
+		if ( ContextHelper::is_in_type_test( $this->phpcsFile, $stackPtr ) ) {
 			return;
 		}
 

--- a/WordPress/Tests/Security/NonceVerificationUnitTest.php
+++ b/WordPress/Tests/Security/NonceVerificationUnitTest.php
@@ -21,6 +21,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @since   1.0.0  This sniff has been moved from the `CSRF` category to the `Security` category.
  *
  * @covers \WordPressCS\WordPress\Helpers\ContextHelper::is_in_function_call
+ * @covers \WordPressCS\WordPress\Helpers\ContextHelper::is_in_type_test
  * @covers \WordPressCS\WordPress\Sniffs\Security\NonceVerificationSniff
  */
 final class NonceVerificationUnitTest extends AbstractSniffUnitTest {


### PR DESCRIPTION
The `is_in_type_test()` utility method is only used by a small set of sniffs, so is better placed in a dedicated class.

This commit moves the `is_in_type_test()` method and the associated `$typeTestFunctions` property to the new `WordPressCS\WordPress\Helpers\ContextHelper` class and starts using that class in the relevant sniffs.

Related to #1465

This method will be tested via the `WordPress.Security.NonceVerification` sniff (via pre-existing tests).