### PR TITLE
WP/CapitalPDangit: use more modular error codes

### DIFF
--- a/WordPress/Sniffs/WP/CapitalPDangitSniff.php
+++ b/WordPress/Sniffs/WP/CapitalPDangitSniff.php
@@ -266,10 +266,15 @@ final class CapitalPDangitSniff extends Sniff {
 				return;
 			}
 
+			$code = 'MisspelledInText';
+			if ( isset( Tokens::$commentTokens[ $this->tokens[ $stackPtr ]['code'] ] ) ) {
+				$code = 'MisspelledInComment';
+			}
+
 			$fix = $this->phpcsFile->addFixableWarning(
 				'Please spell "WordPress" correctly. Found %s misspelling(s): %s',
 				$stackPtr,
-				'Misspelled',
+				$code,
 				array(
 					\count( $misspelled ),
 					implode( ', ', $misspelled ),


### PR DESCRIPTION
This splits the `Misspelled` error code into two distinct error codes to allow for more modular ignoring of issues.

The new error codes are based on the context in which the misspelling is found (similar to other modular codes already in place, like `MisspelledNamespaceName`):
* `MisspelledInText`
* `MisspelledInComment`

As per the discussion in #1942.