### PR TITLE
WP/EnqueuedResources: bring back try/catch

### DIFF
--- a/WordPress/Sniffs/WP/EnqueuedResourcesSniff.php
+++ b/WordPress/Sniffs/WP/EnqueuedResourcesSniff.php
@@ -9,6 +9,7 @@
 
 namespace WordPressCS\WordPress\Sniffs\WP;
 
+use PHP_CodeSniffer\Exceptions\RuntimeException;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\TextStrings;
@@ -53,8 +54,13 @@ final class EnqueuedResourcesSniff extends Sniff {
 		$end_ptr = $stackPtr;
 		$content = $this->tokens[ $stackPtr ]['content'];
 		if ( \T_INLINE_HTML !== $this->tokens[ $stackPtr ]['code'] ) {
-			$end_ptr = TextStrings::getEndOfCompleteTextString( $this->phpcsFile, $stackPtr );
-			$content = TextStrings::getCompleteTextString( $this->phpcsFile, $stackPtr );
+			try {
+				$end_ptr = TextStrings::getEndOfCompleteTextString( $this->phpcsFile, $stackPtr );
+				$content = TextStrings::getCompleteTextString( $this->phpcsFile, $stackPtr );
+			} catch ( RuntimeException $e ) {
+				// Parse error/live coding.
+				return;
+			}
 		}
 
 		if ( preg_match_all( '# rel=\\\\?[\'"]?stylesheet\\\\?[\'"]?#', $content, $matches, \PREG_OFFSET_CAPTURE ) > 0 ) {

--- a/WordPress/Tests/WP/EnqueuedResourcesUnitTest.1.inc
+++ b/WordPress/Tests/WP/EnqueuedResourcesUnitTest.1.inc
@@ -53,3 +53,6 @@ echo '<script type="text/javascript"
 // Test multi-line text string with multiple issues.
 echo '<link rel="stylesheet" href="https://someurl/somefile1.css"/>
 	<link rel="stylesheet" href="https://someurl/somefile2.css"/>';
+
+// Safeguard the handling of a particular type of parse error (forgotten concat operator).
+echo 'not a text we need to worry' 'about anyway, but we shouldn\'t see an uncaught runtime exception because of it';


### PR DESCRIPTION
Commit dec9d40b33939678ed57ae88e977b5fe7198a55b, which was part of PR #2176 removed this `try/catch` and while it shouldn't be needed anymore for valid code, it _could_ still be needed for code containing parse errors.

This commit doesn't completely revert the previous commit, but does bring the try/catch back to prevent this situation.

Includes unit test safeguarding the fix.

Related to #2243