### PR TITLE
AbstractArrayAssignmentRestrictions: implement PHPCSUtils, bug fixes, modern PHP and more

### DIFF
--- a/WordPress/AbstractArrayAssignmentRestrictionsSniff.php
+++ b/WordPress/AbstractArrayAssignmentRestrictionsSniff.php
@@ -177,7 +177,10 @@ abstract class AbstractArrayAssignmentRestrictionsSniff extends Sniff {
 				$valEnd         = $this->phpcsFile->findNext( array( \T_COMMA, \T_SEMICOLON ), ( $valStart + 1 ), null, false, null, true );
 				$val            = trim( GetTokensAsString::compact( $this->phpcsFile, $valStart, ( $valEnd - 1 ), true ) );
 				$val          = TextStrings::stripQuotes( $val );
-				$inst[ $key ] = array( $val, $token['line'] );
+				$inst[ $key ] = array(
+					'value' => $val,
+					'line'  => $token['line'],
+				);
 			}
 		} elseif ( isset( Tokens::$stringTokens[ $token['code'] ] ) ) {
 			/*
@@ -187,8 +190,11 @@ abstract class AbstractArrayAssignmentRestrictionsSniff extends Sniff {
 				return; // No assignments here, nothing to check.
 			}
 
-			foreach ( $matches[1] as $i => $_k ) {
-				$inst[ $_k ] = array( $matches[2][ $i ], $token['line'] );
+			foreach ( $matches[1] as $match_nr => $key ) {
+				$inst[ $key ] = array(
+					'value' => $matches[2][ $match_nr ],
+					'line'  => $token['line'],
+				);
 			}
 		}
 
@@ -209,9 +215,7 @@ abstract class AbstractArrayAssignmentRestrictionsSniff extends Sniff {
 					continue;
 				}
 
-				list( $val, $line ) = $assignment;
-
-				$output = \call_user_func( $callback, $key, $val, $line, $group );
+				$output = \call_user_func( $callback, $key, $assignment['value'], $assignment['line'], $group );
 
 				if ( ! isset( $output ) || false === $output ) {
 					continue;
@@ -227,7 +231,7 @@ abstract class AbstractArrayAssignmentRestrictionsSniff extends Sniff {
 					$stackPtr,
 					( 'error' === $group['type'] ),
 					MessageHelper::stringToErrorcode( $groupName . '_' . $key ),
-					array( $key, $val )
+					array( $key, $assignment['value'] )
 				);
 			}
 		}

--- a/WordPress/AbstractArrayAssignmentRestrictionsSniff.php
+++ b/WordPress/AbstractArrayAssignmentRestrictionsSniff.php
@@ -162,7 +162,7 @@ abstract class AbstractArrayAssignmentRestrictionsSniff extends Sniff {
 		 * `$foo = array( 'bar' => 'taz' );`
 		 * `$foo['bar'] = $taz;`
 		 */
-		if ( \in_array( $token['code'], array( \T_CLOSE_SQUARE_BRACKET, \T_DOUBLE_ARROW ), true ) ) {
+		if ( \T_CLOSE_SQUARE_BRACKET === $token['code'] || \T_DOUBLE_ARROW === $token['code'] ) {
 			$operator = $stackPtr; // T_DOUBLE_ARROW.
 			if ( \T_CLOSE_SQUARE_BRACKET === $token['code'] ) {
 				$operator = $this->phpcsFile->findNext( \T_EQUAL, ( $stackPtr + 1 ) );
@@ -177,7 +177,7 @@ abstract class AbstractArrayAssignmentRestrictionsSniff extends Sniff {
 				$val            = TextStrings::stripQuotes( $val );
 				$inst[ $key ][] = array( $val, $token['line'] );
 			}
-		} elseif ( \in_array( $token['code'], array( \T_CONSTANT_ENCAPSED_STRING, \T_DOUBLE_QUOTED_STRING ), true ) ) {
+		} elseif ( isset( Tokens::$stringTokens[ $token['code'] ] ) ) {
 			/*
 			 * Covers assignments via query parameters: `$foo = 'bar=taz&other=thing';`.
 			 */

--- a/WordPress/AbstractArrayAssignmentRestrictionsSniff.php
+++ b/WordPress/AbstractArrayAssignmentRestrictionsSniff.php
@@ -9,6 +9,7 @@
 
 namespace WordPressCS\WordPress;
 
+use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\Utils\GetTokensAsString;
 use PHPCSUtils\Utils\MessageHelper;
 use PHPCSUtils\Utils\TextStrings;
@@ -146,7 +147,7 @@ abstract class AbstractArrayAssignmentRestrictionsSniff extends Sniff {
 		$token = $this->tokens[ $stackPtr ];
 
 		if ( \T_CLOSE_SQUARE_BRACKET === $token['code'] ) {
-			$equal = $this->phpcsFile->findNext( \T_WHITESPACE, ( $stackPtr + 1 ), null, true );
+			$equal = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true );
 			if ( \T_EQUAL !== $this->tokens[ $equal ]['code'] ) {
 				// This is not an assignment. Bow out.
 				return;
@@ -167,7 +168,7 @@ abstract class AbstractArrayAssignmentRestrictionsSniff extends Sniff {
 				$operator = $this->phpcsFile->findNext( \T_EQUAL, ( $stackPtr + 1 ) );
 			}
 
-			$keyIdx = $this->phpcsFile->findPrevious( array( \T_WHITESPACE, \T_CLOSE_SQUARE_BRACKET ), ( $operator - 1 ), null, true );
+			$keyIdx = $this->phpcsFile->findPrevious( Tokens::$emptyTokens, ( $stackPtr - 1 ), null, true );
 			if ( ! is_numeric( $this->tokens[ $keyIdx ]['content'] ) ) {
 				$key            = TextStrings::stripQuotes( $this->tokens[ $keyIdx ]['content'] );
 				$valStart       = $this->phpcsFile->findNext( array( \T_WHITESPACE ), ( $operator + 1 ), null, true );

--- a/WordPress/AbstractArrayAssignmentRestrictionsSniff.php
+++ b/WordPress/AbstractArrayAssignmentRestrictionsSniff.php
@@ -174,10 +174,18 @@ abstract class AbstractArrayAssignmentRestrictionsSniff extends Sniff {
 			if ( isset( Tokens::$stringTokens[ $this->tokens[ $keyIdx ]['code'] ] )
 				&& ! is_numeric( $this->tokens[ $keyIdx ]['content'] )
 			) {
-				$key            = TextStrings::stripQuotes( $this->tokens[ $keyIdx ]['content'] );
-				$valStart       = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $operator + 1 ), null, true );
-				$valEnd         = $this->phpcsFile->findNext( array( \T_COMMA, \T_SEMICOLON ), ( $valStart + 1 ), null, false, null, true );
-				$val            = trim( GetTokensAsString::compact( $this->phpcsFile, $valStart, ( $valEnd - 1 ), true ) );
+				$key      = TextStrings::stripQuotes( $this->tokens[ $keyIdx ]['content'] );
+				$valStart = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $operator + 1 ), null, true );
+				$valEnd   = $this->phpcsFile->findEndOfStatement( $valStart, \T_COLON );
+				if ( \T_COMMA === $this->tokens[ $valEnd ]['code']
+					|| \T_SEMICOLON === $this->tokens[ $valEnd ]['code']
+				) {
+					// FindEndOfStatement includes the comma/semi-colon if that's the end of the statement.
+					// That's not what we want (and inconsistent), so remove it.
+					--$valEnd;
+				}
+
+				$val          = trim( GetTokensAsString::compact( $this->phpcsFile, $valStart, $valEnd, true ) );
 				$val          = TextStrings::stripQuotes( $val );
 				$inst[ $key ] = array(
 					'value'  => $val,

--- a/WordPress/AbstractArrayAssignmentRestrictionsSniff.php
+++ b/WordPress/AbstractArrayAssignmentRestrictionsSniff.php
@@ -182,6 +182,7 @@ abstract class AbstractArrayAssignmentRestrictionsSniff extends Sniff {
 			if ( preg_match_all( '#(?:^|&)([a-z_]+)=([^&]*)#i', TextStrings::stripQuotes( $token['content'] ), $matches ) <= 0 ) {
 				return; // No assignments here, nothing to check.
 			}
+
 			foreach ( $matches[1] as $i => $_k ) {
 				$inst[ $_k ][] = array( $matches[2][ $i ], $token['line'] );
 			}

--- a/WordPress/AbstractArrayAssignmentRestrictionsSniff.php
+++ b/WordPress/AbstractArrayAssignmentRestrictionsSniff.php
@@ -176,8 +176,8 @@ abstract class AbstractArrayAssignmentRestrictionsSniff extends Sniff {
 				$valStart       = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $operator + 1 ), null, true );
 				$valEnd         = $this->phpcsFile->findNext( array( \T_COMMA, \T_SEMICOLON ), ( $valStart + 1 ), null, false, null, true );
 				$val            = trim( GetTokensAsString::compact( $this->phpcsFile, $valStart, ( $valEnd - 1 ), true ) );
-				$val            = TextStrings::stripQuotes( $val );
-				$inst[ $key ][] = array( $val, $token['line'] );
+				$val          = TextStrings::stripQuotes( $val );
+				$inst[ $key ] = array( $val, $token['line'] );
 			}
 		} elseif ( isset( Tokens::$stringTokens[ $token['code'] ] ) ) {
 			/*
@@ -188,7 +188,7 @@ abstract class AbstractArrayAssignmentRestrictionsSniff extends Sniff {
 			}
 
 			foreach ( $matches[1] as $i => $_k ) {
-				$inst[ $_k ][] = array( $matches[2][ $i ], $token['line'] );
+				$inst[ $_k ] = array( $matches[2][ $i ], $token['line'] );
 			}
 		}
 
@@ -204,33 +204,31 @@ abstract class AbstractArrayAssignmentRestrictionsSniff extends Sniff {
 
 			$callback = ( isset( $group['callback'] ) && is_callable( $group['callback'] ) ) ? $group['callback'] : array( $this, 'callback' );
 
-			foreach ( $inst as $key => $assignments ) {
+			foreach ( $inst as $key => $assignment ) {
 				if ( ! \in_array( $key, $group['keys'], true ) ) {
 					continue;
 				}
 
-				foreach ( $assignments as $occurance ) {
-					list( $val, $line ) = $occurance;
+				list( $val, $line ) = $assignment;
 
-					$output = \call_user_func( $callback, $key, $val, $line, $group );
+				$output = \call_user_func( $callback, $key, $val, $line, $group );
 
-					if ( ! isset( $output ) || false === $output ) {
-						continue;
-					} elseif ( true === $output ) {
-						$message = $group['message'];
-					} else {
-						$message = $output;
-					}
-
-					MessageHelper::addMessage(
-						$this->phpcsFile,
-						$message,
-						$stackPtr,
-						( 'error' === $group['type'] ),
-						MessageHelper::stringToErrorcode( $groupName . '_' . $key ),
-						array( $key, $val )
-					);
+				if ( ! isset( $output ) || false === $output ) {
+					continue;
+				} elseif ( true === $output ) {
+					$message = $group['message'];
+				} else {
+					$message = $output;
 				}
+
+				MessageHelper::addMessage(
+					$this->phpcsFile,
+					$message,
+					$stackPtr,
+					( 'error' === $group['type'] ),
+					MessageHelper::stringToErrorcode( $groupName . '_' . $key ),
+					array( $key, $val )
+				);
 			}
 		}
 	}

--- a/WordPress/AbstractArrayAssignmentRestrictionsSniff.php
+++ b/WordPress/AbstractArrayAssignmentRestrictionsSniff.php
@@ -9,6 +9,7 @@
 
 namespace WordPressCS\WordPress;
 
+use PHPCSUtils\Utils\GetTokensAsString;
 use PHPCSUtils\Utils\MessageHelper;
 use PHPCSUtils\Utils\TextStrings;
 use WordPressCS\WordPress\Helpers\RulesetPropertyHelper;
@@ -171,7 +172,7 @@ abstract class AbstractArrayAssignmentRestrictionsSniff extends Sniff {
 				$key            = TextStrings::stripQuotes( $this->tokens[ $keyIdx ]['content'] );
 				$valStart       = $this->phpcsFile->findNext( array( \T_WHITESPACE ), ( $operator + 1 ), null, true );
 				$valEnd         = $this->phpcsFile->findNext( array( \T_COMMA, \T_SEMICOLON ), ( $valStart + 1 ), null, false, null, true );
-				$val            = $this->phpcsFile->getTokensAsString( $valStart, ( $valEnd - $valStart ) );
+				$val            = trim( GetTokensAsString::compact( $this->phpcsFile, $valStart, ( $valEnd - 1 ), true ) );
 				$val            = TextStrings::stripQuotes( $val );
 				$inst[ $key ][] = array( $val, $token['line'] );
 			}

--- a/WordPress/AbstractArrayAssignmentRestrictionsSniff.php
+++ b/WordPress/AbstractArrayAssignmentRestrictionsSniff.php
@@ -178,8 +178,9 @@ abstract class AbstractArrayAssignmentRestrictionsSniff extends Sniff {
 				$val            = trim( GetTokensAsString::compact( $this->phpcsFile, $valStart, ( $valEnd - 1 ), true ) );
 				$val          = TextStrings::stripQuotes( $val );
 				$inst[ $key ] = array(
-					'value' => $val,
-					'line'  => $token['line'],
+					'value'  => $val,
+					'line'   => $token['line'],
+					'keyptr' => $keyIdx,
 				);
 			}
 		} elseif ( isset( Tokens::$stringTokens[ $token['code'] ] ) ) {
@@ -192,8 +193,9 @@ abstract class AbstractArrayAssignmentRestrictionsSniff extends Sniff {
 
 			foreach ( $matches[1] as $match_nr => $key ) {
 				$inst[ $key ] = array(
-					'value' => $matches[2][ $match_nr ],
-					'line'  => $token['line'],
+					'value'  => $matches[2][ $match_nr ],
+					'line'   => $token['line'],
+					'keyptr' => $stackPtr,
 				);
 			}
 		}
@@ -228,7 +230,7 @@ abstract class AbstractArrayAssignmentRestrictionsSniff extends Sniff {
 				MessageHelper::addMessage(
 					$this->phpcsFile,
 					$message,
-					$stackPtr,
+					$assignment['keyptr'],
 					( 'error' === $group['type'] ),
 					MessageHelper::stringToErrorcode( $groupName . '_' . $key ),
 					array( $key, $assignment['value'] )

--- a/WordPress/AbstractArrayAssignmentRestrictionsSniff.php
+++ b/WordPress/AbstractArrayAssignmentRestrictionsSniff.php
@@ -171,7 +171,7 @@ abstract class AbstractArrayAssignmentRestrictionsSniff extends Sniff {
 			$keyIdx = $this->phpcsFile->findPrevious( Tokens::$emptyTokens, ( $stackPtr - 1 ), null, true );
 			if ( ! is_numeric( $this->tokens[ $keyIdx ]['content'] ) ) {
 				$key            = TextStrings::stripQuotes( $this->tokens[ $keyIdx ]['content'] );
-				$valStart       = $this->phpcsFile->findNext( array( \T_WHITESPACE ), ( $operator + 1 ), null, true );
+				$valStart       = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $operator + 1 ), null, true );
 				$valEnd         = $this->phpcsFile->findNext( array( \T_COMMA, \T_SEMICOLON ), ( $valStart + 1 ), null, false, null, true );
 				$val            = trim( GetTokensAsString::compact( $this->phpcsFile, $valStart, ( $valEnd - 1 ), true ) );
 				$val            = TextStrings::stripQuotes( $val );

--- a/WordPress/AbstractArrayAssignmentRestrictionsSniff.php
+++ b/WordPress/AbstractArrayAssignmentRestrictionsSniff.php
@@ -169,7 +169,9 @@ abstract class AbstractArrayAssignmentRestrictionsSniff extends Sniff {
 			}
 
 			$keyIdx = $this->phpcsFile->findPrevious( Tokens::$emptyTokens, ( $stackPtr - 1 ), null, true );
-			if ( ! is_numeric( $this->tokens[ $keyIdx ]['content'] ) ) {
+			if ( isset( Tokens::$stringTokens[ $this->tokens[ $keyIdx ]['code'] ] )
+				&& ! is_numeric( $this->tokens[ $keyIdx ]['content'] )
+			) {
 				$key            = TextStrings::stripQuotes( $this->tokens[ $keyIdx ]['content'] );
 				$valStart       = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $operator + 1 ), null, true );
 				$valEnd         = $this->phpcsFile->findNext( array( \T_COMMA, \T_SEMICOLON ), ( $valStart + 1 ), null, false, null, true );

--- a/WordPress/AbstractArrayAssignmentRestrictionsSniff.php
+++ b/WordPress/AbstractArrayAssignmentRestrictionsSniff.php
@@ -203,12 +203,12 @@ abstract class AbstractArrayAssignmentRestrictionsSniff extends Sniff {
 			$callback = ( isset( $group['callback'] ) && is_callable( $group['callback'] ) ) ? $group['callback'] : array( $this, 'callback' );
 
 			foreach ( $inst as $key => $assignments ) {
+				if ( ! \in_array( $key, $group['keys'], true ) ) {
+					continue;
+				}
+
 				foreach ( $assignments as $occurance ) {
 					list( $val, $line ) = $occurance;
-
-					if ( ! \in_array( $key, $group['keys'], true ) ) {
-						continue;
-					}
 
 					$output = \call_user_func( $callback, $key, $val, $line, $group );
 

--- a/WordPress/AbstractArrayAssignmentRestrictionsSniff.php
+++ b/WordPress/AbstractArrayAssignmentRestrictionsSniff.php
@@ -147,8 +147,8 @@ abstract class AbstractArrayAssignmentRestrictionsSniff extends Sniff {
 		$token = $this->tokens[ $stackPtr ];
 
 		if ( \T_CLOSE_SQUARE_BRACKET === $token['code'] ) {
-			$equal = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true );
-			if ( \T_EQUAL !== $this->tokens[ $equal ]['code'] ) {
+			$equalPtr = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true );
+			if ( \T_EQUAL !== $this->tokens[ $equalPtr ]['code'] ) {
 				// This is not an assignment. Bow out.
 				return;
 			}
@@ -165,7 +165,7 @@ abstract class AbstractArrayAssignmentRestrictionsSniff extends Sniff {
 		if ( \T_CLOSE_SQUARE_BRACKET === $token['code'] || \T_DOUBLE_ARROW === $token['code'] ) {
 			$operator = $stackPtr; // T_DOUBLE_ARROW.
 			if ( \T_CLOSE_SQUARE_BRACKET === $token['code'] ) {
-				$operator = $this->phpcsFile->findNext( \T_EQUAL, ( $stackPtr + 1 ) );
+				$operator = $equalPtr;
 			}
 
 			$keyIdx = $this->phpcsFile->findPrevious( Tokens::$emptyTokens, ( $stackPtr - 1 ), null, true );

--- a/WordPress/AbstractArrayAssignmentRestrictionsSniff.php
+++ b/WordPress/AbstractArrayAssignmentRestrictionsSniff.php
@@ -186,7 +186,6 @@ abstract class AbstractArrayAssignmentRestrictionsSniff extends Sniff {
 				}
 
 				$val          = trim( GetTokensAsString::compact( $this->phpcsFile, $valStart, $valEnd, true ) );
-				$val          = TextStrings::stripQuotes( $val );
 				$inst[ $key ] = array(
 					'value'  => $val,
 					'line'   => $token['line'],

--- a/WordPress/AbstractArrayAssignmentRestrictionsSniff.php
+++ b/WordPress/AbstractArrayAssignmentRestrictionsSniff.php
@@ -148,7 +148,9 @@ abstract class AbstractArrayAssignmentRestrictionsSniff extends Sniff {
 
 		if ( \T_CLOSE_SQUARE_BRACKET === $token['code'] ) {
 			$equalPtr = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true );
-			if ( \T_EQUAL !== $this->tokens[ $equalPtr ]['code'] ) {
+			if ( \T_EQUAL !== $this->tokens[ $equalPtr ]['code']
+				&& \T_COALESCE_EQUAL !== $this->tokens[ $equalPtr ]['code']
+			) {
 				// This is not an assignment. Bow out.
 				return;
 			}

--- a/WordPress/Tests/WP/PostsPerPageUnitTest.inc
+++ b/WordPress/Tests/WP/PostsPerPageUnitTest.inc
@@ -70,3 +70,8 @@ $query_args[
 // Ensure that PHP 7.4 null coalesce equals get picked up on.
 $query_args['posts_per_page'] ??= 50; // OK.
 $query_args['posts_per_page'] ??= 200; // Bad.
+
+// Ensure that the sniff does not report on PHP 8.0 match arms.
+$val = match($val) {
+	'posts_per_page' => 999, // OK, not an array assignment.
+};

--- a/WordPress/Tests/WP/PostsPerPageUnitTest.inc
+++ b/WordPress/Tests/WP/PostsPerPageUnitTest.inc
@@ -40,10 +40,10 @@ $firstChars = $text[0] . $text[1]; // OK.
 // Text strings which are not query strings should be ignored.
 _query_posts( 'numberposts' ); // OK.
 
-// Assignments to non-string keys should be ignored.
+// Assignments to non-string keys should be ignored. Note: PHP will auto-cast numeric strings to ints, so those should also be disregarded.
 $var[10] = 300; // OK.
-
-
+$var[] = 400; // OK.
+$var['239'] = 500; // OK.
 
 // Ensure the sniff disregards comments.
 $query_args['posts_per_page' /* high */ ] = 999; // Bad.

--- a/WordPress/Tests/WP/PostsPerPageUnitTest.inc
+++ b/WordPress/Tests/WP/PostsPerPageUnitTest.inc
@@ -66,3 +66,7 @@ _query_posts( 'posts_per_page=999&nopaging=true&posts_per_page=50' ); // OK.
 $query_args[
 	'posts_per_page'
 ] = 300; // Bad, error should be reported on the above line.
+
+// Ensure that PHP 7.4 null coalesce equals get picked up on.
+$query_args['posts_per_page'] ??= 50; // OK.
+$query_args['posts_per_page'] ??= 200; // Bad.

--- a/WordPress/Tests/WP/PostsPerPageUnitTest.inc
+++ b/WordPress/Tests/WP/PostsPerPageUnitTest.inc
@@ -53,3 +53,8 @@ $query_args['posts_per_page'] /* high */  = 999; // Bad.
 $args = array(
 	'posts_per_page' /* high */ => 999, // Bad.
 );
+
+$query_args['posts_per_page'] = /* high */ 999; // Bad.
+$args = array(
+	'posts_per_page' => /* high */ 999, // Bad.
+);

--- a/WordPress/Tests/WP/PostsPerPageUnitTest.inc
+++ b/WordPress/Tests/WP/PostsPerPageUnitTest.inc
@@ -42,3 +42,14 @@ _query_posts( 'numberposts' ); // OK.
 
 // Assignments to non-string keys should be ignored.
 $var[10] = 300; // OK.
+
+
+
+// Ensure the sniff disregards comments.
+$query_args['posts_per_page' /* high */ ] = 999; // Bad.
+
+$query_args['posts_per_page'] /* high */  = 999; // Bad.
+
+$args = array(
+	'posts_per_page' /* high */ => 999, // Bad.
+);

--- a/WordPress/Tests/WP/PostsPerPageUnitTest.inc
+++ b/WordPress/Tests/WP/PostsPerPageUnitTest.inc
@@ -61,3 +61,8 @@ $args = array(
 
 // Safeguard that when a query string contains duplicate key, the value of the last one is used.
 _query_posts( 'posts_per_page=999&nopaging=true&posts_per_page=50' ); // OK.
+
+// Ensure the error gets reported on the key pointer.
+$query_args[
+	'posts_per_page'
+] = 300; // Bad, error should be reported on the above line.

--- a/WordPress/Tests/WP/PostsPerPageUnitTest.inc
+++ b/WordPress/Tests/WP/PostsPerPageUnitTest.inc
@@ -75,3 +75,9 @@ $query_args['posts_per_page'] ??= 200; // Bad.
 $val = match($val) {
 	'posts_per_page' => 999, // OK, not an array assignment.
 };
+
+// Verify handling of arrays without trailing comma after the last array item.
+$args = array( 'posts_per_page' => 999 ); // Bad.
+$args = [
+	'posts_per_page' => 999
+]; // Bad.

--- a/WordPress/Tests/WP/PostsPerPageUnitTest.inc
+++ b/WordPress/Tests/WP/PostsPerPageUnitTest.inc
@@ -28,3 +28,17 @@ $query_args['posts_per_page'] = 100; // OK.
 $query_args['posts_per_page'] = 200; // OK.
 $query_args['posts_per_page'] = 300; // Bad.
 // phpcs:set WordPress.WP.PostsPerPage posts_per_page 100
+
+// phpcs:set WordPress.WP.PostsPerPage exclude[] posts_per_page
+$query_args['posts_per_page'] = 300; // OK, group excluded.
+// phpcs:set WordPress.WP.PostsPerPage exclude[]
+
+// Ensure there will be no false positive for array access brackets when not used for an assignment.
+$var = $query_args['posts_per_page']; // OK.
+$firstChars = $text[0] . $text[1]; // OK.
+
+// Text strings which are not query strings should be ignored.
+_query_posts( 'numberposts' ); // OK.
+
+// Assignments to non-string keys should be ignored.
+$var[10] = 300; // OK.

--- a/WordPress/Tests/WP/PostsPerPageUnitTest.inc
+++ b/WordPress/Tests/WP/PostsPerPageUnitTest.inc
@@ -58,3 +58,6 @@ $query_args['posts_per_page'] = /* high */ 999; // Bad.
 $args = array(
 	'posts_per_page' => /* high */ 999, // Bad.
 );
+
+// Safeguard that when a query string contains duplicate key, the value of the last one is used.
+_query_posts( 'posts_per_page=999&nopaging=true&posts_per_page=50' ); // OK.

--- a/WordPress/Tests/WP/PostsPerPageUnitTest.php
+++ b/WordPress/Tests/WP/PostsPerPageUnitTest.php
@@ -56,6 +56,7 @@ final class PostsPerPageUnitTest extends AbstractSniffUnitTest {
 			54 => 1,
 			57 => 1,
 			59 => 1,
+			67 => 1,
 		);
 	}
 }

--- a/WordPress/Tests/WP/PostsPerPageUnitTest.php
+++ b/WordPress/Tests/WP/PostsPerPageUnitTest.php
@@ -51,6 +51,9 @@ final class PostsPerPageUnitTest extends AbstractSniffUnitTest {
 			23 => 1,
 			24 => 1,
 			29 => 1,
+			49 => 1,
+			51 => 1,
+			54 => 1,
 		);
 	}
 }

--- a/WordPress/Tests/WP/PostsPerPageUnitTest.php
+++ b/WordPress/Tests/WP/PostsPerPageUnitTest.php
@@ -57,6 +57,7 @@ final class PostsPerPageUnitTest extends AbstractSniffUnitTest {
 			57 => 1,
 			59 => 1,
 			67 => 1,
+			72 => 1,
 		);
 	}
 }

