### PR TITLE
Move "array walking" functions related functionality to dedicated `ArrayWalkingFunctionsHelper` + support PHP 8.0+ named parameters

### DIFF
--- a/WordPress/Helpers/ArrayWalkingFunctionsHelper.php
+++ b/WordPress/Helpers/ArrayWalkingFunctionsHelper.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPressCS\WordPress\Helpers;
+
+/**
+ * Helper functions and function lists for checking whether a function applies a callback to an array.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @since   3.0.0 The property in this class was previously contained in the
+ *                `WordPressCS\WordPress\Sniff` class and has been moved here.
+ */
+final class ArrayWalkingFunctionsHelper {
+
+	/**
+	 * List of array functions which apply a callback to the array.
+	 *
+	 * These are often used for sanitization/escaping an array variable.
+	 *
+	 * Note: functions which alter the array by reference are not listed here on purpose.
+	 * These cannot easily be used for sanitization as they can't be combined with unslashing.
+	 * Similarly, they cannot be used for late escaping as the return value is a boolean, not
+	 * the altered array.
+	 *
+	 * @since 2.1.0
+	 * @since 3.0.0 - Moved from the Sniff class to this class.
+	 *              - Visibility changed from protected to private and property made static.
+	 *
+	 * @var array <string function name> => <int parameter position of the callback parameter>
+	 */
+	private static $arrayWalkingFunctions = array(
+		'array_map' => 1,
+		'map_deep'  => 2,
+	);
+
+	/**
+	 * Retrieve a list of the supported "array walking" functions.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @return array<string, int>
+	 */
+	public static function get_array_walking_functions() {
+		return self::$arrayWalkingFunctions;
+	}
+
+	/**
+	 * Check if a particular function is an "array walking" function.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @param string $functionName The name of the function to check.
+	 *
+	 * @return bool
+	 */
+	public static function is_array_walking_function( $functionName ) {
+		return isset( self::$arrayWalkingFunctions[ $functionName ] );
+	}
+}

