### PR TITLE
Move is_in_isset_or_empty() utility method to dedicated `ContextHelper` + improve

### DIFF
--- a/WordPress/Helpers/ContextHelper.php
+++ b/WordPress/Helpers/ContextHelper.php
@@ -254,8 +254,14 @@ final class ContextHelper {
 
 		$functionPtr = self::is_in_function_call( $phpcsFile, $stackPtr, self::$key_exists_functions );
 		if ( false !== $functionPtr ) {
-			$second_param = PassedParameters::getParameter( $phpcsFile, $functionPtr, 2 );
-			if ( $stackPtr >= $second_param['start'] && $stackPtr <= $second_param['end'] ) {
+			/*
+			 * Both functions being checked have the same parameters. If the function list would
+			 * be expanded, this needs to be revisited.
+			 */
+			$array_param = PassedParameters::getParameter( $phpcsFile, $functionPtr, 2, 'array' );
+			if ( false !== $array_param
+				&& ( $stackPtr >= $array_param['start'] && $stackPtr <= $array_param['end'] )
+			) {
 				return true;
 			}
 		}

--- a/WordPress/Helpers/ContextHelper.php
+++ b/WordPress/Helpers/ContextHelper.php
@@ -63,6 +63,18 @@ final class ContextHelper {
 	);
 
 	/**
+	 * List of PHP native functions to check if an array index exists.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @var array
+	 */
+	private static $key_exists_functions = array(
+		'array_key_exists' => true,
+		'key_exists'       => true, // Alias.
+	);
+
+	/**
 	 * Check if a particular token acts - statically or non-statically - on an object.
 	 *
 	 * @internal Note: this may still mistake a namespaced function imported via a `use` statement for
@@ -255,12 +267,7 @@ final class ContextHelper {
 			return true;
 		}
 
-		$valid_functions = array(
-			'array_key_exists' => true,
-			'key_exists'       => true, // Alias.
-		);
-
-		$functionPtr = self::is_in_function_call( $phpcsFile, $stackPtr, $valid_functions );
+		$functionPtr = self::is_in_function_call( $phpcsFile, $stackPtr, self::$key_exists_functions );
 		if ( false !== $functionPtr ) {
 			$second_param = PassedParameters::getParameter( $phpcsFile, $functionPtr, 2 );
 			if ( $stackPtr >= $second_param['start'] && $stackPtr <= $second_param['end'] ) {

--- a/WordPress/Helpers/ContextHelper.php
+++ b/WordPress/Helpers/ContextHelper.php
@@ -12,6 +12,7 @@ namespace WordPressCS\WordPress\Helpers;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\Tokens\Collections;
+use PHPCSUtils\Utils\Parentheses;
 use PHPCSUtils\Utils\PassedParameters;
 
 /**
@@ -247,23 +248,7 @@ final class ContextHelper {
 	 * @return bool Whether the token is inside an isset() or empty() statement.
 	 */
 	public static function is_in_isset_or_empty( File $phpcsFile, $stackPtr ) {
-		$tokens = $phpcsFile->getTokens();
-		if ( ! isset( $tokens[ $stackPtr ]['nested_parenthesis'] ) ) {
-			return false;
-		}
-
-		$nested_parenthesis = $tokens[ $stackPtr ]['nested_parenthesis'];
-
-		end( $nested_parenthesis );
-		$open_parenthesis = key( $nested_parenthesis );
-
-		$previous_non_empty = $phpcsFile->findPrevious( Tokens::$emptyTokens, ( $open_parenthesis - 1 ), null, true, null, true );
-		if ( false === $previous_non_empty ) {
-			return false;
-		}
-
-		$previous_code = $tokens[ $previous_non_empty ]['code'];
-		if ( \T_ISSET === $previous_code || \T_EMPTY === $previous_code ) {
+		if ( Parentheses::lastOwnerIn( $phpcsFile, $stackPtr, array( \T_ISSET, \T_EMPTY ) ) !== false ) {
 			return true;
 		}
 

--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -429,54 +429,6 @@ abstract class Sniff implements PHPCS_Sniff {
 	}
 
 	/**
-	 * Check if a token is inside of an isset(), empty() or array_key_exists() statement.
-	 *
-	 * @since 0.5.0
-	 * @since 2.1.0 Now checks for the token being used as the array parameter
-	 *              in function calls to array_key_exists() and key_exists() as well.
-	 *
-	 * @param int $stackPtr The index of the token in the stack.
-	 *
-	 * @return bool Whether the token is inside an isset() or empty() statement.
-	 */
-	protected function is_in_isset_or_empty( $stackPtr ) {
-
-		if ( ! isset( $this->tokens[ $stackPtr ]['nested_parenthesis'] ) ) {
-			return false;
-		}
-
-		$nested_parenthesis = $this->tokens[ $stackPtr ]['nested_parenthesis'];
-
-		end( $nested_parenthesis );
-		$open_parenthesis = key( $nested_parenthesis );
-
-		$previous_non_empty = $this->phpcsFile->findPrevious( Tokens::$emptyTokens, ( $open_parenthesis - 1 ), null, true, null, true );
-		if ( false === $previous_non_empty ) {
-			return false;
-		}
-
-		$previous_code = $this->tokens[ $previous_non_empty ]['code'];
-		if ( \T_ISSET === $previous_code || \T_EMPTY === $previous_code ) {
-			return true;
-		}
-
-		$valid_functions = array(
-			'array_key_exists' => true,
-			'key_exists'       => true, // Alias.
-		);
-
-		$functionPtr = ContextHelper::is_in_function_call( $this->phpcsFile, $stackPtr, $valid_functions );
-		if ( false !== $functionPtr ) {
-			$second_param = PassedParameters::getParameter( $this->phpcsFile, $functionPtr, 2 );
-			if ( $stackPtr >= $second_param['start'] && $stackPtr <= $second_param['end'] ) {
-				return true;
-			}
-		}
-
-		return false;
-	}
-
-	/**
 	 * Check if something is only being sanitized.
 	 *
 	 * @since 0.5.0

--- a/WordPress/Sniffs/Security/NonceVerificationSniff.php
+++ b/WordPress/Sniffs/Security/NonceVerificationSniff.php
@@ -200,7 +200,7 @@ class NonceVerificationSniff extends Sniff {
 		}
 
 		$allow_nonce_after = false;
-		if ( $this->is_in_isset_or_empty( $stackPtr )
+		if ( ContextHelper::is_in_isset_or_empty( $this->phpcsFile, $stackPtr )
 			|| ContextHelper::is_in_type_test( $this->phpcsFile, $stackPtr )
 			|| VariableHelper::is_comparison( $this->phpcsFile, $stackPtr )
 			|| $this->is_in_array_comparison( $stackPtr )

--- a/WordPress/Sniffs/Security/ValidatedSanitizedInputSniff.php
+++ b/WordPress/Sniffs/Security/ValidatedSanitizedInputSniff.php
@@ -126,7 +126,7 @@ class ValidatedSanitizedInputSniff extends Sniff {
 		}
 
 		// This superglobal is being validated.
-		if ( $this->is_in_isset_or_empty( $stackPtr ) ) {
+		if ( ContextHelper::is_in_isset_or_empty( $this->phpcsFile, $stackPtr ) ) {
 			return;
 		}
 

--- a/WordPress/Tests/Security/NonceVerificationUnitTest.inc
+++ b/WordPress/Tests/Security/NonceVerificationUnitTest.inc
@@ -313,3 +313,32 @@ function disallow_custom_unslash_before_noncecheck_via_namespaced_function() {
 	wp_verify_nonce( $var );
 	echo $var;
 }
+
+// Tests specifically for the ContextHelper::is_in_isset_or_empty().
+function allow_in_array_key_exists_before_noncecheck() {
+	if (array_key_exists('foo', $_POST) === false) { // OK.
+		return;
+	}
+
+	wp_verify_nonce( 'some_action' );
+}
+
+function allow_in_key_exists_before_noncecheck() {
+	if (key_exists('foo', $_POST['subset']) === false) { // OK.
+		return;
+	}
+
+	wp_verify_nonce( 'some_action' );
+}
+
+function disallow_in_custom_key_exists_before_noncecheck() {
+	if (My\key_exists('foo', $_POST['subset']) === false) { // Bad.
+		return;
+	}
+
+	if ($obj?->array_key_exists('foo', $_POST['subset']) === false) { // Bad.
+		return;
+	}
+
+	wp_verify_nonce( 'some_action' );
+}

--- a/WordPress/Tests/Security/NonceVerificationUnitTest.inc
+++ b/WordPress/Tests/Security/NonceVerificationUnitTest.inc
@@ -342,3 +342,23 @@ function disallow_in_custom_key_exists_before_noncecheck() {
 
 	wp_verify_nonce( 'some_action' );
 }
+
+function disallow_in_array_key_exists_before_noncecheck_when_not_in_array_param() {
+	if ( array_key_exists( $_POST, $GLOBALS ) === false ) { // Bad (not that it makes sense anyhow).
+		return;
+	}
+
+	if ( array_key_exists( arrays: $_POST, key: 'foo', ) === false ) { // Bad (typo in param label).
+		return;
+	}
+
+	wp_verify_nonce( 'some_action' );
+}
+
+function allow_in_array_key_exists_before_noncecheck_with_named_params() {
+	if (array_key_exists( array: $_POST, key: 'foo', ) === false) { // OK.
+		return;
+	}
+
+	wp_verify_nonce( 'some_action' );
+}

--- a/WordPress/Tests/Security/NonceVerificationUnitTest.php
+++ b/WordPress/Tests/Security/NonceVerificationUnitTest.php
@@ -22,6 +22,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \WordPressCS\WordPress\Helpers\ContextHelper::is_in_function_call
  * @covers \WordPressCS\WordPress\Helpers\ContextHelper::is_in_type_test
+ * @covers \WordPressCS\WordPress\Helpers\ContextHelper::is_in_isset_or_empty
  * @covers \WordPressCS\WordPress\Sniffs\Security\NonceVerificationSniff
  */
 final class NonceVerificationUnitTest extends AbstractSniffUnitTest {
@@ -60,6 +61,8 @@ final class NonceVerificationUnitTest extends AbstractSniffUnitTest {
 			269 => 1,
 			306 => 1,
 			312 => 1,
+			335 => 1,
+			339 => 1,
 		);
 	}
 

--- a/WordPress/Tests/Security/NonceVerificationUnitTest.php
+++ b/WordPress/Tests/Security/NonceVerificationUnitTest.php
@@ -63,6 +63,8 @@ final class NonceVerificationUnitTest extends AbstractSniffUnitTest {
 			312 => 1,
 			335 => 1,
 			339 => 1,
+			347 => 1,
+			351 => 1,
 		);
 	}
 


### PR DESCRIPTION
### Move is_in_isset_or_empty() utility method to dedicated `ContextHelper`

The `is_in_isset_or_empty()` utility method is only used by a small set of sniffs, so is better placed in a dedicated class.

This commit moves the `is_in_isset_or_empty()` method to the new `WordPressCS\WordPress\Helpers\ContextHelper` class and starts using that class in the relevant sniffs.

Related to #1465

This method will be tested via the `WordPress.Security.NonceVerification` sniff (via pre-existing and new tests).

### ContextHelper::is_in_isset_or_empty(): move functions array to property

... instead of re-defining it each time the function is called.

### ContextHelper::is_in_isset_or_empty(): use PHPCSUtils

... to simplify the determination of whether a token is within a call to `isset()` or `empty()`.

### ContextHelper::is_in_isset_or_empty(): add support for PHP 8.0 named parameters

Includes tests in the `WordPress.Security.NonceVerification` test file.