--- a/WordPress/Tests/WP/PostsPerPageUnitTest.php
+++ b/WordPress/Tests/WP/PostsPerPageUnitTest.php
@@ -54,6 +54,8 @@ final class PostsPerPageUnitTest extends AbstractSniffUnitTest {
 			49 => 1,
 			51 => 1,
 			54 => 1,
+			57 => 1,
+			59 => 1,
 		);
 	}
 }

--- a/WordPress/Tests/WP/PostsPerPageUnitTest.php
+++ b/WordPress/Tests/WP/PostsPerPageUnitTest.php
@@ -58,6 +58,8 @@ final class PostsPerPageUnitTest extends AbstractSniffUnitTest {
 			59 => 1,
 			67 => 1,
 			72 => 1,
+			80 => 1,
+			82 => 1,
 		);
 	}
 }


### PR DESCRIPTION
## Review notes

This PR is the result of a comprehensive review of the `AbstractArrayAssignmentRestrictionsSniff` class.

While this PR makes significant improvements, there is still more wrong with this abstract:

* The text quotes are stripped off the value before it gets passed to the callback, meaning the callback can no longer determine what type of value was received, which could lead to false positives/negatives.
    Example: https://3v4l.org/YH5Rp (and yes, this means that even though numeric literals with underscores should be supported, we cannot do so reliably).
