### PR TITLE
Move is_safe_casted() utility method to dedicated ContextHelper

### DIFF
--- a/WordPress/Helpers/ContextHelper.php
+++ b/WordPress/Helpers/ContextHelper.php
@@ -30,6 +30,22 @@ use PHPCSUtils\Utils\PassedParameters;
 final class ContextHelper {
 
 	/**
+	 * Tokens which when they preceed code indicate the value is safely casted.
+	 *
+	 * @since 1.1.0
+	 * @since 3.0.0 - Moved from the Sniff class to this class.
+	 *              - The property visibility was changed from `protected` to `public static`.
+	 *
+	 * @var array
+	 */
+	public static $safe_casts = array(
+		\T_INT_CAST    => true,
+		\T_DOUBLE_CAST => true,
+		\T_BOOL_CAST   => true,
+		\T_UNSET_CAST  => true,
+	);
+
+	/**
 	 * List of PHP native functions to test the type of a variable.
 	 *
 	 * Using these functions is safe in combination with superglobals without
@@ -267,5 +283,35 @@ final class ContextHelper {
 		}
 
 		return false;
+	}
+
+	/**
+	 * Check if something is being casted to a safe value.
+	 *
+	 * @since 0.5.0
+	 * @since 3.0.0 - Moved from the Sniff class to this class.
+	 *              - The method visibility was changed from `protected` to `public static`.
+	 *
+	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+	 * @param int                         $stackPtr  The index of the token in the stack.
+	 *
+	 * @return bool Whether the token being casted.
+	 */
+	public static function is_safe_casted( File $phpcsFile, $stackPtr ) {
+		// Get the last non-empty token.
+		$prev = $phpcsFile->findPrevious(
+			Tokens::$emptyTokens,
+			( $stackPtr - 1 ),
+			null,
+			true
+		);
+
+		if ( false === $prev ) {
+			return false;
+		}
+
+		// Check if it is a safe cast.
+		$tokens = $phpcsFile->getTokens();
+		return isset( self::$safe_casts[ $tokens[ $prev ]['code'] ] );
 	}
 }

--- a/WordPress/Helpers/ContextHelper.php
+++ b/WordPress/Helpers/ContextHelper.php
@@ -298,20 +298,9 @@ final class ContextHelper {
 	 * @return bool Whether the token being casted.
 	 */
 	public static function is_safe_casted( File $phpcsFile, $stackPtr ) {
-		// Get the last non-empty token.
-		$prev = $phpcsFile->findPrevious(
-			Tokens::$emptyTokens,
-			( $stackPtr - 1 ),
-			null,
-			true
-		);
-
-		if ( false === $prev ) {
-			return false;
-		}
-
-		// Check if it is a safe cast.
 		$tokens = $phpcsFile->getTokens();
+		$prev   = $phpcsFile->findPrevious( Tokens::$emptyTokens, ( $stackPtr - 1 ), null, true );
+
 		return isset( self::$safe_casts[ $tokens[ $prev ]['code'] ] );
 	}
 }

