### PR TITLE
Helpers: make sure function names are checked case-insensitively

### DIFF
--- a/WordPress/Helpers/ArrayWalkingFunctionsHelper.php
+++ b/WordPress/Helpers/ArrayWalkingFunctionsHelper.php
@@ -71,7 +71,7 @@ final class ArrayWalkingFunctionsHelper {
 	 * @return bool
 	 */
 	public static function is_array_walking_function( $functionName ) {
-		return isset( self::$arrayWalkingFunctions[ $functionName ] );
+		return isset( self::$arrayWalkingFunctions[ strtolower( $functionName ) ] );
 	}
 
 	/**
@@ -93,7 +93,7 @@ final class ArrayWalkingFunctionsHelper {
 			return false;
 		}
 
-		$functionName = $tokens[ $stackPtr ]['content'];
+		$functionName = strtolower( $tokens[ $stackPtr ]['content'] );
 		if ( isset( self::$arrayWalkingFunctions[ $functionName ] ) === false ) {
 			return false;
 		}

--- a/WordPress/Helpers/EscapingFunctionsTrait.php
+++ b/WordPress/Helpers/EscapingFunctionsTrait.php
@@ -223,7 +223,7 @@ trait EscapingFunctionsTrait {
 			$this->addedCustomEscapingFunctions['escape'] = $this->customEscapingFunctions;
 		}
 
-		return isset( $this->allEscapingFunctions[ $functionName ] );
+		return isset( $this->allEscapingFunctions[ strtolower( $functionName ) ] );
 	}
 
 	/**
@@ -247,6 +247,6 @@ trait EscapingFunctionsTrait {
 			$this->addedCustomEscapingFunctions['autoescape'] = $this->customAutoEscapedFunctions;
 		}
 
-		return isset( $this->allAutoEscapedFunctions[ $functionName ] );
+		return isset( $this->allAutoEscapedFunctions[ strtolower( $functionName ) ] );
 	}
 }

--- a/WordPress/Helpers/FormattingFunctionsHelper.php
+++ b/WordPress/Helpers/FormattingFunctionsHelper.php
@@ -56,6 +56,6 @@ final class FormattingFunctionsHelper {
 	 * @return bool
 	 */
 	public static function is_formatting_function( $functionName ) {
-		return isset( self::$formattingFunctions[ $functionName ] );
+		return isset( self::$formattingFunctions[ strtolower( $functionName ) ] );
 	}
 }

--- a/WordPress/Helpers/PrintingFunctionsTrait.php
+++ b/WordPress/Helpers/PrintingFunctionsTrait.php
@@ -107,6 +107,6 @@ trait PrintingFunctionsTrait {
 			$this->addedCustomPrintingFunctions = $this->customPrintingFunctions;
 		}
 
-		return isset( $this->allPrintingFunctions[ $functionName ] );
+		return isset( $this->allPrintingFunctions[ strtolower( $functionName ) ] );
 	}
 }

--- a/WordPress/Helpers/SanitizingFunctionsTrait.php
+++ b/WordPress/Helpers/SanitizingFunctionsTrait.php
@@ -220,7 +220,7 @@ trait SanitizingFunctionsTrait {
 	 * @return bool
 	 */
 	public function is_sanitizing_function( $functionName ) {
-		return isset( $this->get_sanitizing_functions()[ $functionName ] );
+		return isset( $this->get_sanitizing_functions()[ strtolower( $functionName ) ] );
 	}
 
 	/**
@@ -233,6 +233,6 @@ trait SanitizingFunctionsTrait {
 	 * @return bool
 	 */
 	public function is_sanitizing_and_unslashing_function( $functionName ) {
-		return isset( $this->get_sanitizing_and_unslashing_functions()[ $functionName ] );
+		return isset( $this->get_sanitizing_and_unslashing_functions()[ strtolower( $functionName ) ] );
 	}
 }

