### PR TITLE
ContextHelper::$safe_casts: make `private`

### DIFF
--- a/WordPress/Helpers/ContextHelper.php
+++ b/WordPress/Helpers/ContextHelper.php
@@ -34,11 +34,11 @@ final class ContextHelper {
 	 *
 	 * @since 1.1.0
 	 * @since 3.0.0 - Moved from the Sniff class to this class.
-	 *              - The property visibility was changed from `protected` to `public static`.
+	 *              - The property visibility was changed from `protected` to `private static`.
 	 *
 	 * @var array
 	 */
-	public static $safe_casts = array(
+	private static $safe_casts = array(
 		\T_INT_CAST    => true,
 		\T_DOUBLE_CAST => true,
 		\T_BOOL_CAST   => true,
@@ -304,6 +304,17 @@ final class ContextHelper {
 		}
 
 		return false;
+	}
+
+	/**
+	 * Retrieve a list of the tokens which are regarded as "safe casts".
+	 *
+	 * @since 3.0.0
+	 *
+	 * @return array<string, bool>
+	 */
+	public static function get_safe_cast_tokens() {
+		return self::$safe_casts;
 	}
 
 	/**

--- a/WordPress/Sniffs/Security/EscapeOutputSniff.php
+++ b/WordPress/Sniffs/Security/EscapeOutputSniff.php
@@ -340,7 +340,7 @@ class EscapeOutputSniff extends Sniff {
 			$watch = false;
 
 			// Allow int/double/bool casted variables.
-			if ( isset( ContextHelper::$safe_casts[ $this->tokens[ $i ]['code'] ] ) ) {
+			if ( isset( ContextHelper::get_safe_cast_tokens()[ $this->tokens[ $i ]['code'] ] ) ) {
 				$in_cast = true;
 				continue;
 			}

--- a/WordPress/Tests/Security/EscapeOutputUnitTest.php
+++ b/WordPress/Tests/Security/EscapeOutputUnitTest.php
@@ -21,6 +21,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * @since   1.0.0      This sniff has been moved from the `XSS` category to the `Security` category.
  *
  * @covers \WordPressCS\WordPress\Helpers\ArrayWalkingFunctionsHelper
+ * @covers \WordPressCS\WordPress\Helpers\ContextHelper::get_safe_cast_tokens
  * @covers \WordPressCS\WordPress\Helpers\ConstantsHelper::is_use_of_global_constant
  * @covers \WordPressCS\WordPress\Helpers\EscapingFunctionsTrait
  * @covers \WordPressCS\WordPress\Helpers\PrintingFunctionsTrait


### PR DESCRIPTION
Follow up on #2232.

This property was previously not made `private` as it is used by the `EscapeOutput` sniff. For consistency with other classes and to better protect the value of the property, I'm proposing to make it `private` now anyway and add a `get_safe_cast_tokens()` method to retrieve the list.

This prevents potential problems if external standards would attempt to adjust the list (which they could while the property was `public static`, even though the class is `final`).