### PR TITLE
Docs: clarify the `$matched_content` parameter

### DIFF
--- a/WordPress/AbstractClassRestrictionsSniff.php
+++ b/WordPress/AbstractClassRestrictionsSniff.php
@@ -192,6 +192,26 @@ abstract class AbstractClassRestrictionsSniff extends AbstractFunctionRestrictio
 	}
 
 	/**
+	 * Process a matched token.
+	 *
+	 * @since 0.11.0 Split out from the `process()` method.
+	 *
+	 * @param int    $stackPtr        The position of the current token in the stack.
+	 * @param string $group_name      The name of the group which was matched.
+	 * @param string $matched_content The token content (function name) which was matched
+	 *                                in it original case.
+	 *
+	 * @return int|void Integer stack pointer to skip forward or void to continue
+	 *                  normal file processing.
+	 *
+	 * @phpcs:disable Generic.CodeAnalysis.UselessOverridingMethod.Found
+	 */
+	public function process_matched_token( $stackPtr, $group_name, $matched_content ) {
+		parent::process_matched_token( $stackPtr, $group_name, $matched_content );
+	}
+	// phpcs:enable
+
+	/**
 	 * Prepare the class name for use in a regular expression.
 	 *
 	 * The getGroups() method allows for providing class names with a wildcard * to target

--- a/WordPress/AbstractFunctionParameterSniff.php
+++ b/WordPress/AbstractFunctionParameterSniff.php
@@ -62,7 +62,8 @@ abstract class AbstractFunctionParameterSniff extends AbstractFunctionRestrictio
 	 *
 	 * @param int    $stackPtr        The position of the current token in the stack.
 	 * @param string $group_name      The name of the group which was matched.
-	 * @param string $matched_content The token content (function name) which was matched.
+	 * @param string $matched_content The token content (function name) which was matched
+	 *                                in lowercase.
 	 *
 	 * @return int|void Integer stack pointer to skip forward or void to continue
 	 *                  normal file processing.
@@ -85,7 +86,8 @@ abstract class AbstractFunctionParameterSniff extends AbstractFunctionRestrictio
 	 *
 	 * @param int    $stackPtr        The position of the current token in the stack.
 	 * @param string $group_name      The name of the group which was matched.
-	 * @param string $matched_content The token content (function name) which was matched.
+	 * @param string $matched_content The token content (function name) which was matched
+	 *                                in lowercase.
 	 * @param array  $parameters      Array with information about the parameters.
 	 *
 	 * @return int|void Integer stack pointer to skip forward or void to continue
@@ -101,7 +103,8 @@ abstract class AbstractFunctionParameterSniff extends AbstractFunctionRestrictio
 	 *
 	 * @param int    $stackPtr        The position of the current token in the stack.
 	 * @param string $group_name      The name of the group which was matched.
-	 * @param string $matched_content The token content (function name) which was matched.
+	 * @param string $matched_content The token content (function name) which was matched
+	 *                                in lowercase.
 	 *
 	 * @return int|void Integer stack pointer to skip forward or void to continue
 	 *                  normal file processing.

--- a/WordPress/AbstractFunctionRestrictionsSniff.php
+++ b/WordPress/AbstractFunctionRestrictionsSniff.php
@@ -320,7 +320,8 @@ abstract class AbstractFunctionRestrictionsSniff extends Sniff {
 	 *
 	 * @param int    $stackPtr        The position of the current token in the stack.
 	 * @param string $group_name      The name of the group which was matched.
-	 * @param string $matched_content The token content (function name) which was matched.
+	 * @param string $matched_content The token content (function name) which was matched
+	 *                                in lowercase.
 	 *
 	 * @return int|void Integer stack pointer to skip forward or void to continue
 	 *                  normal file processing.

--- a/WordPress/Sniffs/CodeAnalysis/EscapedNotTranslatedSniff.php
+++ b/WordPress/Sniffs/CodeAnalysis/EscapedNotTranslatedSniff.php
@@ -57,7 +57,8 @@ final class EscapedNotTranslatedSniff extends AbstractFunctionParameterSniff {
 	 *
 	 * @param int    $stackPtr        The position of the current token in the stack.
 	 * @param string $group_name      The name of the group which was matched.
-	 * @param string $matched_content The token content (function name) which was matched.
+	 * @param string $matched_content The token content (function name) which was matched
+	 *                                in lowercase.
 	 * @param array  $parameters      Array with information about the parameters.
 	 *
 	 * @return void

--- a/WordPress/Sniffs/DateTime/CurrentTimeTimestampSniff.php
+++ b/WordPress/Sniffs/DateTime/CurrentTimeTimestampSniff.php
@@ -59,7 +59,8 @@ final class CurrentTimeTimestampSniff extends AbstractFunctionParameterSniff {
 	 *
 	 * @param int    $stackPtr        The position of the current token in the stack.
 	 * @param string $group_name      The name of the group which was matched.
-	 * @param string $matched_content The token content (function name) which was matched.
+	 * @param string $matched_content The token content (function name) which was matched
+	 *                                in lowercase.
 	 * @param array  $parameters      Array with information about the parameters.
 	 *
 	 * @return void

--- a/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
+++ b/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
@@ -806,7 +806,8 @@ final class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 	 *
 	 * @param int    $stackPtr        The position of the current token in the stack.
 	 * @param string $group_name      The name of the group which was matched.
-	 * @param string $matched_content The token content (function name) which was matched.
+	 * @param string $matched_content The token content (function name) which was matched
+	 *                                in lowercase.
 	 * @param array  $parameters      Array with information about the parameters.
 	 *
 	 * @return void

--- a/WordPress/Sniffs/NamingConventions/ValidHookNameSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidHookNameSniff.php
@@ -87,7 +87,8 @@ class ValidHookNameSniff extends AbstractFunctionParameterSniff {
 	 *
 	 * @param int    $stackPtr        The position of the current token in the stack.
 	 * @param string $group_name      The name of the group which was matched.
-	 * @param string $matched_content The token content (function name) which was matched.
+	 * @param string $matched_content The token content (function name) which was matched
+	 *                                in lowercase.
 	 * @param array  $parameters      Array with information about the parameters.
 	 *
 	 * @return void

--- a/WordPress/Sniffs/NamingConventions/ValidPostTypeSlugSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidPostTypeSlugSniff.php
@@ -117,7 +117,8 @@ final class ValidPostTypeSlugSniff extends AbstractFunctionParameterSniff {
 	 *
 	 * @param int    $stackPtr        The position of the current token in the stack.
 	 * @param array  $group_name      The name of the group which was matched.
-	 * @param string $matched_content The token content (function name) which was matched.
+	 * @param string $matched_content The token content (function name) which was matched
+	 *                                in lowercase.
 	 * @param array  $parameters      Array with information about the parameters.
 	 *
 	 * @return void

--- a/WordPress/Sniffs/PHP/IniSetSniff.php
+++ b/WordPress/Sniffs/PHP/IniSetSniff.php
@@ -137,7 +137,8 @@ final class IniSetSniff extends AbstractFunctionParameterSniff {
 	 *
 	 * @param int    $stackPtr        The position of the current token in the stack.
 	 * @param string $group_name      The name of the group which was matched.
-	 * @param string $matched_content The token content (function name) which was matched.
+	 * @param string $matched_content The token content (function name) which was matched
+	 *                                in lowercase.
 	 * @param array  $parameters      Array with information about the parameters.
 	 *
 	 * @return void

--- a/WordPress/Sniffs/PHP/PregQuoteDelimiterSniff.php
+++ b/WordPress/Sniffs/PHP/PregQuoteDelimiterSniff.php
@@ -50,7 +50,8 @@ final class PregQuoteDelimiterSniff extends AbstractFunctionParameterSniff {
 	 *
 	 * @param int    $stackPtr        The position of the current token in the stack.
 	 * @param string $group_name      The name of the group which was matched.
-	 * @param string $matched_content The token content (function name) which was matched.
+	 * @param string $matched_content The token content (function name) which was matched
+	 *                                in lowercase.
 	 * @param array  $parameters      Array with information about the parameters.
 	 *
 	 * @return void

--- a/WordPress/Sniffs/PHP/StrictInArraySniff.php
+++ b/WordPress/Sniffs/PHP/StrictInArraySniff.php
@@ -77,7 +77,8 @@ final class StrictInArraySniff extends AbstractFunctionParameterSniff {
 	 *
 	 * @param int    $stackPtr        The position of the current token in the stack.
 	 * @param string $group_name      The name of the group which was matched.
-	 * @param string $matched_content The token content (function name) which was matched.
+	 * @param string $matched_content The token content (function name) which was matched
+	 *                                in lowercase.
 	 * @param array  $parameters      Array with information about the parameters.
 	 *
 	 * @return void

--- a/WordPress/Sniffs/Security/PluginMenuSlugSniff.php
+++ b/WordPress/Sniffs/Security/PluginMenuSlugSniff.php
@@ -106,7 +106,8 @@ final class PluginMenuSlugSniff extends AbstractFunctionParameterSniff {
 	 *
 	 * @param int    $stackPtr        The position of the current token in the stack.
 	 * @param string $group_name      The name of the group which was matched.
-	 * @param string $matched_content The token content (function name) which was matched.
+	 * @param string $matched_content The token content (function name) which was matched
+	 *                                in lowercase.
 	 * @param array  $parameters      Array with information about the parameters.
 	 *
 	 * @return void

--- a/WordPress/Sniffs/Utils/I18nTextDomainFixerSniff.php
+++ b/WordPress/Sniffs/Utils/I18nTextDomainFixerSniff.php
@@ -467,7 +467,8 @@ final class I18nTextDomainFixerSniff extends AbstractFunctionParameterSniff {
 	 *
 	 * @param int    $stackPtr        The position of the current token in the stack.
 	 * @param string $group_name      The name of the group which was matched.
-	 * @param string $matched_content The token content (function name) which was matched.
+	 * @param string $matched_content The token content (function name) which was matched
+	 *                                in lowercase.
 	 * @param array  $parameters      Array with information about the parameters.
 	 *
 	 * @return void
@@ -594,7 +595,8 @@ final class I18nTextDomainFixerSniff extends AbstractFunctionParameterSniff {
 	 *
 	 * @param int    $stackPtr        The position of the current token in the stack.
 	 * @param string $group_name      The name of the group which was matched.
-	 * @param string $matched_content The token content (function name) which was matched.
+	 * @param string $matched_content The token content (function name) which was matched
+	 *                                in lowercase.
 	 *
 	 * @return void
 	 */

