### PR TITLE
Core: add section about namespace declaration rules with select new sniffs

### DIFF
--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -414,6 +414,29 @@
 
 	<!--
 	#############################################################################
+	Handbook: Declare Statements, Namespace, and Import Statements - Namespace declarations.
+	Ref: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#namespace-declarations
+	#############################################################################
+	-->
+	<!-- Rule: Each part of a namespace name should consist of capitalized words separated by underscores. -->
+
+	<!-- Rule: Namespace declarations should have exactly one blank line before the declaration and at least one blank line after. -->
+
+	<!-- Covers rule: There should be only one namespace declaration per file... -->
+	<rule ref="Universal.Namespaces.OneDeclarationPerFile"/>
+
+	<!-- Rule: ... and it should be at the top of the file.
+		 Note: with only one namespace declaration, it not being at the top of the file would be a parse error. -->
+
+	<!-- Covers rule: Namespace declarations using curly brace syntax are not allowed. -->
+	<rule ref="Universal.Namespaces.DisallowCurlyBraceSyntax"/>
+
+	<!-- Covers rule: Explicit global namespace declaration (namespace declaration without name) are also not allowed. -->
+	<rule ref="Universal.Namespaces.DisallowDeclarationWithoutName"/>
+
+
+	<!--
+	#############################################################################
 	Handbook: Object-Oriented Programming - Only One Object Structure (Class/Interface/Trait) per File.
 	Ref: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#only-one-object-structure-class-interface-trait-per-file
 	#############################################################################


### PR DESCRIPTION
> ### Namespace declarations
>
> Each part of a namespace name should consist of capitalized words separated by underscores.
>
> Namespace declarations should have exactly one blank line before the declaration and at least one blank line after.
>
> There should be only one namespace declaration per file, and it should be at the top of the file. Namespace declarations using curly brace syntax are not allowed. Explicit global namespace declaration (namespace declaration without name) are also not allowed.

Refs:
* https://make.wordpress.org/core/2020/03/20/updating-the-coding-standards-for-modern-php/ - Namespace declarations section
* https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#namespace-declarations
* WordPress/wpcs-docs#97
* WordPress/WordPress-Coding-Standards#1763
* PHPCSStandards/PHPCSExtra#4
* PHPCSStandards/PHPCSExtra#6
* PHPCSStandards/PHPCSExtra#50

Notes:
* The "_Each part of a namespace name should consist of capitalized words separated by underscores_" rule needs a new dedicated sniff.
    An issue will need to be opened about this in WPCS. The corresponding issue in PHPCSExtra is PHPCSStandards/PHPCSExtra#231
* The "_Namespace declarations should have exactly one blank line before the declaration and at least one blank line after_" will probably also need a new sniff.
    My research shows the following:
    - The `PSR2.Namespaces.NamespaceDeclaration` sniff, which is included in `Extra` can _sort of_ cover the "after" part, as in: it check for exactly one blank line after, which is close to, but not exactly what we want.
    - The `PSR12.Files.FileHeader` sniff can check both "before" and "after", but will also, again, check for exactly one blank line.
        The problem with that sniff is that it currently is "all or nothing", it does not have modular error codes, so we cannot ignore some other things from that sniff (requires blank line between PHP open tag and file docblock), which makes it problematic to include the sniff.
        If upstream PR squizlabs/PHP_CodeSniffer#2729 would (finally) be merged, we could reconsider adding that sniff though.
* As for the "_... it (the namespace declaration) should be at the top of the file_" rule. I do not believe we need to actively check for this.
    With the "_only one namespace declaration per file_" rule being enforced, placing the namespace declaration anywhere else than at the top of the file would be a parse error.

Other notes:
* The "_namespace keyword should be lowercase_" part, as mentioned in the Make post, is already covered by the `Generic.PHP.LowerCaseKeyword` sniff.
* The "_There should be exactly one space between the namespace keyword and the start of the namespace name_" part, as mentioned in the Make post, is already covered by the `Generic.WhiteSpace.LanguageConstructSpacing` sniff, which was moved to `Core` in #2097.
* The "_namespace names in a namespace declaration should not start with a leading backslash \\_", as well as the "_There should be no whitespace or comments within the name part of the namespace declaration._", as mentioned in the Make post, are things which can (and should) be flagged by PHPCompatibility 10.0.

Closes #1763