* A compound key, like `[ $prefix . 'posts_per_page' ]`, will be flagged as if the key were `'posts_per_page'` as the key does not get captured in its entirety.
* Along the same lines, the fact that the callback method gets a string value for `$key` and `$value` is wrong as it doesn't allow the sniffs to walk the tokens for a proper analysis of the key/value.

To fix all of that, would IMO require changing the method signature for the `callback()` method.
Adjusting the method signature is non-trivial as it would instantly cause fatal errors for all sniffs using the abstract due to the signature mismatch: https://3v4l.org/0tf0c

Alternatively, adding a second callback method option which would receive stack pointers could be considered.

In both cases, that would be quite a big breaking change and even though we are at 3.0.0, I have not seen any issues reported asking for a change along these lines, so I don't think making that breaking change is justified.

If anything, I think we may need to introduce a replacement for this abstract at some point (which passes the tokens to the callback) and deprecate this one. Then dev-users can migrate to the replacement at their own pace.

That is outside the scope of this PR however. This PR attempts to make _what's there_ better in the full knowledge that this is an abstract which shouldn't exist in its current form.


## Commit details

### AbstractArrayAssignmentRestrictions: add some extra tests

... to raise code coverage and cover some situations previously untested.

Tests have been added to the `WordPress.WP.PostsPerPage` sniff, which contains a `@covers` tag for the abstract.