--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -327,7 +327,7 @@ abstract class Sniff implements PHPCS_Sniff {
 		if ( ArrayWalkingFunctionsHelper::is_array_walking_function( $functionName ) ) {
 
 			// Get the callback parameter.
-			$callback = PassedParameters::getParameter( $this->phpcsFile, $functionPtr, ArrayWalkingFunctionsHelper::get_array_walking_functions()[ $functionName ] );
+			$callback = ArrayWalkingFunctionsHelper::get_callback_parameter( $this->phpcsFile, $functionPtr );
 
 			if ( ! empty( $callback ) ) {
 				/*

--- a/WordPress/Sniffs/Security/EscapeOutputSniff.php
+++ b/WordPress/Sniffs/Security/EscapeOutputSniff.php
@@ -12,6 +12,7 @@ namespace WordPressCS\WordPress\Sniffs\Security;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\Utils\PassedParameters;
 use PHPCSUtils\Utils\TextStrings;
+use WordPressCS\WordPress\Helpers\ArrayWalkingFunctionsHelper;
 use WordPressCS\WordPress\Helpers\ContextHelper;
 use WordPressCS\WordPress\Helpers\ConstantsHelper;
 use WordPressCS\WordPress\Helpers\EscapingFunctionsTrait;
@@ -354,13 +355,13 @@ class EscapeOutputSniff extends Sniff {
 
 				if ( false !== $function_opener ) {
 
-					if ( isset( $this->arrayWalkingFunctions[ $functionName ] ) ) {
+					if ( ArrayWalkingFunctionsHelper::is_array_walking_function( $functionName ) ) {
 
 						// Get the callback parameter.
 						$callback = PassedParameters::getParameter(
 							$this->phpcsFile,
 							$ptr,
-							$this->arrayWalkingFunctions[ $functionName ]
+							ArrayWalkingFunctionsHelper::get_array_walking_functions()[ $functionName ]
 						);
 
 						if ( ! empty( $callback ) ) {

--- a/WordPress/Sniffs/Security/EscapeOutputSniff.php
+++ b/WordPress/Sniffs/Security/EscapeOutputSniff.php
@@ -358,11 +358,7 @@ class EscapeOutputSniff extends Sniff {
 					if ( ArrayWalkingFunctionsHelper::is_array_walking_function( $functionName ) ) {
 
 						// Get the callback parameter.
-						$callback = PassedParameters::getParameter(
-							$this->phpcsFile,
-							$ptr,
-							ArrayWalkingFunctionsHelper::get_array_walking_functions()[ $functionName ]
-						);
+						$callback = ArrayWalkingFunctionsHelper::get_callback_parameter( $this->phpcsFile, $ptr );
 
 						if ( ! empty( $callback ) ) {
 							/*

--- a/WordPress/Tests/Security/EscapeOutputUnitTest.inc
+++ b/WordPress/Tests/Security/EscapeOutputUnitTest.inc
@@ -305,3 +305,15 @@ _deprecated_file(); // Ignore.
 echo antispambot( 'john.doe@mysite.com' ); // OK.
 echo antispambot( esc_html( $email ) ); // OK.
 echo antispambot( $email ); // Bad.
+
+/*
+ * Safeguard support for PHP 8.0+ named parameters for array walking functions.
+ */
+echo implode( '<br>', map_deep( callback: 'esc_html', value: $items ) ); // Ok.
+echo implode( '<br>', map_deep( value: $items ) ); // Bad, missing callback param, so escaping can not be verified.
+echo implode( '<br>', map_deep( call_back: 'esc_html', value: $items ) ); // Bad, wrong param name, so escaping can not be verified.
+echo implode( '<br>', map_deep( callback: 'foo', value: $items, ) ); // Bad, non-escaping function as callback.
+
+// Note: named params not supported due to the `...$arrays` in array_map()`, but that's not the concern of this sniff.
+echo implode( '<br>', array_map( array: $items, callback: 'esc_html', ) ); // Ok.
+echo implode( '<br>', array_map( array: $items, callback: 'foo', ) ); // Bad.

--- a/WordPress/Tests/Security/EscapeOutputUnitTest.php
+++ b/WordPress/Tests/Security/EscapeOutputUnitTest.php
@@ -20,6 +20,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @since   0.13.0     Class name changed: this class is now namespaced.
  * @since   1.0.0      This sniff has been moved from the `XSS` category to the `Security` category.
  *
+ * @covers \WordPressCS\WordPress\Helpers\ArrayWalkingFunctionsHelper
  * @covers \WordPressCS\WordPress\Helpers\ConstantsHelper::is_use_of_global_constant
  * @covers \WordPressCS\WordPress\Helpers\EscapingFunctionsTrait
  * @covers \WordPressCS\WordPress\Helpers\PrintingFunctionsTrait

--- a/WordPress/Tests/Security/EscapeOutputUnitTest.php
+++ b/WordPress/Tests/Security/EscapeOutputUnitTest.php
@@ -96,6 +96,10 @@ final class EscapeOutputUnitTest extends AbstractSniffUnitTest {
 			294 => 1,
 			297 => 1,
 			307 => 1,
+			313 => 1,
+			314 => 1,
+			315 => 1,
+			319 => 1,
 		);
 	}
 

--- a/WordPress/Tests/Security/ValidatedSanitizedInputUnitTest.php
+++ b/WordPress/Tests/Security/ValidatedSanitizedInputUnitTest.php
@@ -20,6 +20,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @since   0.13.0 Class name changed: this class is now namespaced.
  * @since   1.0.0  This sniff has been moved from the `VIP` category to the `Security` category.
  *
+ * @covers \WordPressCS\WordPress\Helpers\ArrayWalkingFunctionsHelper
  * @covers \WordPressCS\WordPress\Helpers\VariableHelper
  * @covers \WordPressCS\WordPress\Sniffs\Security\ValidatedSanitizedInputSniff
  */


### PR DESCRIPTION
### Move "array walking" functions related functionality to dedicated `ArrayWalkingFunctionsHelper`

The "array walking" function list is only used by a small set of sniffs, so are better placed in a dedicated class.

The `$arrayWalkingFunctions` property has also been made `private static`.

Checking whether or not something is an "array walking" function should now be done by calling the `ArrayWalkingFunctionsHelper::is_array_walking_function()` method.

Related to #1465

### ArrayWalkingFunctionsHelper: add support for PHP 8.0+ named parameters

* Transform the `$arrayWalkingFunctions` array to a multi-dimensional array to allow for it to include information about parameter names.
* Add new `get_callback_parameter()` method to retrieve the parameter information using the PHPCSUtils `PassedParameters` functionality.
* Adjust the sniff code retrieving a parameter from these functions to use this new method.
* Adjust the `get_array_walking_functions()` method to still return a single-dimensional array.

Includes additional unit tests.