### PR TITLE
Move unslashing-only functions related functionality to dedicated `UnslashingFunctionsHelper`

### DIFF
--- a/WordPress/Helpers/UnslashingFunctionsHelper.php
+++ b/WordPress/Helpers/UnslashingFunctionsHelper.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPressCS\WordPress\Helpers;
+
+/**
+ * Helper functions and function lists for checking whether a function is an unslashing function.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @since   3.0.0 The property in this class was previously contained in the
+ *                `WordPressCS\WordPress\Sniff` class and has been moved here.
+ */
+final class UnslashingFunctionsHelper {
+
+	/**
+	 * Functions which unslash the data passed to them.
+	 *
+	 * @since 2.1.0
+	 * @since 3.0.0 - Moved from the Sniff class to this class.
+	 *              - Visibility changed from protected to private and property made static.
+	 *
+	 * @var array<string, bool>
+	 */
+	private static $unslashingFunctions = array(
+		'stripslashes_deep'              => true,
+		'stripslashes_from_strings_only' => true,
+		'wp_unslash'                     => true,
+	);
+
+	/**
+	 * Retrieve a list of the unslashing functions.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @return array<string, bool>
+	 */
+	public static function get_unslashing_functions() {
+		return self::$unslashingFunctions;
+	}
+
+	/**
+	 * Check if a particular function is regarded as a unslashing function.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @param string $functionName The name of the function to check.
+	 *
+	 * @return bool
+	 */
+	public static function is_unslashing_function( $functionName ) {
+		return isset( self::$unslashingFunctions[ $functionName ] );
+	}
+}

--- a/WordPress/Sniffs/Security/NonceVerificationSniff.php
+++ b/WordPress/Sniffs/Security/NonceVerificationSniff.php
@@ -13,6 +13,7 @@ use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\Utils\MessageHelper;
 use WordPressCS\WordPress\Helpers\ContextHelper;
 use WordPressCS\WordPress\Helpers\RulesetPropertyHelper;
+use WordPressCS\WordPress\Helpers\UnslashingFunctionsHelper;
 use WordPressCS\WordPress\Helpers\VariableHelper;
 use WordPressCS\WordPress\Sniff;
 
@@ -184,7 +185,7 @@ class NonceVerificationSniff extends Sniff {
 			|| ContextHelper::is_in_type_test( $this->phpcsFile, $stackPtr )
 			|| VariableHelper::is_comparison( $this->phpcsFile, $stackPtr )
 			|| ContextHelper::is_in_array_comparison( $this->phpcsFile, $stackPtr )
-			|| ContextHelper::is_in_function_call( $this->phpcsFile, $stackPtr, $this->unslashingFunctions ) !== false
+			|| ContextHelper::is_in_function_call( $this->phpcsFile, $stackPtr, UnslashingFunctionsHelper::get_unslashing_functions() ) !== false
 			|| $this->is_only_sanitized( $stackPtr )
 		) {
 			$allow_nonce_after = true;

--- a/WordPress/Tests/Security/ValidatedSanitizedInputUnitTest.php
+++ b/WordPress/Tests/Security/ValidatedSanitizedInputUnitTest.php
@@ -22,6 +22,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \WordPressCS\WordPress\Helpers\ArrayWalkingFunctionsHelper
  * @covers \WordPressCS\WordPress\Helpers\SanitizingFunctionsTrait
+ * @covers \WordPressCS\WordPress\Helpers\UnslashingFunctionsHelper
  * @covers \WordPressCS\WordPress\Helpers\VariableHelper
  * @covers \WordPressCS\WordPress\Sniffs\Security\ValidatedSanitizedInputSniff
  */


### PR DESCRIPTION
The unslashing function list is only used by a small set of sniffs, so are better placed in a dedicated class.

The `$unslashingFunctions` property has also been made `private static`.

Checking whether or not something is an unslashing function should now be done by calling the `UnslashingFunctionsHelper::is_unslashing_function()` method.

Includes removing a `@internal` comment from the `Sniff` class docblock as it is now redundant.

Related to #1465