### PR TITLE
Improve consistency in method names across Helpers

### DIFF
--- a/WordPress/Helpers/ArrayWalkingFunctionsHelper.php
+++ b/WordPress/Helpers/ArrayWalkingFunctionsHelper.php
@@ -34,6 +34,7 @@ final class ArrayWalkingFunctionsHelper {
 	 * @since 2.1.0
 	 * @since 3.0.0 - Moved from the Sniff class to this class.
 	 *              - Visibility changed from protected to private and property made static.
+	 *                Use the `get_functions()` method for access.
 	 *              - The value has changed from an integer to an array containing the integer
 	 *                parameter position + its name.
 	 *
@@ -57,7 +58,7 @@ final class ArrayWalkingFunctionsHelper {
 	 *
 	 * @return array<string, bool>
 	 */
-	public static function get_array_walking_functions() {
+	public static function get_functions() {
 		return \array_fill_keys( \array_keys( self::$arrayWalkingFunctions ), true );
 	}
 

--- a/WordPress/Helpers/UnslashingFunctionsHelper.php
+++ b/WordPress/Helpers/UnslashingFunctionsHelper.php
@@ -24,6 +24,7 @@ final class UnslashingFunctionsHelper {
 	 * @since 2.1.0
 	 * @since 3.0.0 - Moved from the Sniff class to this class.
 	 *              - Visibility changed from protected to private and property made static.
+	 *                Use the `get_functions()` method for access.
 	 *
 	 * @var array<string, bool>
 	 */
@@ -40,7 +41,7 @@ final class UnslashingFunctionsHelper {
 	 *
 	 * @return array<string, bool>
 	 */
-	public static function get_unslashing_functions() {
+	public static function get_functions() {
 		return self::$unslashingFunctions;
 	}
 

--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -182,7 +182,7 @@ abstract class Sniff implements PHPCS_Sniff {
 
 		$valid_functions  = $this->get_sanitizing_functions();
 		$valid_functions += $this->get_sanitizing_and_unslashing_functions();
-		$valid_functions += UnslashingFunctionsHelper::get_unslashing_functions();
+		$valid_functions += UnslashingFunctionsHelper::get_functions();
 		$valid_functions += ArrayWalkingFunctionsHelper::get_functions();
 
 		$functionPtr = ContextHelper::is_in_function_call( $this->phpcsFile, $stackPtr, $valid_functions );
@@ -204,7 +204,7 @@ abstract class Sniff implements PHPCS_Sniff {
 			$is_unslashed = true;
 
 			// Remove the unslashing functions.
-			$valid_functions = array_diff_key( $valid_functions, UnslashingFunctionsHelper::get_unslashing_functions() );
+			$valid_functions = array_diff_key( $valid_functions, UnslashingFunctionsHelper::get_functions() );
 
 			// Check is any of the remaining (sanitizing) functions is used.
 			$higherFunctionPtr = ContextHelper::is_in_function_call( $this->phpcsFile, $functionPtr, $valid_functions );

--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -183,7 +183,7 @@ abstract class Sniff implements PHPCS_Sniff {
 		$valid_functions  = $this->get_sanitizing_functions();
 		$valid_functions += $this->get_sanitizing_and_unslashing_functions();
 		$valid_functions += UnslashingFunctionsHelper::get_unslashing_functions();
-		$valid_functions += ArrayWalkingFunctionsHelper::get_array_walking_functions();
+		$valid_functions += ArrayWalkingFunctionsHelper::get_functions();
 
 		$functionPtr = ContextHelper::is_in_function_call( $this->phpcsFile, $stackPtr, $valid_functions );
 

--- a/WordPress/Sniffs/Security/NonceVerificationSniff.php
+++ b/WordPress/Sniffs/Security/NonceVerificationSniff.php
@@ -185,7 +185,7 @@ class NonceVerificationSniff extends Sniff {
 			|| ContextHelper::is_in_type_test( $this->phpcsFile, $stackPtr )
 			|| VariableHelper::is_comparison( $this->phpcsFile, $stackPtr )
 			|| ContextHelper::is_in_array_comparison( $this->phpcsFile, $stackPtr )
-			|| ContextHelper::is_in_function_call( $this->phpcsFile, $stackPtr, UnslashingFunctionsHelper::get_unslashing_functions() ) !== false
+			|| ContextHelper::is_in_function_call( $this->phpcsFile, $stackPtr, UnslashingFunctionsHelper::get_functions() ) !== false
 			|| $this->is_only_sanitized( $stackPtr )
 		) {
 			$allow_nonce_after = true;


### PR DESCRIPTION
### ArrayWalkingFunctionsHelper: improve consistency in method names across Helpers

For the stand-alone Helper classes which only contain one "functions list" array property, name the retrieval method `get_functions()`.

After all, these are not traits, which run a risk of a class `use`-ing the trait overloading the method and as the method is `static`, the class name used in the function call already clearly indicates _which_ function list is being retrieved.

### UnslashingFunctionsHelper: improve consistency in method names across Helpers

For the stand-alone Helper classes which only contain one "functions list" array property, name the retrieval method `get_functions()`.

After all, these are not traits, which run a risk of a class `use`-ing the trait overloading the method and as the method is `static`, the class name used in the function call already clearly indicates _which_ function list is being retrieved.