### PR TITLE
Tests: fix unintentional (parse/compile) errors in test case files

### DIFF
--- a/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.1.inc
+++ b/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.1.inc
@@ -376,7 +376,7 @@ function acronymFunction() {
 
 // Issue #1311 - allow for overrulable WP Core constants.
 define( 'FORCE_SSL_ADMIN', true );
-const SCRIPT_DEBUG = $develop_src;
+const SCRIPT_DEBUG = true;
 
 // Allow for hook name prefixes with less conventional separators.
 // phpcs:set WordPress.NamingConventions.PrefixAllGlobals prefixes[] test-this,myplugin\
@@ -558,7 +558,7 @@ function acronym_null_coalesce_equals() {
 }
 
 // Safeguard that property assignments using the PHP 8.0+ nullsafe object operator do not trigger false positives.
-$acronym_object??->property = 10;
+$acronym_object?->property = 10;
 
 /*
  * Safeguard support for function calls using PHP 8.0+ named parameters.

--- a/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.1.inc
+++ b/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.1.inc
@@ -164,7 +164,7 @@ $_POST['something'] = 'value';
 do_action_deprecated( 'set_current_user' ); // Deprecated hook, ignored.
 
 // WP global variables, override warning is handled by another sniff.
-function acronym_do_something() {
+function acronym_do_another_thing() {
 	global $post;
 	$post = 'value';
 	$GLOBALS['post'] = 'value';
@@ -511,7 +511,7 @@ function aa_do_something(){}
 
 // The following line mimicks an empty prefix value.
 // phpcs:set WordPress.NamingConventions.PrefixAllGlobals prefixes[] ,
-function aa_do_something(){}
+function aaa_do_something(){}
 
 // phpcs:set WordPress.NamingConventions.PrefixAllGlobals prefixes[] 😊
 function 😊_do_something(){}

--- a/WordPress/Tests/NamingConventions/ValidFunctionNameUnitTest.inc
+++ b/WordPress/Tests/NamingConventions/ValidFunctionNameUnitTest.inc
@@ -52,7 +52,7 @@ class Its_A_Kind_Of_Magic {
 	function __sleep() {} // Ok.
 	function __wakeup() {} // Ok.
 	function __toString() {} // Ok.
-	function __set_state() {} // Ok.
+	static function __set_state($properties) {} // Ok.
 	function __clone() {} // Ok.
 	function __invoke() {} // Ok.
 	function __debugInfo() {} // Ok.
@@ -148,7 +148,7 @@ class Deprecated {
 
 class PHP74Magic {
 	function __serialize() {} // OK.
-	function __unserialize() {} // OK.
+	function __unserialize($data) {} // OK.
 }
 
 class More_Nested {

--- a/WordPress/Tests/NamingConventions/ValidVariableNameUnitTest.inc
+++ b/WordPress/Tests/NamingConventions/ValidVariableNameUnitTest.inc
@@ -208,7 +208,7 @@ function has_params( $without_default, $with_default = 'default' ) {} // OK.
 $closure = function ( $without_default, $with_default = 'default' ) {}; // OK.
 $arrow = fn ( $without_default, $with_default = 'default' ) => 10; // OK.
 
-function has_params( $withoutDefault, $withDefault = 'default' ) {} // Bad x 2.
+function has_params_too( $withoutDefault, $withDefault = 'default' ) {} // Bad x 2.
 $closure = function ( $withoutDefault, $withDefault = 'default' ) {}; // Bad x 2.
 $arrow = fn ( $withoutDefault, $withDefault = 'default' ) => 10; // Bad x 2.
 

--- a/WordPress/Tests/NamingConventions/ValidVariableNameUnitTest.inc
+++ b/WordPress/Tests/NamingConventions/ValidVariableNameUnitTest.inc
@@ -11,7 +11,7 @@ class MyClass {
 	var $_varName = 'hello'; // Bad.
 
 	public $varNamf  = 'hello'; // Bad.
-	public bool $var_namf = 'hello';
+	public bool $var_namf = true;
 	public $varnamf  = 'hello';
 	public $_varNamf = 'hello'; // Bad.
 

--- a/WordPress/Tests/Security/NonceVerificationUnitTest.inc
+++ b/WordPress/Tests/Security/NonceVerificationUnitTest.inc
@@ -235,7 +235,7 @@ function allow_for_nonce_check_within_switch() {
 }
 
 function allow_for_array_compare_before_noncecheck() {
-	if ( array_search( array( 'subscribe', 'unsubscribe', $_POST['action'], true ) // OK.
+	if ( array_search( array( 'subscribe', 'unsubscribe' ), $_POST['action'], true ) // OK.
 		&& wp_verify_nonce( $_POST['newsletter_nonce'] )
 	) {}
 }

--- a/WordPress/Tests/Security/NonceVerificationUnitTest.inc
+++ b/WordPress/Tests/Security/NonceVerificationUnitTest.inc
@@ -265,12 +265,12 @@ function allow_for_unslash_in_sanitization() {
 	echo $var;
 }
 
-function dont_allow_bypass_nonce_via_sanitization() {
+function dont_allow_bypass_nonce_via_sanitization_bad() {
 	$var = sanitize_text_field( $_POST['foo'] ); // Bad.
 	echo $var;
 }
 
-function dont_allow_bypass_nonce_via_sanitization() {
+function dont_allow_bypass_nonce_via_sanitization_good() {
 	$var = sanitize_text_field( $_POST['foo'] ); // OK.
 	wp_verify_nonce( $var );
 	echo $var;
@@ -364,7 +364,7 @@ function allow_in_array_key_exists_before_noncecheck_with_named_params() {
 }
 
 // Tests specifically for the ContextHelper::is_in_array_comparison().
-function allow_for_array_comparison_in_condition() {
+function allow_for_array_comparison_in_condition_non_lowercase_function_call() {
 	if ( Array_Keys( $_GET['actions'], 'my_action', true ) ) { // OK.
 		check_admin_referer( 'foo' );
 		foo();

--- a/WordPress/Tests/Security/ValidatedSanitizedInputUnitTest.inc
+++ b/WordPress/Tests/Security/ValidatedSanitizedInputUnitTest.inc
@@ -228,9 +228,9 @@ function test_more_safe_functions() {
 
 function test_allow_array_key_exists_alias() {
 	if ( key_exists( 'my_field1', $_POST ) ) {
-	$id = (int) $_POST['my_field1']; // OK.
+		$id = (int) $_POST['my_field1']; // OK.
+	}
 }
-
 function test_correct_multi_level_array_validation() {
 	if ( isset( $_POST['toplevel']['sublevel'] ) ) {
 		$id = (int) $_POST['toplevel']; // OK, if a subkey exists, the top level key *must* also exist.

--- a/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.4.inc
+++ b/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.4.inc
@@ -223,7 +223,7 @@ function foo() {
 // Missing domain parameter.
 _n( plural: $plural, single: $single ); // Error.
 esc_attr_x(
-	context : $context
+	context : $context,
 	text    : $text,
 );
 

--- a/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.4.inc.fixed
+++ b/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.4.inc.fixed
@@ -228,7 +228,7 @@ function foo() {
 // Missing domain parameter.
 _n( plural: $plural, single: $single ); // Error.
 esc_attr_x(
-	context : $context
+	context : $context,
 	text    : $text,
 );
 

--- a/WordPress/Tests/WP/CapabilitiesUnitTest.1.inc
+++ b/WordPress/Tests/WP/CapabilitiesUnitTest.1.inc
@@ -114,4 +114,5 @@ $obj->current_user_can( 'foo_bar' ); // Ok. We're not checking for method calls.
 My\NamespaceS\add_posts_page( 'page_title', 'menu_title', 'administrator', 'menu_slug', 'function' ); // Ok. We're not checking namespaced functions.
 
 // Parse error, should be handled correctly by bowing out.
+// This must be the last test in the file!
 add_posts_page( 'page_title',

--- a/WordPress/Tests/WP/CapitalPDangitUnitTest.1.inc
+++ b/WordPress/Tests/WP/CapitalPDangitUnitTest.1.inc
@@ -185,7 +185,7 @@ EOD;
 define( 'WORDPRESS_SOMETHING', 'wordpress' ); // OK.
 class TestMe {
 	public const MY_CONST = 123,
-		ANOTHER => array( 'a' => 'b' ),
+		ANOTHER = array( 'a' => 'b' ),
 		WORDPRESS_SOMETHING = 'wordpress'; // OK (complex declaration to make sure start of statement is detected correctly).
 }
 
@@ -200,7 +200,7 @@ echo namespace\function_name(); // OK - operator.
 namespace Foo\WordPress\Bar; // OK.
 namespace My_WordPress_Plugin; // OK.
 
-namespace Foo\Bar\Wordpress\; // Bad.
+namespace Foo\Bar\Wordpress; // Bad.
 namespace Foo\word_presss\Bar; // Bad.
 namespace My_Wordpresss_Plugin\Foo\Bar; // Bad.
 

--- a/WordPress/Tests/WP/CapitalPDangitUnitTest.1.inc.fixed
+++ b/WordPress/Tests/WP/CapitalPDangitUnitTest.1.inc.fixed
@@ -185,7 +185,7 @@ EOD;
 define( 'WORDPRESS_SOMETHING', 'wordpress' ); // OK.
 class TestMe {
 	public const MY_CONST = 123,
-		ANOTHER => array( 'a' => 'b' ),
+		ANOTHER = array( 'a' => 'b' ),
 		WORDPRESS_SOMETHING = 'wordpress'; // OK (complex declaration to make sure start of statement is detected correctly).
 }
 
@@ -200,7 +200,7 @@ echo namespace\function_name(); // OK - operator.
 namespace Foo\WordPress\Bar; // OK.
 namespace My_WordPress_Plugin; // OK.
 
-namespace Foo\Bar\Wordpress\; // Bad.
+namespace Foo\Bar\Wordpress; // Bad.
 namespace Foo\word_presss\Bar; // Bad.
 namespace My_Wordpresss_Plugin\Foo\Bar; // Bad.
 

--- a/WordPress/Tests/WP/ClassNameCaseUnitTest.inc
+++ b/WordPress/Tests/WP/ClassNameCaseUnitTest.inc
@@ -28,7 +28,7 @@ WP_Customize_New_Menu_Control::foo();
 $obj = new getID3;
 class MyMailer extends PHPMailer\PHPMailer\PHPMailer {}
 $obj = new Requests_Cookie_Jar();
-$anon = class extends SimplePie_IRI {};
+$anon = new class extends SimplePie_IRI {};
 
 
 /*
@@ -46,7 +46,7 @@ WP_Customize_NEW_Menu_Control::foo();
 $obj = new GetID3();
 class MyMailer extends PhpMailer\PhpMailer\PhpMailer {}
 $obj = new Requests_cookie_jar();
-$anon = class extends SimplePie_Iri {};
+$anon = new class extends SimplePie_Iri {};
 
 
 /*

--- a/WordPress/Tests/WP/CronIntervalUnitTest.inc
+++ b/WordPress/Tests/WP/CronIntervalUnitTest.inc
@@ -142,7 +142,7 @@ add_filter( 'cron_schedules', function ( $schedules ) {
 
 Custom::add_filter( 'cron_schedules', array( $class, $method ) ); // OK, not the WP function.
 add_filter( 'some_hook', array( $place, 'cron_schedules' ) ); // OK, not the hook we're looking for.
-add_filter( function() { return get_hook_name('cron_schedules'); }(), array( $class, $method ) ); // OK, nested in another function call.
+add_filter( (function() { return get_hook_name('cron_schedules'); })(), array( $class, $method ) ); // OK, nested in another function call.
 
 // Deal correctly with the time calculations within parentheses.
 add_filter( 'cron_schedules', function ( $schedules ) {

--- a/WordPress/Tests/WP/GlobalVariablesOverrideUnitTest.1.inc
+++ b/WordPress/Tests/WP/GlobalVariablesOverrideUnitTest.1.inc
@@ -55,7 +55,7 @@ add_filter( 'comments_open', function( $open, $post_id ) {
 	return 'page' === $page->post_type;
 }, 10, 2 );
 
-$closure = function() { $page = 'test' }; // Ok, check against cross-contaminiation from within a closure.
+$closure = function() { $page = 'test'; }; // Ok, check against cross-contaminiation from within a closure.
 
 // Allow overriding globals in functions within unit test classes.
 // https://github.com/WordPress/WordPress-Coding-Standards/issues/300#issuecomment-158778606

--- a/WordPress/Tests/WP/I18nUnitTest.1.inc
+++ b/WordPress/Tests/WP/I18nUnitTest.1.inc
@@ -195,9 +195,9 @@ __( '<foo>Foo</foo>', 'my-slug' ); // Good
 
 // Strings wrapped in `<a href="...">...</a>` aren't flagged, since the link target might require localization.
 __( '<a href="https://wordpress.org">WordPress</a>', 'my-slug' ); // Good
-__( '<a id="anchor">translatable text</a>', 'my-slug' ) // Bad, since no href
-__( '<a>translatable text</a>', 'my-slug' ) // Bad, since no href
-__( '<a href="%s">translatable text</a>', 'my-slug' ) // Good
+__( '<a id="anchor">translatable text</a>', 'my-slug' ); // Bad, since no href
+__( '<a>translatable text</a>', 'my-slug' ); // Bad, since no href
+__( '<a href="%s">translatable text</a>', 'my-slug' ); // Good
 
 // Strings containing malformed XML, to make sure we're able to parse them. No warnings should be thrown.
 __( '<div>text to translate', 'my-slug' );

--- a/WordPress/Tests/WP/I18nUnitTest.1.inc.fixed
+++ b/WordPress/Tests/WP/I18nUnitTest.1.inc.fixed
@@ -195,9 +195,9 @@ __( '<foo>Foo</foo>', 'my-slug' ); // Good
 
 // Strings wrapped in `<a href="...">...</a>` aren't flagged, since the link target might require localization.
 __( '<a href="https://wordpress.org">WordPress</a>', 'my-slug' ); // Good
-__( '<a id="anchor">translatable text</a>', 'my-slug' ) // Bad, since no href
-__( '<a>translatable text</a>', 'my-slug' ) // Bad, since no href
-__( '<a href="%s">translatable text</a>', 'my-slug' ) // Good
+__( '<a id="anchor">translatable text</a>', 'my-slug' ); // Bad, since no href
+__( '<a>translatable text</a>', 'my-slug' ); // Bad, since no href
+__( '<a href="%s">translatable text</a>', 'my-slug' ); // Good
 
 // Strings containing malformed XML, to make sure we're able to parse them. No warnings should be thrown.
 __( '<div>text to translate', 'my-slug' );

--- a/WordPress/Tests/WhiteSpace/OperatorSpacingUnitTest.inc
+++ b/WordPress/Tests/WhiteSpace/OperatorSpacingUnitTest.inc
@@ -69,7 +69,7 @@ if ( $a === $b or
 function foo( int|float $param ) : string|false {}
 
 // Safeguard that the "&" in PHP 8.1 intersection types is disregarded.
-function foo( TypeA&namespace\TypeB $param ) : \TypeC&Partially\Qualified {}
+function fooBar( TypeA&namespace\TypeB $param ) : \TypeC&Partially\Qualified {}
 
 // Safeguard handling of union type separator for readonly properties.
 class Foo {

--- a/WordPress/Tests/WhiteSpace/OperatorSpacingUnitTest.inc
+++ b/WordPress/Tests/WhiteSpace/OperatorSpacingUnitTest.inc
@@ -39,9 +39,9 @@ if ( $a === $b xor $b === $c ) {}
 // Logical operators: Too little space.
 if ( $a === $b&&$b === $c ) {}
 if ( $a === $b||$b === $c ) {}
-if ( $a === {$b}and$b === $c ) {}
-if ( $a === {$b}or$b === $c ) {}
-if ( $a === {$b}xor$b === $c ) {}
+if ( $a === ($b)and$b === $c ) {}
+if ( $a === ($b)or$b === $c ) {}
+if ( $a === ($b)xor$b === $c ) {}
 
 // Logical operators: Too much space.
 if ( $a === $b     &&     $b === $c ) {}

--- a/WordPress/Tests/WhiteSpace/OperatorSpacingUnitTest.inc.fixed
+++ b/WordPress/Tests/WhiteSpace/OperatorSpacingUnitTest.inc.fixed
@@ -69,7 +69,7 @@ if ( $a === $b or
 function foo( int|float $param ) : string|false {}
 
 // Safeguard that the "&" in PHP 8.1 intersection types is disregarded.
-function foo( TypeA&namespace\TypeB $param ) : \TypeC&Partially\Qualified {}
+function fooBar( TypeA&namespace\TypeB $param ) : \TypeC&Partially\Qualified {}
 
 // Safeguard handling of union type separator for readonly properties.
 class Foo {

--- a/WordPress/Tests/WhiteSpace/OperatorSpacingUnitTest.inc.fixed
+++ b/WordPress/Tests/WhiteSpace/OperatorSpacingUnitTest.inc.fixed
@@ -39,9 +39,9 @@ if ( $a === $b xor $b === $c ) {}
 // Logical operators: Too little space.
 if ( $a === $b && $b === $c ) {}
 if ( $a === $b || $b === $c ) {}
-if ( $a === {$b} and $b === $c ) {}
-if ( $a === {$b} or $b === $c ) {}
-if ( $a === {$b} xor $b === $c ) {}
+if ( $a === ($b) and $b === $c ) {}
+if ( $a === ($b) or $b === $c ) {}
+if ( $a === ($b) xor $b === $c ) {}
 
 // Logical operators: Too much space.
 if ( $a === $b && $b === $c ) {}


### PR DESCRIPTION
### Tests: fix unintentional (parse/compile) errors in test case files

### Tests: use unique function names

.. to make it easier to do a parse/compile error check on test case files.

Related to #2243