--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -250,20 +250,6 @@ abstract class Sniff implements PHPCS_Sniff {
 	);
 
 	/**
-	 * Token which when they preceed code indicate the value is safely casted.
-	 *
-	 * @since 1.1.0
-	 *
-	 * @var array
-	 */
-	protected $safe_casts = array(
-		\T_INT_CAST    => true,
-		\T_DOUBLE_CAST => true,
-		\T_BOOL_CAST   => true,
-		\T_UNSET_CAST  => true,
-	);
-
-	/**
 	 * List of array functions which apply a callback to the array.
 	 *
 	 * These are often used for sanitization/escaping an array variable.
@@ -452,40 +438,13 @@ abstract class Sniff implements PHPCS_Sniff {
 
 		// At this point we're expecting the value to have not been casted. If it
 		// was, it wasn't *only* casted, because it's also in a function.
-		if ( $this->is_safe_casted( $stackPtr ) ) {
+		if ( ContextHelper::is_safe_casted( $this->phpcsFile, $stackPtr ) ) {
 			return false;
 		}
 
 		// The only parentheses should belong to the sanitizing function. If there's
 		// more than one set, this isn't *only* sanitization.
 		return ( \count( $this->tokens[ $stackPtr ]['nested_parenthesis'] ) === 1 );
-	}
-
-	/**
-	 * Check if something is being casted to a safe value.
-	 *
-	 * @since 0.5.0
-	 *
-	 * @param int $stackPtr The index of the token in the stack.
-	 *
-	 * @return bool Whether the token being casted.
-	 */
-	protected function is_safe_casted( $stackPtr ) {
-
-		// Get the last non-empty token.
-		$prev = $this->phpcsFile->findPrevious(
-			Tokens::$emptyTokens,
-			( $stackPtr - 1 ),
-			null,
-			true
-		);
-
-		if ( false === $prev ) {
-			return false;
-		}
-
-		// Check if it is a safe cast.
-		return isset( $this->safe_casts[ $this->tokens[ $prev ]['code'] ] );
 	}
 
 	/**
@@ -502,7 +461,7 @@ abstract class Sniff implements PHPCS_Sniff {
 	protected function is_sanitized( $stackPtr, $require_unslash = false ) {
 
 		// First we check if it is being casted to a safe value.
-		if ( $this->is_safe_casted( $stackPtr ) ) {
+		if ( ContextHelper::is_safe_casted( $this->phpcsFile, $stackPtr ) ) {
 			return true;
 		}
 

--- a/WordPress/Sniffs/DB/PreparedSQLSniff.php
+++ b/WordPress/Sniffs/DB/PreparedSQLSniff.php
@@ -12,6 +12,7 @@ namespace WordPressCS\WordPress\Sniffs\DB;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\TextStrings;
+use WordPressCS\WordPress\Helpers\ContextHelper;
 use WordPressCS\WordPress\Helpers\WPDBTrait;
 use WordPressCS\WordPress\Sniff;
 
@@ -201,7 +202,7 @@ final class PreparedSQLSniff extends Sniff {
 					continue;
 				}
 
-				if ( $this->is_safe_casted( $this->i ) ) {
+				if ( ContextHelper::is_safe_casted( $this->phpcsFile, $this->i ) ) {
 					continue;
 				}
 			}

--- a/WordPress/Sniffs/Security/EscapeOutputSniff.php
+++ b/WordPress/Sniffs/Security/EscapeOutputSniff.php
@@ -12,6 +12,7 @@ namespace WordPressCS\WordPress\Sniffs\Security;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\Utils\PassedParameters;
 use PHPCSUtils\Utils\TextStrings;
+use WordPressCS\WordPress\Helpers\ContextHelper;
 use WordPressCS\WordPress\Helpers\RulesetPropertyHelper;
 use WordPressCS\WordPress\Helpers\VariableHelper;
 use WordPressCS\WordPress\Sniff;
@@ -375,7 +376,7 @@ class EscapeOutputSniff extends Sniff {
 			$watch = false;
 
 			// Allow int/double/bool casted variables.
-			if ( isset( $this->safe_casts[ $this->tokens[ $i ]['code'] ] ) ) {
+			if ( isset( ContextHelper::$safe_casts[ $this->tokens[ $i ]['code'] ] ) ) {
 				$in_cast = true;
 				continue;
 			}

--- a/WordPress/Tests/DB/PreparedSQLUnitTest.php
+++ b/WordPress/Tests/DB/PreparedSQLUnitTest.php
@@ -20,6 +20,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @since   0.13.0 Class name changed: this class is now namespaced.
  * @since   1.0.0  This sniff has been moved from the `WP` category to the `DB` category.
  *
+ * @covers \WordPressCS\WordPress\Helpers\ContextHelper::is_safe_casted
  * @covers \WordPressCS\WordPress\Helpers\WPDBTrait
  * @covers \WordPressCS\WordPress\Sniffs\DB\PreparedSQLSniff
  */


### PR DESCRIPTION
### Move is_safe_casted() utility method to dedicated ContextHelper

The `is_safe_casted()` utility method is only used by a small set of sniffs, so is better placed in a dedicated class.

This commit moves the `is_safe_casted()` method and the associated `$safe_casts` property to the new `WordPressCS\WordPress\Helpers\ContextHelper` class and starts using that class in the relevant sniffs.

Related to #1465

This method will be tested via the `WordPress.DB.PreparedSQL` sniff (via pre-existing tests).

### ContextHelper::is_safe_casted(): minor simplification

A non-inline HTML token will always have another non-empty token before it, if nothing else, the PHP open tag, so checking if `$prev` is `false` is redundant.