### PR TITLE
WP/DiscouragedConstants: use the `ConstantsHelper` class

### DIFF
--- a/WordPress/Helpers/ConstantsHelper.php
+++ b/WordPress/Helpers/ConstantsHelper.php
@@ -77,7 +77,6 @@ final class ConstantsHelper {
 			\T_INSTANCEOF      => true,
 			\T_INSTEADOF       => true,
 			\T_GOTO            => true,
-			\T_AS              => true,
 		);
 		$tokens_to_ignore += Tokens::$ooScopeTokens;
 		$tokens_to_ignore += Collections::objectOperators();

--- a/WordPress/Tests/WP/DiscouragedConstantsUnitTest.inc
+++ b/WordPress/Tests/WP/DiscouragedConstantsUnitTest.inc
@@ -100,3 +100,5 @@ enum ContainsConst {
 	const STYLESHEETPATH = 'something';
 	private function STYLESHEETPATH() {}
 }
+
+echo HEADER_TEXTCOLOR::$var; // OK.


### PR DESCRIPTION
Cricky... not sure why none of us ever noticed this, but we had a huge chunk of duplicate code here, which can be removed by letting the sniff use the utility method.

Includes one minor tweak to the utility method.

Includes additional test which would previously have failed.