### PR TITLE
Helpers: add some more defensive coding

### DIFF
--- a/WordPress/Helpers/ContextHelper.php
+++ b/WordPress/Helpers/ContextHelper.php
@@ -129,6 +129,10 @@ final class ContextHelper {
 	 */
 	public static function has_object_operator_before( File $phpcsFile, $stackPtr ) {
 		$tokens = $phpcsFile->getTokens();
+		if ( isset( $tokens[ $stackPtr ] ) === false ) {
+			return false;
+		}
+
 		$before = $phpcsFile->findPrevious( Tokens::$emptyTokens, ( $stackPtr - 1 ), null, true );
 
 		return isset( Collections::objectOperators()[ $tokens[ $before ]['code'] ] );
@@ -151,7 +155,11 @@ final class ContextHelper {
 	 */
 	public static function is_token_namespaced( File $phpcsFile, $stackPtr ) {
 		$tokens = $phpcsFile->getTokens();
-		$prev   = $phpcsFile->findPrevious( Tokens::$emptyTokens, ( $stackPtr - 1 ), null, true );
+		if ( isset( $tokens[ $stackPtr ] ) === false ) {
+			return false;
+		}
+
+		$prev = $phpcsFile->findPrevious( Tokens::$emptyTokens, ( $stackPtr - 1 ), null, true );
 
 		if ( \T_NS_SEPARATOR !== $tokens[ $prev ]['code'] ) {
 			return false;
@@ -320,7 +328,11 @@ final class ContextHelper {
 	 */
 	public static function is_safe_casted( File $phpcsFile, $stackPtr ) {
 		$tokens = $phpcsFile->getTokens();
-		$prev   = $phpcsFile->findPrevious( Tokens::$emptyTokens, ( $stackPtr - 1 ), null, true );
+		if ( isset( $tokens[ $stackPtr ] ) === false ) {
+			return false;
+		}
+
+		$prev = $phpcsFile->findPrevious( Tokens::$emptyTokens, ( $stackPtr - 1 ), null, true );
 
 		return isset( self::$safe_casts[ $tokens[ $prev ]['code'] ] );
 	}

--- a/WordPress/Helpers/DeprecationHelper.php
+++ b/WordPress/Helpers/DeprecationHelper.php
@@ -43,7 +43,11 @@ final class DeprecationHelper {
 	 * @return bool
 	 */
 	public static function is_function_deprecated( File $phpcsFile, $stackPtr ) {
-		$tokens                  = $phpcsFile->getTokens();
+		$tokens = $phpcsFile->getTokens();
+		if ( isset( $tokens[ $stackPtr ] ) === false ) {
+			return false;
+		}
+
 		$ignore                  = Tokens::$methodPrefixes;
 		$ignore[ \T_WHITESPACE ] = \T_WHITESPACE;
 

--- a/WordPress/Helpers/ListHelper.php
+++ b/WordPress/Helpers/ListHelper.php
@@ -53,7 +53,7 @@ final class ListHelper {
 		$tokens = $phpcsFile->getTokens();
 
 		// Is this one of the tokens this function handles ?
-		if ( isset( Collections::listOpenTokensBC()[ $tokens[ $stackPtr ]['code'] ] ) === false ) {
+		if ( isset( $tokens[ $stackPtr ], Collections::listOpenTokensBC()[ $tokens[ $stackPtr ]['code'] ] ) === false ) {
 			return array();
 		}
 

--- a/WordPress/Helpers/ValidationHelper.php
+++ b/WordPress/Helpers/ValidationHelper.php
@@ -99,6 +99,9 @@ final class ValidationHelper {
 	 */
 	public static function is_validated( File $phpcsFile, $stackPtr, $array_keys = array(), $in_condition_only = false ) {
 		$tokens = $phpcsFile->getTokens();
+		if ( isset( $tokens[ $stackPtr ] ) === false ) {
+			return false;
+		}
 
 		if ( $in_condition_only ) {
 			/*

--- a/WordPress/Helpers/VariableHelper.php
+++ b/WordPress/Helpers/VariableHelper.php
@@ -53,7 +53,9 @@ final class VariableHelper {
 		$tokens = $phpcsFile->getTokens();
 		$keys   = array();
 
-		if ( \T_VARIABLE !== $tokens[ $stackPtr ]['code'] ) {
+		if ( isset( $tokens[ $stackPtr ] ) === false
+			|| \T_VARIABLE !== $tokens[ $stackPtr ]['code']
+		) {
 			return $keys;
 		}
 
@@ -140,7 +142,11 @@ final class VariableHelper {
 	 * @return bool Whether this is a comparison.
 	 */
 	public static function is_comparison( File $phpcsFile, $stackPtr, $include_coalesce = true ) {
-		$tokens           = $phpcsFile->getTokens();
+		$tokens = $phpcsFile->getTokens();
+		if ( isset( $tokens[ $stackPtr ] ) === false ) {
+			return false;
+		}
+
 		$comparisonTokens = Tokens::$comparisonTokens;
 		if ( false === $include_coalesce ) {
 			unset( $comparisonTokens[ \T_COALESCE ] );
@@ -203,6 +209,9 @@ final class VariableHelper {
 	 */
 	public static function is_assignment( File $phpcsFile, $stackPtr ) {
 		$tokens = $phpcsFile->getTokens();
+		if ( isset( $tokens[ $stackPtr ] ) === false ) {
+			return false;
+		}
 
 		static $valid = array(
 			\T_VARIABLE             => true,

--- a/WordPress/Helpers/WPDBTrait.php
+++ b/WordPress/Helpers/WPDBTrait.php
@@ -50,8 +50,10 @@ trait WPDBTrait {
 	 * @return bool Whether this is a $wpdb method call.
 	 */
 	protected function is_wpdb_method_call( File $phpcsFile, $stackPtr, $target_methods ) {
-
 		$tokens = $phpcsFile->getTokens();
+		if ( isset( $tokens[ $stackPtr ] ) === false ) {
+			return false;
+		}
 
 		// Check for wpdb.
 		if ( ( \T_VARIABLE === $tokens[ $stackPtr ]['code'] && '$wpdb' !== $tokens[ $stackPtr ]['content'] )


### PR DESCRIPTION
The `Helper` classes containing stand-alone `static` methods can be used by both WPCS itself as well as external standards extending WPCS.

As these methods have been made stand-alone, they should probably contain a little more defensive coding in select places.

Note: this code will not be "covered" by tests at this moment as the WPCS code as-is will never hit these conditions.

At a later point in time, we may want to add dedicated tests for the Helper methods which aren't moving to PHPCSUtils. When we do, we can make sure this defensive code gets covered too.