### PR TITLE
Move is_in_array_comparison() utility method to dedicated `ContextHelper` + fixes

### DIFF
--- a/WordPress/Helpers/ContextHelper.php
+++ b/WordPress/Helpers/ContextHelper.php
@@ -342,7 +342,7 @@ final class ContextHelper {
 		}
 
 		$tokens        = $phpcsFile->getTokens();
-		$function_name = $tokens[ $function_ptr ]['content'];
+		$function_name = strtolower( $tokens[ $function_ptr ]['content'] );
 		if ( true === self::$arrayCompareFunctions[ $function_name ] ) {
 			return true;
 		}

--- a/WordPress/Helpers/ContextHelper.php
+++ b/WordPress/Helpers/ContextHelper.php
@@ -94,19 +94,22 @@ final class ContextHelper {
 	/**
 	 * Array functions to compare a $needle to a predefined set of values.
 	 *
-	 * If the value is set to an integer, the function needs to have at least that
-	 * many parameters for it to be considered as a comparison.
+	 * If the value is set to an array, the parameter specified in the array is
+	 * required for the function call to be considered as a comparison.
 	 *
 	 * @since 2.1.0
 	 * @since 3.0.0 - Moved from the Sniff class to this class.
 	 *              - The property visibility was changed from `protected` to `private static`.
 	 *
-	 * @var array <string function name> => <true|int>
+	 * @var array <string function name> => <true|array>
 	 */
 	private static $arrayCompareFunctions = array(
 		'in_array'     => true,
 		'array_search' => true,
-		'array_keys'   => 2,
+		'array_keys'   => array(
+			'position' => 2,
+			'name'     => 'filter_value',
+		),
 	);
 
 	/**
@@ -347,7 +350,9 @@ final class ContextHelper {
 			return true;
 		}
 
-		if ( PassedParameters::getParameterCount( $phpcsFile, $function_ptr ) >= self::$arrayCompareFunctions[ $function_name ] ) {
+		$target_param = self::$arrayCompareFunctions[ $function_name ];
+		$found_param  = PassedParameters::getParameter( $phpcsFile, $function_ptr, $target_param['position'], $target_param['name'] );
+		if ( false !== $found_param ) {
 			return true;
 		}
 

--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -269,22 +269,6 @@ abstract class Sniff implements PHPCS_Sniff {
 	);
 
 	/**
-	 * Array functions to compare a $needle to a predefined set of values.
-	 *
-	 * If the value is set to an integer, the function needs to have at least that
-	 * many parameters for it to be considered as a comparison.
-	 *
-	 * @since 2.1.0
-	 *
-	 * @var array <string function name> => <true|int>
-	 */
-	protected $arrayCompareFunctions = array(
-		'in_array'     => true,
-		'array_search' => true,
-		'array_keys'   => 2,
-	);
-
-	/**
 	 * Functions that format strings.
 	 *
 	 * These functions are often used for formatting values just before output, and
@@ -833,34 +817,6 @@ abstract class Sniff implements PHPCS_Sniff {
 					// Right variable, correct key.
 					return true;
 			}
-		}
-
-		return false;
-	}
-
-	/**
-	 * Check if a token is inside of an array-value comparison function.
-	 *
-	 * @since 2.1.0
-	 *
-	 * @param int $stackPtr The index of the token in the stack.
-	 *
-	 * @return bool Whether the token is (part of) a parameter to an
-	 *              array-value comparison function.
-	 */
-	protected function is_in_array_comparison( $stackPtr ) {
-		$function_ptr = ContextHelper::is_in_function_call( $this->phpcsFile, $stackPtr, $this->arrayCompareFunctions, true, true );
-		if ( false === $function_ptr ) {
-			return false;
-		}
-
-		$function_name = $this->tokens[ $function_ptr ]['content'];
-		if ( true === $this->arrayCompareFunctions[ $function_name ] ) {
-			return true;
-		}
-
-		if ( PassedParameters::getParameterCount( $this->phpcsFile, $function_ptr ) >= $this->arrayCompareFunctions[ $function_name ] ) {
-			return true;
 		}
 
 		return false;

--- a/WordPress/Sniffs/Security/NonceVerificationSniff.php
+++ b/WordPress/Sniffs/Security/NonceVerificationSniff.php
@@ -203,7 +203,7 @@ class NonceVerificationSniff extends Sniff {
 		if ( ContextHelper::is_in_isset_or_empty( $this->phpcsFile, $stackPtr )
 			|| ContextHelper::is_in_type_test( $this->phpcsFile, $stackPtr )
 			|| VariableHelper::is_comparison( $this->phpcsFile, $stackPtr )
-			|| $this->is_in_array_comparison( $stackPtr )
+			|| ContextHelper::is_in_array_comparison( $this->phpcsFile, $stackPtr )
 			|| ContextHelper::is_in_function_call( $this->phpcsFile, $stackPtr, $this->unslashingFunctions ) !== false
 			|| $this->is_only_sanitized( $stackPtr )
 		) {

--- a/WordPress/Sniffs/Security/ValidatedSanitizedInputSniff.php
+++ b/WordPress/Sniffs/Security/ValidatedSanitizedInputSniff.php
@@ -188,7 +188,7 @@ class ValidatedSanitizedInputSniff extends Sniff {
 		}
 
 		// If this is a comparison using the array comparison functions, sanitization isn't needed.
-		if ( $this->is_in_array_comparison( $stackPtr ) ) {
+		if ( ContextHelper::is_in_array_comparison( $this->phpcsFile, $stackPtr ) ) {
 			return;
 		}
 

--- a/WordPress/Tests/Security/NonceVerificationUnitTest.inc
+++ b/WordPress/Tests/Security/NonceVerificationUnitTest.inc
@@ -362,3 +362,18 @@ function allow_in_array_key_exists_before_noncecheck_with_named_params() {
 
 	wp_verify_nonce( 'some_action' );
 }
+
+// Tests specifically for the ContextHelper::is_in_array_comparison().
+function allow_for_array_comparison_in_condition() {
+	if ( array_keys( $_GET['actions'], 'my_action', true ) ) { // OK.
+		check_admin_referer( 'foo' );
+		foo();
+	}
+}
+
+function disallow_for_non_array_comparison_in_condition() {
+	if ( array_keys( $_GET['actions'] ) ) { // Bad.
+		check_admin_referer( 'foo' );
+		foo();
+	}
+}

--- a/WordPress/Tests/Security/NonceVerificationUnitTest.inc
+++ b/WordPress/Tests/Security/NonceVerificationUnitTest.inc
@@ -377,3 +377,17 @@ function disallow_for_non_array_comparison_in_condition() {
 		foo();
 	}
 }
+
+function allow_for_array_comparison_in_condition_with_named_params() {
+	if ( array_keys( filter_value: 'my_action', array: $_GET['actions'], strict: true, ) ) { // OK.
+		check_admin_referer( 'foo' );
+		foo();
+	}
+}
+
+function disallow_for_non_array_comparison_in_condition_with_named_params() {
+	if ( array_keys( strict: true, array: $_GET['actions'], ) ) { // Bad, missing $filter_value param. Invalid function call, but not our concern.
+		check_admin_referer( 'foo' );
+		foo();
+	}
+}

--- a/WordPress/Tests/Security/NonceVerificationUnitTest.inc
+++ b/WordPress/Tests/Security/NonceVerificationUnitTest.inc
@@ -365,7 +365,7 @@ function allow_in_array_key_exists_before_noncecheck_with_named_params() {
 
 // Tests specifically for the ContextHelper::is_in_array_comparison().
 function allow_for_array_comparison_in_condition() {
-	if ( array_keys( $_GET['actions'], 'my_action', true ) ) { // OK.
+	if ( Array_Keys( $_GET['actions'], 'my_action', true ) ) { // OK.
 		check_admin_referer( 'foo' );
 		foo();
 	}

--- a/WordPress/Tests/Security/NonceVerificationUnitTest.php
+++ b/WordPress/Tests/Security/NonceVerificationUnitTest.php
@@ -77,6 +77,7 @@ final class NonceVerificationUnitTest extends AbstractSniffUnitTest {
 	public function getWarningList() {
 		return array(
 			375 => 1,
+			389 => 1,
 		);
 	}
 }

--- a/WordPress/Tests/Security/NonceVerificationUnitTest.php
+++ b/WordPress/Tests/Security/NonceVerificationUnitTest.php
@@ -23,6 +23,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @covers \WordPressCS\WordPress\Helpers\ContextHelper::is_in_function_call
  * @covers \WordPressCS\WordPress\Helpers\ContextHelper::is_in_type_test
  * @covers \WordPressCS\WordPress\Helpers\ContextHelper::is_in_isset_or_empty
+ * @covers \WordPressCS\WordPress\Helpers\ContextHelper::is_in_array_comparison
  * @covers \WordPressCS\WordPress\Sniffs\Security\NonceVerificationSniff
  */
 final class NonceVerificationUnitTest extends AbstractSniffUnitTest {
@@ -74,7 +75,8 @@ final class NonceVerificationUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of warnings>
 	 */
 	public function getWarningList() {
-		return array();
+		return array(
+			375 => 1,
+		);
 	}
-
 }


### PR DESCRIPTION
### Move is_in_array_comparison() utility method to dedicated `ContextHelper`

The `is_in_array_comparison()` utility method is only used by a small set of sniffs, so is better placed in a dedicated class.

This commit moves the `is_in_array_comparison()` method and the associated `$arrayCompareFunctions` property to the new `WordPressCS\WordPress\Helpers\ContextHelper` class and starts using that class in the relevant sniffs.

Related to #1465

This method will be tested via the `WordPress.Security.NonceVerification` sniff (via pre-existing and new tests).

### ContextHelper::is_in_array_comparison(): bug fix for case-insensitivity

Function names are case-insensitive. The `ContextHelper::is_in_function_call()` method already handles this correctly, but the `ContextHelper::is_in_array_comparison()` method did not, which could result in `Undefined array key` error notices.

Tested by adjusting one of the tests.

### ContextHelper::is_in_array_comparison(): add support for PHP 8.0 named parameters

With named parameters, the function call may have two parameters, without the required `$filter_value` param being one of them. Would make for an invalid function call, but that's not the concern of this sniff.

Fixed now by looking for a specific named parameter.

Includes tests in the `WordPress.Security.NonceVerification` test file (which include PHP 7.3+ trailing commas in function calls).