### PR TITLE
AbstractFunctionRestrictionsSniff: add extra tests and various bug fixes

### DIFF
--- a/WordPress/AbstractFunctionRestrictionsSniff.php
+++ b/WordPress/AbstractFunctionRestrictionsSniff.php
@@ -223,7 +223,10 @@ abstract class AbstractFunctionRestrictionsSniff extends Sniff {
 			return false;
 		}
 
-		$prev = $this->phpcsFile->findPrevious( Tokens::$emptyTokens, ( $stackPtr - 1 ), null, true );
+		$search                   = Tokens::$emptyTokens;
+		$search[ \T_BITWISE_AND ] = \T_BITWISE_AND;
+
+		$prev = $this->phpcsFile->findPrevious( $search, ( $stackPtr - 1 ), null, true );
 
 		// Skip sniffing on function, OO definitions or for function aliases in use statements.
 		$invalid_tokens  = Tokens::$ooScopeTokens;

--- a/WordPress/AbstractFunctionRestrictionsSniff.php
+++ b/WordPress/AbstractFunctionRestrictionsSniff.php
@@ -214,11 +214,6 @@ abstract class AbstractFunctionRestrictionsSniff extends Sniff {
 	 * @return bool
 	 */
 	public function is_targetted_token( $stackPtr ) {
-
-		if ( \T_STRING !== $this->tokens[ $stackPtr ]['code'] ) {
-			return false;
-		}
-
 		// Exclude function definitions, class methods, and namespaced calls.
 		if ( ContextHelper::has_object_operator_before( $this->phpcsFile, $stackPtr ) === true ) {
 			return false;
@@ -229,17 +224,16 @@ abstract class AbstractFunctionRestrictionsSniff extends Sniff {
 		}
 
 		$prev = $this->phpcsFile->findPrevious( Tokens::$emptyTokens, ( $stackPtr - 1 ), null, true );
-		if ( false !== $prev ) {
-			// Skip sniffing on function, class definitions or for function aliases in use statements.
-			$skipped = array(
-				\T_FUNCTION        => \T_FUNCTION,
-				\T_CLASS           => \T_CLASS,
-				\T_AS              => \T_AS, // Use declaration alias.
-			);
 
-			if ( isset( $skipped[ $this->tokens[ $prev ]['code'] ] ) ) {
-				return false;
-			}
+		// Skip sniffing on function, class definitions or for function aliases in use statements.
+		$skipped = array(
+			\T_FUNCTION        => \T_FUNCTION,
+			\T_CLASS           => \T_CLASS,
+			\T_AS              => \T_AS, // Use declaration alias.
+		);
+
+		if ( isset( $skipped[ $this->tokens[ $prev ]['code'] ] ) ) {
+			return false;
 		}
 
 		// Check if this could even be a function call.

--- a/WordPress/AbstractFunctionRestrictionsSniff.php
+++ b/WordPress/AbstractFunctionRestrictionsSniff.php
@@ -232,6 +232,7 @@ abstract class AbstractFunctionRestrictionsSniff extends Sniff {
 		$invalid_tokens  = Tokens::$ooScopeTokens;
 		$invalid_tokens += array(
 			\T_FUNCTION => \T_FUNCTION,
+			\T_NEW      => \T_NEW,
 			\T_AS       => \T_AS, // Use declaration alias.
 		);
 

--- a/WordPress/AbstractFunctionRestrictionsSniff.php
+++ b/WordPress/AbstractFunctionRestrictionsSniff.php
@@ -10,6 +10,7 @@
 namespace WordPressCS\WordPress;
 
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Utils\Context;
 use PHPCSUtils\Utils\MessageHelper;
 use WordPressCS\WordPress\Helpers\ContextHelper;
 use WordPressCS\WordPress\Helpers\RulesetPropertyHelper;
@@ -220,6 +221,11 @@ abstract class AbstractFunctionRestrictionsSniff extends Sniff {
 		}
 
 		if ( ContextHelper::is_token_namespaced( $this->phpcsFile, $stackPtr ) === true ) {
+			return false;
+		}
+
+		if ( Context::inAttribute( $this->phpcsFile, $stackPtr ) ) {
+			// Class instantiation or constant in attribute, not function call.
 			return false;
 		}
 

--- a/WordPress/AbstractFunctionRestrictionsSniff.php
+++ b/WordPress/AbstractFunctionRestrictionsSniff.php
@@ -155,13 +155,23 @@ abstract class AbstractFunctionRestrictionsSniff extends Sniff {
 		foreach ( $this->groups as $groupName => $group ) {
 			if ( empty( $group[ $key ] ) ) {
 				unset( $this->groups[ $groupName ] );
-			} else {
-				$items       = array_map( array( $this, 'prepare_name_for_regex' ), $group[ $key ] );
-				$all_items[] = $items;
-				$items       = implode( '|', $items );
-
-				$this->groups[ $groupName ]['regex'] = sprintf( $this->regex_pattern, $items );
+				continue;
 			}
+
+			// Lowercase the items and potential allows as the comparisons should be done case-insensitively.
+			// Note: this disregards non-ascii names, but as we don't have any of those, that is okay for now.
+			$items                              = array_map( 'strtolower', $group[ $key ] );
+			$this->groups[ $groupName ][ $key ] = $items;
+
+			if ( ! empty( $group['allow'] ) ) {
+				$this->groups[ $groupName ]['allow'] = array_change_key_case( $group['allow'], \CASE_LOWER );
+			}
+
+			$items       = array_map( array( $this, 'prepare_name_for_regex' ), $items );
+			$all_items[] = $items;
+			$items       = implode( '|', $items );
+
+			$this->groups[ $groupName ]['regex'] = sprintf( $this->regex_pattern, $items );
 		}
 
 		if ( empty( $this->groups ) ) {

--- a/WordPress/AbstractFunctionRestrictionsSniff.php
+++ b/WordPress/AbstractFunctionRestrictionsSniff.php
@@ -225,14 +225,14 @@ abstract class AbstractFunctionRestrictionsSniff extends Sniff {
 
 		$prev = $this->phpcsFile->findPrevious( Tokens::$emptyTokens, ( $stackPtr - 1 ), null, true );
 
-		// Skip sniffing on function, class definitions or for function aliases in use statements.
-		$skipped = array(
-			\T_FUNCTION        => \T_FUNCTION,
-			\T_CLASS           => \T_CLASS,
-			\T_AS              => \T_AS, // Use declaration alias.
+		// Skip sniffing on function, OO definitions or for function aliases in use statements.
+		$invalid_tokens  = Tokens::$ooScopeTokens;
+		$invalid_tokens += array(
+			\T_FUNCTION => \T_FUNCTION,
+			\T_AS       => \T_AS, // Use declaration alias.
 		);
 
-		if ( isset( $skipped[ $this->tokens[ $prev ]['code'] ] ) ) {
+		if ( isset( $invalid_tokens[ $this->tokens[ $prev ]['code'] ] ) ) {
 			return false;
 		}
 

--- a/WordPress/Tests/DB/RestrictedFunctionsUnitTest.inc
+++ b/WordPress/Tests/DB/RestrictedFunctionsUnitTest.inc
@@ -82,9 +82,15 @@ maxdb_stat();
 
 // WP Native function which was named a bit unfortunately.
 mysql_to_rfc3339(); // Ok.
+Mysql_to_RFC3339(); // Ok, comparison should be done case insensitively.
 
 // Other WP Native functions which shouldn't give a problem anyway.
 mysql2date(); // Ok.
 wp_check_mysql_version(); // Ok.
 wp_check_php_mysql_version(); // Ok.
 WP_Date_Query::build_mysql_datetime(); // Ok.
+
+// Verify the "allow" key in the function groups is handled case-insensitively.
+myFictionFunction(); // Bad.
+myFictional(); // OK.
+Myfictional(); // OK.

--- a/WordPress/Tests/DB/RestrictedFunctionsUnitTest.php
+++ b/WordPress/Tests/DB/RestrictedFunctionsUnitTest.php
@@ -10,6 +10,7 @@
 namespace WordPressCS\WordPress\Tests\DB;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use WordPressCS\WordPress\AbstractFunctionRestrictionsSniff;
 
 /**
  * Unit test class for the DB_RestrictedFunctions sniff.
@@ -19,9 +20,38 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @since   0.10.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
  *
+ * @covers \WordPressCS\WordPress\AbstractFunctionRestrictionsSniff
  * @covers \WordPressCS\WordPress\Sniffs\DB\RestrictedFunctionsSniff
  */
 final class RestrictedFunctionsUnitTest extends AbstractSniffUnitTest {
+
+	/**
+	 * Add a number of extra restricted functions to unit test the abstract
+	 * AbstractFunctionRestrictionsSniff class.
+	 *
+	 * @before
+	 */
+	protected function enhanceGroups() {
+		parent::setUp();
+
+		AbstractFunctionRestrictionsSniff::$unittest_groups = array(
+			'test-empty-funtions-array' => array(
+				'type'      => 'error',
+				'message'   => 'Detected usage of %s.',
+				'functions' => array(),
+			),
+		);
+	}
+
+	/**
+	 * Reset the $groups property.
+	 *
+	 * @after
+	 */
+	protected function resetGroups() {
+		AbstractFunctionRestrictionsSniff::$unittest_groups = array();
+		parent::tearDown();
+	}
 
 	/**
 	 * Returns the lines where errors should occur.

--- a/WordPress/Tests/DB/RestrictedFunctionsUnitTest.php
+++ b/WordPress/Tests/DB/RestrictedFunctionsUnitTest.php
@@ -40,6 +40,12 @@ final class RestrictedFunctionsUnitTest extends AbstractSniffUnitTest {
 				'message'   => 'Detected usage of %s.',
 				'functions' => array(),
 			),
+			'test_allow-key-handled-case-insensitively' => array(
+				'type'      => 'error',
+				'message'   => 'Detected usage of %s.',
+				'functions' => array( 'myFiction*' ),
+				'allow'     => array( 'myFictional' => true ),
+			),
 		);
 	}
 
@@ -106,6 +112,8 @@ final class RestrictedFunctionsUnitTest extends AbstractSniffUnitTest {
 			74 => 1,
 			75 => 1,
 			76 => 1,
+
+			94 => 1,
 		);
 	}
 

--- a/WordPress/Tests/WP/DiscouragedFunctionsUnitTest.inc
+++ b/WordPress/Tests/WP/DiscouragedFunctionsUnitTest.inc
@@ -33,3 +33,7 @@ use Query_Posts; // OK.
 use function wp_reset_query; // Warning.
 use function wp_reset_query as myFunction; // Warning.
 use function someOtherFunction as wp_reset_query; // OK, alias, not our target.
+
+// Live coding/parse error.
+// This has to be the last test in the file!!!
+\query_posts

--- a/WordPress/Tests/WP/DiscouragedFunctionsUnitTest.inc
+++ b/WordPress/Tests/WP/DiscouragedFunctionsUnitTest.inc
@@ -34,8 +34,9 @@ use function wp_reset_query; // Warning.
 use function wp_reset_query as myFunction; // Warning.
 use function someOtherFunction as wp_reset_query; // OK, alias, not our target.
 
-// Bug fix: prevent false positive for functions declared to return by reference.
+// Bug fixes: prevent false positives for functions declared to return by reference or class instantiations.
 function &query_posts() {} // OK, function declaration, not function use.
+$obj = new WP_Reset_Query(); // OK, class instantiation, not function call.
 
 // Live coding/parse error.
 // This has to be the last test in the file!!!

--- a/WordPress/Tests/WP/DiscouragedFunctionsUnitTest.inc
+++ b/WordPress/Tests/WP/DiscouragedFunctionsUnitTest.inc
@@ -21,3 +21,9 @@ namespace\query_posts(); // OK, not the global function.
 
 // Ensure the sniff doesn't act on functions not listed in the target functions array.
 query_post(); // OK, not one of the target functions.
+
+// Ignore, not a function call.
+class WP_Reset_Query {}
+interface Query_Posts {}
+trait WP_Reset_Query {}
+enum Query_Posts {}

--- a/WordPress/Tests/WP/DiscouragedFunctionsUnitTest.inc
+++ b/WordPress/Tests/WP/DiscouragedFunctionsUnitTest.inc
@@ -27,3 +27,9 @@ class WP_Reset_Query {}
 interface Query_Posts {}
 trait WP_Reset_Query {}
 enum Query_Posts {}
+
+// Ensure the sniff flags function `use` statements, but not class `use` statements or aliases.
+use Query_Posts; // OK.
+use function wp_reset_query; // Warning.
+use function wp_reset_query as myFunction; // Warning.
+use function someOtherFunction as wp_reset_query; // OK, alias, not our target.

--- a/WordPress/Tests/WP/DiscouragedFunctionsUnitTest.inc
+++ b/WordPress/Tests/WP/DiscouragedFunctionsUnitTest.inc
@@ -38,6 +38,12 @@ use function someOtherFunction as wp_reset_query; // OK, alias, not our target.
 function &query_posts() {} // OK, function declaration, not function use.
 $obj = new WP_Reset_Query(); // OK, class instantiation, not function call.
 
+// Prevent false positives on class instantiations in PHP 8.0+ attributes.
+class AttributesShouldBeIgnored {
+	#[WP_Reset_Query()]
+	public function foo() {}
+}
+
 // Live coding/parse error.
 // This has to be the last test in the file!!!
 \query_posts

--- a/WordPress/Tests/WP/DiscouragedFunctionsUnitTest.inc
+++ b/WordPress/Tests/WP/DiscouragedFunctionsUnitTest.inc
@@ -18,3 +18,6 @@ namespace\query_posts(); // OK, not the global function.
 
 // ... but does act on fully qualified function calls.
 \query_posts(); // Warning.
+
+// Ensure the sniff doesn't act on functions not listed in the target functions array.
+query_post(); // OK, not one of the target functions.

--- a/WordPress/Tests/WP/DiscouragedFunctionsUnitTest.inc
+++ b/WordPress/Tests/WP/DiscouragedFunctionsUnitTest.inc
@@ -44,6 +44,24 @@ class AttributesShouldBeIgnored {
 	public function foo() {}
 }
 
+/*
+ * Test exclude property.
+ */
+// Exclude one group:
+// phpcs:set WordPress.WP.DiscouragedFunctions exclude[] query_posts
+query_posts(); // OK, excluded group.
+\wp_reset_query(); // Warning.
+
+// Exclude all groups:
+// phpcs:set WordPress.WP.DiscouragedFunctions exclude[] query_posts,wp_reset_query
+query_posts(); // OK, excluded group.
+wp_reset_query(); // OK, excluded group.
+
+// Reset group exclusions.
+// phpcs:set WordPress.WP.DiscouragedFunctions exclude[]
+\query_posts(); // Warning.
+
+
 // Live coding/parse error.
 // This has to be the last test in the file!!!
 \query_posts

--- a/WordPress/Tests/WP/DiscouragedFunctionsUnitTest.inc
+++ b/WordPress/Tests/WP/DiscouragedFunctionsUnitTest.inc
@@ -34,6 +34,9 @@ use function wp_reset_query; // Warning.
 use function wp_reset_query as myFunction; // Warning.
 use function someOtherFunction as wp_reset_query; // OK, alias, not our target.
 
+// Bug fix: prevent false positive for functions declared to return by reference.
+function &query_posts() {} // OK, function declaration, not function use.
+
 // Live coding/parse error.
 // This has to be the last test in the file!!!
 \query_posts

--- a/WordPress/Tests/WP/DiscouragedFunctionsUnitTest.inc
+++ b/WordPress/Tests/WP/DiscouragedFunctionsUnitTest.inc
@@ -61,6 +61,8 @@ wp_reset_query(); // OK, excluded group.
 // phpcs:set WordPress.WP.DiscouragedFunctions exclude[]
 \query_posts(); // Warning.
 
+// Safeguard that a function used as a PHP 8.1+ first class callable is also flagged.
+call_user_func( query_posts(...), $param ); // Warning.
 
 // Live coding/parse error.
 // This has to be the last test in the file!!!

--- a/WordPress/Tests/WP/DiscouragedFunctionsUnitTest.php
+++ b/WordPress/Tests/WP/DiscouragedFunctionsUnitTest.php
@@ -49,6 +49,7 @@ final class DiscouragedFunctionsUnitTest extends AbstractSniffUnitTest {
 			34 => 1,
 			53 => 1,
 			62 => 1,
+			65 => 1,
 		);
 	}
 }

--- a/WordPress/Tests/WP/DiscouragedFunctionsUnitTest.php
+++ b/WordPress/Tests/WP/DiscouragedFunctionsUnitTest.php
@@ -45,6 +45,8 @@ final class DiscouragedFunctionsUnitTest extends AbstractSniffUnitTest {
 			3  => 1,
 			4  => 1,
 			20 => 1,
+			33 => 1,
+			34 => 1,
 		);
 	}
 }

--- a/WordPress/Tests/WP/DiscouragedFunctionsUnitTest.php
+++ b/WordPress/Tests/WP/DiscouragedFunctionsUnitTest.php
@@ -47,6 +47,8 @@ final class DiscouragedFunctionsUnitTest extends AbstractSniffUnitTest {
 			20 => 1,
 			33 => 1,
 			34 => 1,
+			53 => 1,
+			62 => 1,
 		);
 	}
 }


### PR DESCRIPTION
### AbstractFunctionRestrictionsSniff: add test for non-listed function

... to ensure the abstract sniff doesn't act on functions which are not our target.

Tested via tests in the test file for the `WordPress.WP.DiscouragedFunctions` sniff.
_These tests are deliberately placed in this sniff as a) it doesn't have a WP version component, so the test file wouldn't need to be reorganized and b) the sniff is not likely to move to PHPCSExtra as it is WP specific._

### AbstractFunctionRestrictionsSniff::is_targetted_token(): remove some redundant code

1. The sniff only listens to `T_STRING`, so the check for a token code mismatch would never be `true`.
    Note: there are other abstracts which extend from this one, which do listen to other tokens, but those have their own `is_targetted_token()` method.
2. A `T_STRING` token will always have another non-empty token before it, if nothing else, the PHP open tag, so checking if `$prev` is `false` is redundant.

### AbstractFunctionRestrictionsSniff::is_targetted_token(): add tests with OO declarations

... to safeguard that the sniff skips out early for OO structure declarations and make sure that all OO structures are taking into account.

This shouldn't be a problem anymore since PHPCS 3.7.0, but just making sure.

Includes renaming the variable containing the array of tokens to skip out on.

Tested via tests in the test file for the `WordPress.WP.DiscouragedFunctions` sniff.

### AbstractFunctionRestrictionsSniff::is_targetted_token(): add tests with import use declarations

... to safeguard that the sniff does not act on class imports, does act on function imports, but does not act on aliases for imports.

Tested via tests in the test file for the `WordPress.WP.DiscouragedFunctions` sniff.

### AbstractFunctionRestrictionsSniff::is_targetted_token(): add test with live coding/parse error

Tested via tests in the test file for the `WordPress.WP.DiscouragedFunctions` sniff.

### AbstractFunctionRestrictionsSniff::is_targetted_token(): bug fix - false positive on function declaration returning by reference

Includes test in the test file for the `WordPress.WP.DiscouragedFunctions` sniff.

### AbstractFunctionRestrictionsSniff::is_targetted_token(): bug fix - false positive for class instantiation

... when the class has the same name as a targetted function.

Includes test in the test file for the `WordPress.WP.DiscouragedFunctions` sniff.

### AbstractFunctionRestrictionsSniff::is_targetted_token(): prevent false positives on PHP 8.0+ attributes

`T_STRING` tokens in PHP 8.0+ attributes are either class names or possibly constant names (as a parameter for the class instantiation).
They are never function calls (as things are).

This commit ensures that `T_STRING` tokens in attributes are not confused with function calls.

Tested via tests in the test file for the `WordPress.WP.DiscouragedFunctions` sniff.

### AbstractFunctionRestrictionsSniff::process_token(): add tests for the `exclude` property

Tests have been added to the test file for the `WordPress.WP.DiscouragedFunctions` sniff.

### AbstractFunctionRestrictionsSniff: add test with empty functions group

This test is added to the `WordPress.DB.RestrictedFunctions` test class as we need to test the sniff with both the `$unittest_groups` property set and not set, so we need to use a second class to test the abstract properly.

The `WordPress.DB.RestrictedFunctions` sniff was chosen deliberately as it is one of the few function related sniff which use the `'allow'` key, which will allow us to test the correct handling of that key as well.

### AbstractFunctionRestrictionsSniff: bug fix - function names should be compared case-insensitively

While WP natively doesn't use non-snakecase function names, the abstract may be used by external sniffs, so should handle both snake_case as well as camelCase/camelCaps methos correctly.

This commit ensures that the names of the functions in each group, as well as the names of the function in a potential `'allow'` key are handled case-insensitively.

Includes tests via the `WordPress.DB.RestrictedFunctions` sniff.

### AbstractFunctionRestrictionsSniff: add test with PHP 8.1+ first class callables

... to ensure the abstract sniff will cause those to be flagged as well.

Tested via tests in the test file for the `WordPress.WP.DiscouragedFunctions` sniff.