### PR TITLE
Core: replace the Generic `EndFileNewline` sniff with the PSR2 one

### DIFF
--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -705,8 +705,8 @@
 		</properties>
 	</rule>
 
-	<!-- All files should end with a new line. -->
-	<rule ref="Generic.Files.EndFileNewline"/>
+	<!-- All files should end with a new line, but only one. -->
+	<rule ref="PSR2.Files.EndFileNewline"/>
 
 	<!-- No whitespace should come before semicolons. -->
 	<rule ref="Squiz.WhiteSpace.SemicolonSpacing"/>


### PR DESCRIPTION
PHP_CodeSniffer contains two sniffs which enforce that a file ends on a new line character:
* `Generic.Files.EndFileNewline`
* `PSR2.Files.EndFileNewline`

The `Generic` sniff _only_ checks if there is a new line character.

The `PSR2` sniff checks the same, but additionally also checks there is only one new line character (blank line) at the end of the file.
The checks in the `PSR2` sniff have distinct error codes, so plugins/themes who do not want to enforce the "single blank line" rule can choose to exclude it from their custom ruleset.
Additionally, both checks in the `PSR2` sniff have auto-fixers available.

The `Core` ruleset already contains the `Generic.Files.EndFileNewline` sniff.
I'm now proposing to switch the `Generic` sniff out in favour of the slightly stricter `PSR2` version.