### PR TITLE
Move formatting functions related functionality to dedicated `FormattingFunctionsHelper`

### DIFF
--- a/WordPress/Helpers/FormattingFunctionsHelper.php
+++ b/WordPress/Helpers/FormattingFunctionsHelper.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPressCS\WordPress\Helpers;
+
+/**
+ * Helper functions and function lists for checking whether a function is a formatting function.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @since   3.0.0 The property in this class was previously contained in the
+ *                `WordPressCS\WordPress\Sniff` class and has been moved here.
+ */
+final class FormattingFunctionsHelper {
+
+	/**
+	 * Functions that format strings.
+	 *
+	 * These functions are often used for formatting values just before output, and
+	 * it is common practice to escape the individual parameters passed to them as
+	 * needed instead of escaping the entire result. This is especially true when the
+	 * string being formatted contains HTML, which makes escaping the full result
+	 * more difficult.
+	 *
+	 * @since 0.5.0
+	 * @since 0.11.0 Changed from public static to protected non-static.
+	 * @since 3.0.0 - Moved from the Sniff class to this class.
+	 *              - Visibility changed from protected to private and property made static.
+	 *
+	 * @var array<string, bool>
+	 */
+	private static $formattingFunctions = array(
+		'antispambot' => true,
+		'array_fill'  => true,
+		'ent2ncr'     => true,
+		'implode'     => true,
+		'join'        => true,
+		'nl2br'       => true,
+		'sprintf'     => true,
+		'vsprintf'    => true,
+		'wp_sprintf'  => true,
+	);
+
+	/**
+	 * Check if a particular function is regarded as a formatting function.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @param string $functionName The name of the function to check.
+	 *
+	 * @return bool
+	 */
+	public static function is_formatting_function( $functionName ) {
+		return isset( self::$formattingFunctions[ $functionName ] );
+	}
+}

--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -151,32 +151,6 @@ abstract class Sniff implements PHPCS_Sniff {
 	);
 
 	/**
-	 * Functions that format strings.
-	 *
-	 * These functions are often used for formatting values just before output, and
-	 * it is common practice to escape the individual parameters passed to them as
-	 * needed instead of escaping the entire result. This is especially true when the
-	 * string being formatted contains HTML, which makes escaping the full result
-	 * more difficult.
-	 *
-	 * @since 0.5.0
-	 * @since 0.11.0 Changed from public static to protected non-static.
-	 *
-	 * @var array
-	 */
-	protected $formattingFunctions = array(
-		'antispambot' => true,
-		'array_fill'  => true,
-		'ent2ncr'     => true,
-		'implode'     => true,
-		'join'        => true,
-		'nl2br'       => true,
-		'sprintf'     => true,
-		'vsprintf'    => true,
-		'wp_sprintf'  => true,
-	);
-
-	/**
 	 * A list of superglobals that incorporate user input.
 	 *
 	 * @since 0.5.0

--- a/WordPress/Sniffs/DB/PreparedSQLSniff.php
+++ b/WordPress/Sniffs/DB/PreparedSQLSniff.php
@@ -13,6 +13,7 @@ use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\TextStrings;
 use WordPressCS\WordPress\Helpers\ContextHelper;
+use WordPressCS\WordPress\Helpers\FormattingFunctionsHelper;
 use WordPressCS\WordPress\Helpers\WPDBTrait;
 use WordPressCS\WordPress\Sniff;
 
@@ -225,7 +226,7 @@ final class PreparedSQLSniff extends Sniff {
 						$this->i = $this->tokens[ $opening_paren ]['parenthesis_closer'];
 						continue;
 					}
-				} elseif ( isset( $this->formattingFunctions[ $this->tokens[ $this->i ]['content'] ] ) ) {
+				} elseif ( FormattingFunctionsHelper::is_formatting_function( $this->tokens[ $this->i ]['content'] ) ) {
 					continue;
 				}
 			}

--- a/WordPress/Sniffs/Security/EscapeOutputSniff.php
+++ b/WordPress/Sniffs/Security/EscapeOutputSniff.php
@@ -15,6 +15,7 @@ use PHPCSUtils\Utils\TextStrings;
 use WordPressCS\WordPress\Helpers\ContextHelper;
 use WordPressCS\WordPress\Helpers\ConstantsHelper;
 use WordPressCS\WordPress\Helpers\EscapingFunctionsTrait;
+use WordPressCS\WordPress\Helpers\FormattingFunctionsHelper;
 use WordPressCS\WordPress\Helpers\PrintingFunctionsTrait;
 use WordPressCS\WordPress\Helpers\VariableHelper;
 use WordPressCS\WordPress\Sniff;
@@ -345,7 +346,7 @@ class EscapeOutputSniff extends Sniff {
 				$ptr                    = $i;
 				$functionName           = $this->tokens[ $i ]['content'];
 				$function_opener        = $this->phpcsFile->findNext( \T_OPEN_PARENTHESIS, ( $i + 1 ), null, false, null, true );
-				$is_formatting_function = isset( $this->formattingFunctions[ $functionName ] );
+				$is_formatting_function = FormattingFunctionsHelper::is_formatting_function( $functionName );
 
 				if ( false !== $function_opener ) {
 

--- a/WordPress/Tests/DB/PreparedSQLUnitTest.php
+++ b/WordPress/Tests/DB/PreparedSQLUnitTest.php
@@ -21,6 +21,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @since   1.0.0  This sniff has been moved from the `WP` category to the `DB` category.
  *
  * @covers \WordPressCS\WordPress\Helpers\ContextHelper::is_safe_casted
+ * @covers \WordPressCS\WordPress\Helpers\FormattingFunctionsHelper
  * @covers \WordPressCS\WordPress\Helpers\WPDBTrait
  * @covers \WordPressCS\WordPress\Sniffs\DB\PreparedSQLSniff
  */


### PR DESCRIPTION
The formatting function list is only used by a small set of sniffs, so are better placed in a dedicated class.

The `$formattingFunctions` property has also been made `private static`.

Checking whether or not something is a formatting function should now be done by calling the `FormattingFunctionsHelper::is_formatting_function()` method.

Related to #1465