### PR TITLE
Core: add section about import use statement rules with select new sniffs

### DIFF
--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -425,14 +425,44 @@
 	<!-- Covers rule: There should be only one namespace declaration per file... -->
 	<rule ref="Universal.Namespaces.OneDeclarationPerFile"/>
 
-	<!-- Rule: ... and it should be at the top of the file.
+	<!-- Covers rule: ... and it should be at the top of the file.
 		 Note: with only one namespace declaration, it not being at the top of the file would be a parse error. -->
+	<!-- When in the file header, covered by PSR12.Files.FileHeader.IncorrectOrder. -->
 
 	<!-- Covers rule: Namespace declarations using curly brace syntax are not allowed. -->
 	<rule ref="Universal.Namespaces.DisallowCurlyBraceSyntax"/>
 
 	<!-- Covers rule: Explicit global namespace declaration (namespace declaration without name) are also not allowed. -->
 	<rule ref="Universal.Namespaces.DisallowDeclarationWithoutName"/>
+
+
+	<!--
+	#############################################################################
+	Handbook: Declare Statements, Namespace, and Import Statements - Using import use statements.
+	Ref: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#using-import-use-statements
+	#############################################################################
+	-->
+	<!-- Covers rule: Import use statements should be at the top of the file and follow the (optional) namespace declaration. -->
+	<rule ref="PSR12.Files.FileHeader.IncorrectOrder"/>
+
+	<!-- Covers rule: Import use statements should follow a specific order based on the type of the import:
+		 1. use statements for namespaces, classes, interfaces, traits and enums
+		 2. use statements for functions
+		 3. use statements for constants -->
+	<!-- Not yet covered: use statements which are not part of the file header. -->
+	<rule ref="PSR12.Files.FileHeader.IncorrectGrouping"/>
+
+	<!-- Rule: When using aliases, make sure the aliases follow the WordPress naming convention and are unique. -->
+
+	<!-- Rule: (example based rules, group use formatting, spacing around keywords) -->
+	<!-- Spacing after "use" keyword: covered by the Generic.WhiteSpace.LanguageConstructSpacing sniff. -->
+
+	<!-- Implied through the examples: Names in an import use statement should not start with a leading backslash. -->
+	<rule ref="Universal.UseStatements.NoLeadingBackslash"/>
+
+	<!-- Implied through the examples: The use, function, const and as keywords should be lowercase.
+		 For the "use" and "as" keywords, this is covered via the Generic.PHP.LowerCaseKeyword sniff. -->
+	<rule ref="Universal.UseStatements.LowercaseFunctionConst"/>
 
 
 	<!--


### PR DESCRIPTION
> ### Using import use statements
>
> Using import `use` statements allows you to refer to constants, functions, classes, interfaces, namespaces, enums and traits that live outside of the current namespace.
>
> Import `use` statements should be at the top of the file and follow the (optional) `namespace` declaration. They should follow a specific order based on the **type** of the import:
>
> 1. `use` statements for namespaces, classes, interfaces, traits and enums
> 2. `use` statements for functions
> 3. `use` statements for constants
>
> Aliases can be used to prevent name collisions (two classes in different namespaces using the same class name).
> When using aliases, make sure the aliases follow the WordPress naming convention and are unique.
>
> The following examples showcase the correct and incorrect usage of import use statements regarding things like spacing, groupings, leading backslashes, etc.

Refs:
* https://make.wordpress.org/core/2020/03/20/updating-the-coding-standards-for-modern-php/ - Import use statement section
* https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#using-import-use-statements
* WordPress/wpcs-docs#98
* PHPCSStandards/PHPCSExtra#46
* PHPCSStandards/PHPCSExtra#58

Notes:
* The "_Import use statements should be at the top of a file and should directly follow the (optional) namespace declaration._" rule is _sort of_ covered by the `PSR12.Files.FileHeader.IncorrectOrder` sniff.
    This sniff will flag incorrect order when a `use` statement is part of the file header, but will **not** pick up on `use` statements which are not at the top of the file.
* The "_There should be exactly one blank line before the first import use statement of each type and at least one blank line after the last import use statement._" will probably need a new sniff.
    My research shows the following:
    - The `PSR12.Files.FileHeader` sniff can check both "before" and "after", but will check for exactly one blank line.
        The problem with that sniff is that it currently is "all or nothing", it does not have modular error codes for the various file headers sections for the blank line check, so we cannot ignore some other things from that sniff (requires blank line between PHP open tag and file docblock), which makes it problematic to include the sniff.
        If upstream PR squizlabs/PHP_CodeSniffer#2729 would (finally) be merged, we could reconsider adding that sniff though.
* The "_There should be exactly one space after each keyword._" rule is currently only checked for the `use` keyword via the `Generic.WhiteSpace.LanguageConstructSpacing` sniff, which was moved to `Core` in #2097.
    PHPCSExtra 1.1.0 will contain a new `Universal.UseStatements.KeywordSpacing` sniff which can check the spacing around the `function`, `const` and `as` keywords.
* The "_Alias names should comply with the existing WordPress naming conventions for class/function/constant names._" rule will need a new dedicated sniff.
    An issue will need to be opened about this in WPCS. The corresponding issue in PHPCSExtra is PHPCSStandards/PHPCSExtra#232
* The "_Only set an alias when using a different name._" rule as mentioned in the Make post is currently not checked.
    PHPCSExtra 1.1.0 will contain a new `Universal.UseStatements.NoUselessAliases` sniff which will be able to check this.
* The "_When using group use statements ... There should be one statement for each type – OO constructs (classes/interfaces/traits), functions, constants. The various types should not be combined in one group use statement._" rule as mentioned in the Make post is currently not checked.
    PHPCSExtra 1.1.0 will contain a new `Universal.UseStatements.DisallowMixedGroupUse` sniff which will be able to check this.
* As for the formatting rules for group use statements: there are currently no sniffs available for this, so a new sniff is needed to check this.
    
Other notes:
* The "_There should be no whitespace or comments within the name part of a use declaration._", as mentioned in the Make post, can (and should) be flagged by PHPCompatibility 10.0.