### PR TITLE
NamingConventions/PrefixAllGlobals: make the "is PHP native polyfill ?" check case-insensitive

### DIFF
--- a/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
+++ b/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
@@ -218,6 +218,7 @@ final class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 		// Get a list of all PHP native functions.
 		$all_functions            = get_defined_functions();
 		$this->built_in_functions = array_flip( $all_functions['internal'] );
+		$this->built_in_functions = array_change_key_case( $this->built_in_functions, \CASE_LOWER );
 
 		// Set the sniff targets.
 		$targets  = array(
@@ -413,7 +414,8 @@ final class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 					}
 
 					$item_name = FunctionDeclarations::getName( $this->phpcsFile, $stackPtr );
-					if ( isset( $this->built_in_functions[ $item_name ] ) ) {
+					$item_lc   = strtolower( $item_name );
+					if ( isset( $this->built_in_functions[ $item_lc ] ) ) {
 						// Backfill for PHP native function.
 						return;
 					}

--- a/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.1.inc
+++ b/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.1.inc
@@ -644,4 +644,11 @@ function acronym_only_check_global_statement_in_current_scope() {
 	$something = 'value'; // OK, global statement is in different scope.
 }
 
+/*
+ * Safeguard that function name comparisons for PHP native function polyfills are done case-insensitively.
+ */
+if ( function_exists( 'stripos' ) ) {
+	function striPos() {}
+}
+
 // phpcs:set WordPress.NamingConventions.PrefixAllGlobals prefixes[]


### PR DESCRIPTION
The `PrefixAllGlobals` sniff has a tolerance for non-prefixed polyfills for PHP native functions. This check, however, did a case-sensitive comparison, while PHP natively treats function names case-insensitively.

Fixed now.

Includes tests.