### PR TITLE
WP/I18n: allow for new PHP 8.0+ `[s]printf()` placeholders

### DIFF
--- a/WordPress/Sniffs/WP/I18nSniff.php
+++ b/WordPress/Sniffs/WP/I18nSniff.php
@@ -63,7 +63,7 @@ final class I18nSniff extends AbstractFunctionParameterSniff {
 				[0-9]+                     # Width specifier.
 				(?:\.(?:[ 0]|\'.)?[0-9]+)? # Optional precision specifier with optional padding character.
 			)
-			[bcdeEfFgGosuxX]           # Type specifier.
+			[bcdeEfFgGhHosuxX]           # Type specifier.
 		)
 	)/x';
 
@@ -85,7 +85,7 @@ final class I18nSniff extends AbstractFunctionParameterSniff {
 			[0-9]+                     # Width specifier.
 			(?:\.(?:[ 0]|\'.)?[0-9]+)? # Optional precision specifier with optional padding character.
 		)
-		[bcdeEfFgGosuxX]           # Type specifier.
+		[bcdeEfFgGhHosuxX]           # Type specifier.
 	)/x';
 
 	/**

--- a/WordPress/Tests/WP/I18nUnitTest.1.inc
+++ b/WordPress/Tests/WP/I18nUnitTest.1.inc
@@ -314,4 +314,7 @@ esc_html_e( 'foo', '' ); // Bad: text domain mismatch.
 // phpcs:set WordPress.WP.I18n text_domain[]
 esc_html_e( 'foo', '' ); // Bad: text-domain can not be empty.
 
+// PHP 8.0+: safeguard handling of newly introduced placeholders.
+__( 'There are %1$h monkeys in the %H', 'my-slug' ); // Bad: multiple arguments should be numbered.
+
 // phpcs:enable WordPress.WP.I18n.MissingTranslatorsComment

--- a/WordPress/Tests/WP/I18nUnitTest.1.inc.fixed
+++ b/WordPress/Tests/WP/I18nUnitTest.1.inc.fixed
@@ -314,4 +314,7 @@ esc_html_e( 'foo', '' ); // Bad: text domain mismatch.
 // phpcs:set WordPress.WP.I18n text_domain[]
 esc_html_e( 'foo', '' ); // Bad: text-domain can not be empty.
 
+// PHP 8.0+: safeguard handling of newly introduced placeholders.
+__( 'There are %1$h monkeys in the %H', 'my-slug' ); // Bad: multiple arguments should be numbered.
+
 // phpcs:enable WordPress.WP.I18n.MissingTranslatorsComment

--- a/WordPress/Tests/WP/I18nUnitTest.php
+++ b/WordPress/Tests/WP/I18nUnitTest.php
@@ -148,6 +148,7 @@ final class I18nUnitTest extends AbstractSniffUnitTest {
 					306 => 1,
 					311 => 1,
 					315 => 1,
+					318 => 1,
 				);
 
 			case 'I18nUnitTest.2.inc':


### PR DESCRIPTION
PHP 8.0 silently (not mentioned in migration guide, changelog etc - I only discovered it by accident via a small note in the manual) introduced two new placeholder characters for the `*printf()` range of functions.

This commit updates the regexes used in the `WordPress.WP.I18n` sniff to allow them to recognize those characters as placeholders which should be examined.

Includes unit tests.

Ref: https://www.php.net/manual/en/function.sprintf.php