--- a/WordPress/Sniffs/WP/AlternativeFunctionsSniff.php
+++ b/WordPress/Sniffs/WP/AlternativeFunctionsSniff.php
@@ -214,7 +214,8 @@ final class AlternativeFunctionsSniff extends AbstractFunctionRestrictionsSniff 
 	 *
 	 * @param int    $stackPtr        The position of the current token in the stack.
 	 * @param string $group_name      The name of the group which was matched.
-	 * @param string $matched_content The token content (function name) which was matched.
+	 * @param string $matched_content The token content (function name) which was matched
+	 *                                in lowercase.
 	 *
 	 * @return int|void Integer stack pointer to skip forward or void to continue
 	 *                  normal file processing.

--- a/WordPress/Sniffs/WP/CapabilitiesSniff.php
+++ b/WordPress/Sniffs/WP/CapabilitiesSniff.php
@@ -352,14 +352,14 @@ final class CapabilitiesSniff extends AbstractFunctionParameterSniff {
 	 *
 	 * @param int    $stackPtr        The position of the current token in the stack.
 	 * @param array  $group_name      The name of the group which was matched.
-	 * @param string $matched_content The token content (function name) which was matched.
+	 * @param string $matched_content The token content (function name) which was matched
+	 *                                in lowercase.
 	 * @param array  $parameters      Array with information about the parameters.
 	 *
 	 * @return void
 	 */
 	public function process_parameters( $stackPtr, $group_name, $matched_content, $parameters ) {
-		$function_name_lc = strtolower( $matched_content );
-		$function_details = $this->target_functions[ $function_name_lc ];
+		$function_details = $this->target_functions[ $matched_content ];
 
 		$parameter = PassedParameters::getParameterFromStack(
 			$parameters,

--- a/WordPress/Sniffs/WP/ClassNameCaseSniff.php
+++ b/WordPress/Sniffs/WP/ClassNameCaseSniff.php
@@ -630,6 +630,7 @@ final class ClassNameCaseSniff extends AbstractClassRestrictionsSniff {
 	 * @param string $group_name      The name of the group which was matched. Will
 	 *                                always be 'wp_classes'.
 	 * @param string $matched_content The token content (class name) which was matched.
+	 *                                in its original case.
 	 *
 	 * @return void
 	 */

--- a/WordPress/Sniffs/WP/DeprecatedClassesSniff.php
+++ b/WordPress/Sniffs/WP/DeprecatedClassesSniff.php
@@ -91,7 +91,8 @@ final class DeprecatedClassesSniff extends AbstractClassRestrictionsSniff {
 	 * @param int    $stackPtr        The position of the current token in the stack.
 	 * @param string $group_name      The name of the group which was matched. Will
 	 *                                always be 'deprecated_classes'.
-	 * @param string $matched_content The token content (class name) which was matched.
+	 * @param string $matched_content The token content (class name) which was matched
+	 *                                in its original case.
 	 *
 	 * @return void
 	 */

--- a/WordPress/Sniffs/WP/DeprecatedFunctionsSniff.php
+++ b/WordPress/Sniffs/WP/DeprecatedFunctionsSniff.php
@@ -1520,7 +1520,8 @@ final class DeprecatedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 	 * @param int    $stackPtr        The position of the current token in the stack.
 	 * @param string $group_name      The name of the group which was matched. Will
 	 *                                always be 'deprecated_functions'.
-	 * @param string $matched_content The token content (function name) which was matched.
+	 * @param string $matched_content The token content (function name) which was matched
+	 *                                in lowercase.
 	 *
 	 * @return void
 	 */
@@ -1528,24 +1529,22 @@ final class DeprecatedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 
 		$this->set_minimum_wp_version();
 
-		$function_name = strtolower( $matched_content );
-
 		$message = '%s() has been deprecated since WordPress version %s.';
 		$data    = array(
-			$matched_content,
-			$this->deprecated_functions[ $function_name ]['version'],
+			$this->tokens[ $stackPtr ]['content'],
+			$this->deprecated_functions[ $matched_content ]['version'],
 		);
 
-		if ( ! empty( $this->deprecated_functions[ $function_name ]['alt'] ) ) {
+		if ( ! empty( $this->deprecated_functions[ $matched_content ]['alt'] ) ) {
 			$message .= ' Use %s instead.';
-			$data[]   = $this->deprecated_functions[ $function_name ]['alt'];
+			$data[]   = $this->deprecated_functions[ $matched_content ]['alt'];
 		}
 
 		MessageHelper::addMessage(
 			$this->phpcsFile,
 			$message,
 			$stackPtr,
-			( $this->wp_version_compare( $this->deprecated_functions[ $function_name ]['version'], $this->minimum_wp_version, '<' ) ),
+			( $this->wp_version_compare( $this->deprecated_functions[ $matched_content ]['version'], $this->minimum_wp_version, '<' ) ),
 			MessageHelper::stringToErrorcode( $matched_content . 'Found' ),
 			$data
 		);

--- a/WordPress/Sniffs/WP/DeprecatedParameterValuesSniff.php
+++ b/WordPress/Sniffs/WP/DeprecatedParameterValuesSniff.php
@@ -218,7 +218,8 @@ final class DeprecatedParameterValuesSniff extends AbstractFunctionParameterSnif
 	 *
 	 * @param int    $stackPtr        The position of the current token in the stack.
 	 * @param string $group_name      The name of the group which was matched.
-	 * @param string $matched_content The token content (function name) which was matched.
+	 * @param string $matched_content The token content (function name) which was matched
+	 *                                in lowercase.
 	 * @param array  $parameters      Array with information about the parameters.
 	 *
 	 * @return void
@@ -243,7 +244,8 @@ final class DeprecatedParameterValuesSniff extends AbstractFunctionParameterSnif
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param string $matched_content The token content (function name) which was matched.
+	 * @param string $matched_content The token content (function name) which was matched
+	 *                                in lowercase.
 	 * @param array  $parameter       Array with start and end token positon of the parameter.
 	 * @param array  $parameter_args  Array with alternative and WordPress deprecation version of the parameter.
 	 *

--- a/WordPress/Sniffs/WP/DeprecatedParametersSniff.php
+++ b/WordPress/Sniffs/WP/DeprecatedParametersSniff.php
@@ -316,7 +316,8 @@ final class DeprecatedParametersSniff extends AbstractFunctionParameterSniff {
 	 *
 	 * @param int    $stackPtr        The position of the current token in the stack.
 	 * @param string $group_name      The name of the group which was matched.
-	 * @param string $matched_content The token content (function name) which was matched.
+	 * @param string $matched_content The token content (function name) which was matched
+	 *                                in lowercase.
 	 * @param array  $parameters      Array with information about the parameters.
 	 *
 	 * @return void

--- a/WordPress/Sniffs/WP/DiscouragedConstantsSniff.php
+++ b/WordPress/Sniffs/WP/DiscouragedConstantsSniff.php
@@ -201,14 +201,14 @@ final class DiscouragedConstantsSniff extends AbstractFunctionParameterSniff {
 	 *
 	 * @param int    $stackPtr        The position of the current token in the stack.
 	 * @param string $group_name      The name of the group which was matched.
-	 * @param string $matched_content The token content (function name) which was matched.
+	 * @param string $matched_content The token content (function name) which was matched
+	 *                                in lowercase.
 	 * @param array  $parameters      Array with information about the parameters.
 	 *
 	 * @return void
 	 */
 	public function process_parameters( $stackPtr, $group_name, $matched_content, $parameters ) {
-		$function_name = strtolower( $matched_content );
-		$target_param  = $this->target_functions[ $function_name ];
+		$target_param = $this->target_functions[ $matched_content ];
 
 		// Was the target parameter passed ?
 		$found_param = PassedParameters::getParameterFromStack( $parameters, $target_param['position'], $target_param['name'] );

--- a/WordPress/Sniffs/WP/EnqueuedResourceParametersSniff.php
+++ b/WordPress/Sniffs/WP/EnqueuedResourceParametersSniff.php
@@ -114,7 +114,8 @@ final class EnqueuedResourceParametersSniff extends AbstractFunctionParameterSni
 	 *
 	 * @param int    $stackPtr        The position of the current token in the stack.
 	 * @param string $group_name      The name of the group which was matched.
-	 * @param string $matched_content The token content (function name) which was matched.
+	 * @param string $matched_content The token content (function name) which was matched
+	 *                                in lowercase.
 	 * @param array  $parameters      Array with information about the parameters.
 	 *
 	 * @return void

--- a/WordPress/Sniffs/WP/I18nSniff.php
+++ b/WordPress/Sniffs/WP/I18nSniff.php
@@ -262,7 +262,8 @@ final class I18nSniff extends AbstractFunctionParameterSniff {
 	 *
 	 * @param int    $stackPtr        The position of the current token in the stack.
 	 * @param string $group_name      The name of the group which was matched.
-	 * @param string $matched_content The token content (function name) which was matched.
+	 * @param string $matched_content The token content (function name) which was matched
+	 *                                in lowercase.
 	 *
 	 * @return void
 	 */
@@ -293,7 +294,8 @@ final class I18nSniff extends AbstractFunctionParameterSniff {
 	 *
 	 * @param int    $stackPtr        The position of the current token in the stack.
 	 * @param string $group_name      The name of the group which was matched.
-	 * @param string $matched_content The token content (function name) which was matched.
+	 * @param string $matched_content The token content (function name) which was matched
+	 *                                in lowercase.
 	 *
 	 * @return void
 	 */
@@ -318,7 +320,8 @@ final class I18nSniff extends AbstractFunctionParameterSniff {
 	 *
 	 * @param int    $stackPtr        The position of the current token in the stack.
 	 * @param string $group_name      The name of the group which was matched.
-	 * @param string $matched_content The token content (function name) which was matched.
+	 * @param string $matched_content The token content (function name) which was matched
+	 *                                in lowercase.
 	 * @param array  $parameters      Array with information about the parameters.
 	 *
 	 * @return void
@@ -408,7 +411,8 @@ final class I18nSniff extends AbstractFunctionParameterSniff {
 	 * @since 3.0.0 Check moved from the `process_matched_token()` method to this method.
 	 *
 	 * @param int    $stackPtr        The position of the current token in the stack.
-	 * @param string $matched_content The token content (function name) which was matched.
+	 * @param string $matched_content The token content (function name) which was matched
+	 *                                in lowercase.
 	 * @param array  $parameters      The parameters array.
 	 * @param int    $expected_count  The expected number of passed arguments.
 	 *
@@ -434,7 +438,8 @@ final class I18nSniff extends AbstractFunctionParameterSniff {
 	 * @since 3.0.0 Most of the logic in this method used to be contained in the, now removed, `check_argument_tokens()` method.
 	 *
 	 * @param int         $stackPtr        The position of the current token in the stack.
-	 * @param string      $matched_content The token content (function name) which was matched.
+	 * @param string      $matched_content The token content (function name) which was matched
+	 *                                     in lowercase.
 	 * @param string      $param_name      The name of the parameter being examined.
 	 * @param array|false $param_info      Parameter info array for an individual parameter,
 	 *                                     as received from the PassedParemeters class.
@@ -534,7 +539,8 @@ final class I18nSniff extends AbstractFunctionParameterSniff {
 	 *
 	 * @since 3.0.0 The logic in this method used to be contained in the, now removed, `check_argument_tokens()` method.
 	 *
-	 * @param string      $matched_content The token content (function name) which was matched.
+	 * @param string      $matched_content The token content (function name) which was matched
+	 *                                     in lowercase.
 	 * @param string      $param_name      The name of the parameter being examined.
 	 * @param array|false $param_info      Parameter info array for an individual parameter,
 	 *                                     as received from the PassedParemeters class.
@@ -625,7 +631,8 @@ final class I18nSniff extends AbstractFunctionParameterSniff {
 	 *
 	 * @since 3.0.0 The logic in this method used to be contained in the, now removed, `check_text()` method.
 	 *
-	 * @param string      $matched_content The token content (function name) which was matched.
+	 * @param string      $matched_content The token content (function name) which was matched
+	 *                                     in lowercase.
 	 * @param string      $param_name      The name of the parameter being examined.
 	 * @param array|false $param_info      Parameter info array for an individual parameter,
 	 *                                     as received from the PassedParemeters class.
@@ -706,7 +713,8 @@ final class I18nSniff extends AbstractFunctionParameterSniff {
 	 *
 	 * @since 3.0.0 The logic in this method used to be contained in the, now removed, `check_text()` method.
 	 *
-	 * @param string      $matched_content The token content (function name) which was matched.
+	 * @param string      $matched_content The token content (function name) which was matched
+	 *                                     in lowercase.
 	 * @param string      $param_name      The name of the parameter being examined.
 	 * @param array|false $param_info      Parameter info array for an individual parameter,
 	 *                                     as received from the PassedParemeters class.
@@ -740,7 +748,8 @@ final class I18nSniff extends AbstractFunctionParameterSniff {
 	 *
 	 * @since 3.0.0 The logic in this method used to be contained in the, now removed, `check_text()` method.
 	 *
-	 * @param string      $matched_content The token content (function name) which was matched.
+	 * @param string      $matched_content The token content (function name) which was matched
+	 *                                     in lowercase.
 	 * @param string      $param_name      The name of the parameter being examined.
 	 * @param array|false $param_info      Parameter info array for an individual parameter,
 	 *                                     as received from the PassedParemeters class.
@@ -839,7 +848,8 @@ final class I18nSniff extends AbstractFunctionParameterSniff {
 	 *              - The method visibility has been changed from `protected` to `private`.
 	 *
 	 * @param int    $stackPtr        The position of the gettext call token in the stack.
-	 * @param string $matched_content The token content (function name) which was matched.
+	 * @param string $matched_content The token content (function name) which was matched
+	 *                                in lowercase.
 	 * @param array  $parameters      Array with information about the parameters.
 	 *
 	 * @return void


### PR DESCRIPTION
When the `$matched_content` param is passed from the `AbstractFunctionRestrictionsSniff` or, by extension, from the `AbstractFunctionParameterSniff``, it will always already be in lowercase.

When the `$matched_content` param is passed from the `AbstractClassRestrictionsSniff` sniff it will be in its original case.

This commit updates the docs of all involved methods to include information about the case of the content of `$matched_content` to clarify this.

Includes removing two unnecessary calls to `strtolower()` in child classes.

Includes overloading the `process_matched_token()` method in the `AbstractClassRestrictionsSniff`, not because the code does anything different, but only to ensure the docblock annotates correctly that in child classes of that abstract the `$matched_content` will be in its original case.