### AbstractArrayAssignmentRestrictions: improve documentation

Most notably: the value for `'message'` as was appears to have led to sniff devs not using the key, which was never the intention.

### AbstractArrayAssignmentRestrictions: minor readability fix

### AbstractArrayAssignmentRestrictions: implement PHPCSUtils

### AbstractArrayAssignmentRestrictions: bug fix - improve comment tolerance [1]

Non-code style sniffs should ignore most whitespace and comment tokens.

The `AbstractArrayAssignmentRestrictions` did not do so correctly, which could lead to false negatives.

This commit fixes the handling of comments between the "key" and the assignment operator by the sniff.

Includes tests via the `WordPress.WP.PostsPerPage` sniff.

Related to #763

### AbstractArrayAssignmentRestrictions: bug fix - improve comment tolerance [2]

Non-code style sniffs should ignore most whitespace and comment tokens.

The `AbstractArrayAssignmentRestrictions` did not do so correctly, which could lead to false negatives.

This commit fixes the handling of comments between the assignment operator and the assigned value.

Includes tests via the `WordPress.WP.PostsPerPage` sniff.

Related to #763

### AbstractArrayAssignmentRestrictions: minor efficiency tweak [1]

Get rid of two unnecessary `in_array()` function calls.

### AbstractArrayAssignmentRestrictions: minor efficiency tweak [2]

