### PR TITLE
GH Actions: fix fixer conflict check

### DIFF
--- a/.github/workflows/basic-qa.yml
+++ b/.github/workflows/basic-qa.yml
@@ -144,13 +144,15 @@ jobs:
       # Test for fixer conflicts by running the auto-fixers of the complete WPCS over the test case files.
       # This is not an exhaustive test, but should give an early indication for typical fixer conflicts.
       # If only fixable errors are found, the exit code will be 1, which can be interpreted as success.
+      #
+      # Note: the ValidVariableNameUnitTest.inc file is temporarily ignored until upstream PHPCS PR 3833 has been merged.
       - name: Test for fixer conflicts (fixes expected)
         if: ${{ matrix.phpcs_version == 'dev-master' }}
         id: phpcbf
         continue-on-error: true
         run: |
           set +e
-          $(pwd)/vendor/bin/phpcbf -pq ./WordPress/Tests/ --standard=WordPress --extensions=inc --exclude=Generic.PHP.Syntax --report=summary
+          $(pwd)/vendor/bin/phpcbf -pq ./WordPress/Tests/ --standard=WordPress --extensions=inc --exclude=Generic.PHP.Syntax --report=summary --ignore=/WordPress/Tests/NamingConventions/ValidVariableNameUnitTest.inc
           exitcode="$?"
           echo "EXITCODE=$exitcode" >> $GITHUB_OUTPUT
           exit "$exitcode"

--- a/.github/workflows/basic-qa.yml
+++ b/.github/workflows/basic-qa.yml
@@ -146,7 +146,15 @@ jobs:
       # If only fixable errors are found, the exit code will be 1, which can be interpreted as success.
       - name: Test for fixer conflicts (fixes expected)
         if: ${{ matrix.phpcs_version == 'dev-master' }}
+        id: phpcbf
         continue-on-error: true
         run: |
+          set +e
           $(pwd)/vendor/bin/phpcbf -pq ./WordPress/Tests/ --standard=WordPress --extensions=inc --exclude=Generic.PHP.Syntax --report=summary
-          if [ $? -eq 1 ]; then exit 0; fi
+          exitcode="$?"
+          echo "EXITCODE=$exitcode" >> $GITHUB_OUTPUT
+          exit "$exitcode"
+
+      - name: Fail the build on fixer conflicts and other errors
+        if: ${{ steps.phpcbf.outputs.EXITCODE != 0 && steps.phpcbf.outputs.EXITCODE != 1 }}
+        run: exit ${{ steps.phpcbf.outputs.EXITCODE }}


### PR DESCRIPTION
While checking something else, I came across a notice in the GH Actions logs showing that the fixer conflict check was failing.

Some backtracing shows that it has been failing for the past five months since PR #2132 was merged - see: https://github.com/WordPress/WordPress-Coding-Standards/actions/runs/3643130487

Unfortunately, the way the script was set up, this failure was not showing and not failing the builds. /cc @desrosj 

The changes I'm proposing now will fix that.

I've also made sure that once the current fixer conflicts are fixed, the build will properly succeed again: https://github.com/jrfnl/WordPress-Coding-Standards/actions/runs/5048089688/jobs/9055836148

Next up: fix the fixer conflicts and whatever other errors have crept in since the build originally started failing....

### GH Actions: temporarily ignore one test case file for the fixer conflict check

... until upstream PR squizlabs/PHP_CodeSniffer#3833 has been merged.

This will allow for the fixer conflict check to be enabled again already and to prevent new issues from being introduced.