--- a/WordPress/Helpers/UnslashingFunctionsHelper.php
+++ b/WordPress/Helpers/UnslashingFunctionsHelper.php
@@ -54,6 +54,6 @@ final class UnslashingFunctionsHelper {
 	 * @return bool
 	 */
 	public static function is_unslashing_function( $functionName ) {
-		return isset( self::$unslashingFunctions[ $functionName ] );
+		return isset( self::$unslashingFunctions[ strtolower( $functionName ) ] );
 	}
 }

--- a/WordPress/Tests/DB/PreparedSQLUnitTest.1.inc
+++ b/WordPress/Tests/DB/PreparedSQLUnitTest.1.inc
@@ -79,7 +79,7 @@ $all_post_meta = $wpdb->get_results( $wpdb->prepare( sprintf( <<<'ND'
 		AND `post_id` IN (%s)
 ND
 	, $wpdb->postmeta,
-	implode( ',', array_fill( 0, count( $post_ids ), '%d' ) )
+	IMPLODE( ',', array_fill( 0, count( $post_ids ), '%d' ) )
 ), $post_ids ) ); // OK.
 
 wpdb::prepare( "SELECT * FROM $wpdb?->posts WHERE post_title LIKE '" . foo() . "';" ); // Bad.

--- a/WordPress/Tests/Security/EscapeOutputUnitTest.inc
+++ b/WordPress/Tests/Security/EscapeOutputUnitTest.inc
@@ -15,7 +15,7 @@ while ( have_posts() ) {
 ?>
 
 <h2><?php echo $title; // Bad. ?></h2>
-<h2><?php echo esc_html( $title ); // OK. ?></h2>
+<h2><?php echo esc_HTML( $title ); // OK. ?></h2>
 <h2><?php echo apply_filters( 'the_title', $title ); // Bad, no escaping function. ?></h2>
 
 <?php
@@ -138,7 +138,7 @@ _doing_it_wrong( __METHOD__, "Invalid value for the 'bob' argument " . esc_html(
 trigger_error( "There was an error: {$message}", E_USER_NOTICE ); // Bad.
 trigger_error( "There was an error: " . esc_html( $message ), E_USER_NOTICE ); // Ok.
 
-echo '<p>' . sprintf( esc_html__( 'Some text -> %sLink text%s', 'textdomain' ), '<a href="' . esc_url( add_query_arg( array( 'page' => 'my_page' ), admin_url( 'admin.php' ) ) ) . '">', '</a>' ). '</p>'; // Ok.
+echo '<p>' . sprintf( esc_html__( 'Some text -> %sLink text%s', 'textdomain' ), '<a href="' . Esc_Url( add_query_arg( array( 'page' => 'my_page' ), admin_url( 'admin.php' ) ) ) . '">', '</a>' ). '</p>'; // Ok.
 
 echo '<br/><strong>' . sprintf( esc_html__( 'Found %d results', 'textdomain' ), (int) $result_count ) . '</strong><br/><br/>'; // Ok.
 

--- a/WordPress/Tests/Security/EscapeOutputUnitTest.inc
+++ b/WordPress/Tests/Security/EscapeOutputUnitTest.inc
@@ -303,7 +303,7 @@ _deprecated_file(); // Ignore.
 
 // Issue #1246.
 echo antispambot( 'john.doe@mysite.com' ); // OK.
-echo antispambot( esc_html( $email ) ); // OK.
+echo antiSpambot( esc_html( $email ) ); // OK.
 echo antispambot( $email ); // Bad.
 
 /*

--- a/WordPress/Tests/Security/EscapeOutputUnitTest.inc
+++ b/WordPress/Tests/Security/EscapeOutputUnitTest.inc
@@ -171,7 +171,7 @@ echo implode( '<br>', urlencode_deep( $items ) ); // Ok.
 echo implode( '<br>', array_map( 'esc_html', $items ) ); // Ok.
 echo implode( '<br>', array_map( 'foo', $items ) ); // Bad.
 echo join( '<br>', $items ); // Bad.
-echo join( '<br>', array_map( 'esc_html', $items ) ); // Ok.
+echo join( '<br>', Array_Map( 'esc_html', $items ) ); // Ok.
 
 echo '<option name="' . esc_attr( $name ) . '"' .
      ( $name === $selected ? ' selected' : '' ) .

--- a/WordPress/Tests/Security/EscapeOutputUnitTest.inc
+++ b/WordPress/Tests/Security/EscapeOutputUnitTest.inc
@@ -128,7 +128,7 @@ echo $html_fragment; // WPCS: XSS whitelist.
 ?><?php echo $html_fragment; // XSS pass. ?><?php
 
 _deprecated_function( __FUNCTION__, '1.3.0', 'another_func' ); // Ok.
-_deprecated_function( __FUNCTION__, '1.3.0', $another_func ); // Bad.
+_Deprecated_Function( __FUNCTION__, '1.3.0', $another_func ); // Bad.
 _deprecated_function( __FUNCTION__, '1.3.0', esc_html( $another_func ) ); // Ok.
 _deprecated_file( __FILE__, '1.3.0' ); // Ok.
 _deprecated_argument( __METHOD__, '1.3.0', 'The $arg is deprecated.' ); // Ok.
@@ -261,7 +261,7 @@ echo esc_html_x( $some_nasty_var, 'context' ); // Ok.
 echo PHP_VERSION_ID, PHP_VERSION, PHP_EOL, PHP_EXTRA_VERSION; // OK.
 
 trigger_error( 'DEBUG INFO - ' . __METHOD__ . '::internal_domains: domain = ' . $domain ); // Bad.
-trigger_error( $domain ); // Bad.
+Trigger_ERROR( $domain ); // Bad.
 
 vprintf( 'Hello %s', [ $foo ] ); // Bad.
 vprintf( 'Hello %s', [ esc_html( $foo ) ] ); // Ok.

--- a/WordPress/Tests/Security/ValidatedSanitizedInputUnitTest.1.inc
+++ b/WordPress/Tests/Security/ValidatedSanitizedInputUnitTest.1.inc
@@ -103,7 +103,7 @@ $current_tax_slug = isset( $_GET['a'] ) ? sanitize_text_field( wp_unslash( $_GET
 
 echo sanitize_text_field( $_POST['foo545'] ); // Error for no validation, unslashing.
 echo array_map( 'sanitize_text_field', $_GET['test'] ); // Bad, no unslashing.
-echo array_map( 'sanitize_key', $_GET['test'] ); // Ok.
+echo Array_Map( 'sanitize_key', $_GET['test'] ); // Ok.
 
 foo( absint( $_GET['foo'] ) ); // Ok.
 $ids = array_map( 'absint', $_GET['test'] ); // Ok.

--- a/WordPress/Tests/Security/ValidatedSanitizedInputUnitTest.1.inc
+++ b/WordPress/Tests/Security/ValidatedSanitizedInputUnitTest.1.inc
@@ -113,7 +113,7 @@ if ( is_array( $_GET['test'] ) ) {} // Ok.
 output( "some string \$_POST[some_var]" ); // Ok.
 output( "some string \\$_POST[some_var] $_GET[evil]" ); // Bad x2.
 
-echo esc_html( wp_strip_all_tags( wp_unslash( $_GET['a'] ) ) ); // Ok.
+echo esc_html( wp_strip_all_tags( WP_Unslash( $_GET['a'] ) ) ); // Ok.
 
 // Test validation check vs anonymous functions.
 isset( $_POST['abc'] ); // Validation in global scope, not function scope.

--- a/WordPress/Tests/Security/ValidatedSanitizedInputUnitTest.1.inc
+++ b/WordPress/Tests/Security/ValidatedSanitizedInputUnitTest.1.inc
@@ -94,7 +94,7 @@ switch ( do_something( wp_unslash( $_POST['foo'] ) ) ) {} // Bad.
 
 // Sanitization is required even when the value is being escaped.
 echo esc_html( wp_unslash( $_POST['foo'] ) ); // Bad.
-echo esc_html( sanitize_text_field( wp_unslash( $_POST['foo'] ) ) ); // Ok.
+echo esc_html( Sanitize_Text_Field( wp_unslash( $_POST['foo'] ) ) ); // Ok.
 
 $current_tax_slug = isset( $_GET['a'] ) ? sanitize_key( $_GET['a'] ) : false; // Ok.
 $current_tax_slug = isset( $_GET['a'] ) ? $_GET['a'] : false; // Bad x 2
@@ -105,7 +105,7 @@ echo sanitize_text_field( $_POST['foo545'] ); // Error for no validation, unslas
 echo array_map( 'sanitize_text_field', $_GET['test'] ); // Bad, no unslashing.
 echo Array_Map( 'sanitize_key', $_GET['test'] ); // Ok.
 
-foo( absint( $_GET['foo'] ) ); // Ok.
+foo( AbsINT( $_GET['foo'] ) ); // Ok.
 $ids = array_map( 'absint', $_GET['test'] ); // Ok.
 
 if ( is_array( $_GET['test'] ) ) {} // Ok.


### PR DESCRIPTION
### ArrayWalkingFunctionsHelper: make sure function names are checked case-insensitively

These functions should be self-contained, so should not presume that the sniff has already lowercased the function name before passing it.

This fixes a bug as, in this case, the sniffs didn't actually lowercase the name before passing it to the Helper class methods, so the sniffs would throw false positives for non-lowercase function calls.

Tested by adjusting some pre-existing tests for the `EscapeOutput` sniff and the `ValidatedSanitizedInput` sniff.

### FormattingFunctionsHelper: make sure function names are checked case-insensitively

These functions should be self-contained, so should not presume that the sniff has already lowercased the function name before passing it.

This fixes a bug as, in this case, the sniffs didn't actually lowercase the name before passing it to the Helper class methods, so the sniffs would throw false positives for non-lowercase function calls.

Tested by adjusting some pre-existing tests for the `PreparedSQL` sniff and the `EscapeOutput` sniff.

### UnslashingFunctionsHelper: make sure function names are checked case-insensitively

These functions should be self-contained, so should not presume that the sniff has already lowercased the function name before passing it.

This fixes a bug as, in this case, the sniff didn't actually lowercase the name before passing it to the Helper class methods, so the sniff would throw false positives for non-lowercase function calls.

Tested by adjusting some pre-existing tests for the `ValidatedSanitizedInput` sniff.

### EscapingFunctionsTrait: make sure function names are checked case-insensitively

These functions should be self-contained, so should not presume that the sniff has already lowercased the function name before passing it.

This fixes a bug as, in this case, the sniff didn't actually lowercase the name before passing it to the trait methods, so the sniff would throw false positives for non-lowercase function calls.

Tested by adjusting some pre-existing tests for the `EscapeOutput` sniff.

### PrintingFunctionsTrait: make sure function names are checked case-insensitively

These functions should be self-contained, so should not presume that the sniff has already lowercased the function name before passing it.

This fixes a bug as, in this case, the sniff didn't actually lowercase the name before passing it to the trait method, so the sniff would throw false negatives for non-lowercase function calls.

Tested by adjusting some pre-existing tests for the `EscapeOutput` sniff.

### SanitizingFunctionsTrait: make sure function names are checked case-insensitively

These functions should be self-contained, so should not presume that the sniff has already lowercased the function name before passing it.

This fixes a bug as, in this case, the sniffs didn't actually lowercase the name before passing it to the Helper class methods, so the sniffs would throw false positives for non-lowercase function calls.

Tested by adjusting some pre-existing tests for the `ValidatedSanitizedInput` sniff.