The position of the `T_EQUAL` token has already been determined before, so let's use the predetermined value for efficiency.

Includes renaming the local variable to be slightly more descriptive.

### AbstractArrayAssignmentRestrictions: minor efficiency tweak [3]

No need to start looping the inner array if the `$key` is not one of the target keys in the current group.

### AbstractArrayAssignmentRestrictions: precision (bug) fix

Check if the array "key" token found is a text string token as well as checking that the content is non-numeric.

This is also an efficiency fix as code like `$query_args[] = 300;` would previously be analyzed with key `[`, which is clearly nonsense.

Along the same lines, a numeric string key would previously also be analyzed, due to the quotes around the number, while PHP auto-casts numeric string keys to integers (see: https://3v4l.org/uVFsO ), which means they are not the target of this sniff and therefore should be disregarded.
This also meant that the `$key` passed to the `callback()` method could previously potentially be an integer (as the same type casts happens when we store the numeric string key to the `$inst` array), while it is documented as `string` only.

Note: this didn't lead to false positives as nobody would set the "key" to search for to `[`, but it was still wrong.

Includes tests via the `WordPress.WP.PostsPerPage` sniff.

### AbstractArrayAssignmentRestrictions: bug fix - simplify the $inst(ances) array

As things were, the sniff would store the encountered "instances" in a multi-dimensional array looking like this:
```
array(
    (string) 'key' => array(
        [0] => array(
            [0] => (string) 'value',
            [1] => (int) line number,
        ),
        ...
    )
)
```

Now, the sniffs listens to four different tokens:
* `T_DOUBLE_ARROW`
* `T_CLOSE_SQUARE_BRACKET`
* `T_CONSTANT_ENCAPSED_STRING`
* `T_DOUBLE_QUOTED_STRING`

For the first two, there could only ever be one entry in the lowest level of the array as it looks at each array item individually due to the use of the `T_DOUBLE_ARROW` token for array declarations and the `T_CLOSE_SQUARE_BRACKET` token being used for assignments to an existing array.

For the last two, the found string is analyzed to see if it is a query string and parsed if it is. In that case, there could be multiple entries in the array.

However.... when PHP parses a query string, there will never be multiple entries for the same key: https://3v4l.org/n3Iv9

So, I cannot fanthom why having multiple entries for the same key would be useful for this sniff. Only the last found entry should be taken into account.
There were also no tests (anywhere) covering a query string containing a duplicate key.

So, taking the above into account, this commit simplifies the entries are stored in the `$inst` array to this:
```
array(
    (string) 'key' => array(
        [0] => (string) 'value',
        [1] => (int) line number,
    )
)
```

This array format change will now prevent incorrect messages about a "high" value which is subsequently overwritten by a "low" value anyway.

Includes tests via the `WordPress.WP.PostsPerPage` sniff.

### AbstractArrayAssignmentRestrictions: make the contents of $inst more comprehensible

Even though the array is only used locally, let's use keys for the entries to make the code more readable/comprehensible.

### AbstractArrayAssignmentRestrictions: report the error for array assignments on the key pointer

For array assignments, the error would previously be reported on a `]` or `=>` token, while those tokens in and of themselves are not where the problem lies.

As the sniff reports based on the key (with an optional value check in the `callback()` method), I think it is more appropriate and more correct for the sniff to report on the stack pointer to the token identified as the key.

To achieve this, a new array entry is added to the `$inst` array so the loop throwing the error has access to that information.

For query strings, the error will continue to be thrown on the text string token containing the query string.

The difference this commit makes can be seen when using the `code` report offered by PHPCS, like so `--report=code`.

Includes tests via the `WordPress.WP.PostsPerPage` sniff.

### AbstractArrayAssignmentRestrictions: allow for PHP 7.4+ null coalesce equals

While other assignment operators all lead to calculations, which means we cannot reliably determine the actual value, the null coalesce assignment operator provides a default value, which means we can analyze the value as if it were the value set.

Includes tests via the `WordPress.WP.PostsPerPage` sniff.

### AbstractArrayAssignmentRestrictions: add test with PHP 8.0 match

Includes tests via the `WordPress.WP.PostsPerPage` sniff.

### AbstractArrayAssignmentRestrictions: bug fix - improve value capturing

This commit improves the way the `AbstractArrayAssignmentRestrictionsSniff` captures the value of an array key assignment before it gets passed on to the callback for further examination.

As things were previously, the sniff would go wrong in two cases:
1. Without a trailing comma after an array item, the long/short array close bracket would be included in the value, while it shouldn't be.
    This was reported in issue #2211.
2. The sniff would not always capture a complete value when the value contained a function call, sub-array, closure etc; basically anything which can contain a comma or semi-colon, but where that comma/semi-colon is in an "inner" construct and not the "outer" construct which is being captured.
    This was reported in issue #2027

The fix included in this commit fixes the first issue completely and a partial fix for the second issue.

Includes tests via the `WordPress.WP.PostsPerPage` sniff.

Fixes #2211

Note: a follow-up PR which builds onto this commit will address #2027.

---

### 🆕 AbstractArrayAssignmentRestrictionsSniff: don't strip quotes off value

As the value capturing is now more likely to (correctly) contain multiple tokens, stripping the quotes of a value is plain incorrect as wit would lead to a value like this:
```php
$var['key'] = 'my' . 10 . 'something';
```
... to be passed on as `my' . 10 . 'something` - i.e. without the surrounding quotes, but with the non-matching quotes inside the value.

I'm proposing to remove the call to `TextStrings::stripQuotes()` to allow the `callback()` to receive a more accurate and actionable value.

This will be a potentially breaking change for _some_ extenders, so will need a clear entry in the dev upgrade guide. (It doesn't impact the WPCS native sniffs extending the abstract at this time)