### PR TITLE
Docs: use correct format for `@internal` tags

### DIFF
--- a/WordPress/Helpers/ContextHelper.php
+++ b/WordPress/Helpers/ContextHelper.php
@@ -115,8 +115,8 @@ final class ContextHelper {
 	/**
 	 * Check if a particular token acts - statically or non-statically - on an object.
 	 *
-	 * @internal Note: this may still mistake a namespaced function imported via a `use` statement for
-	 * a global function!
+	 * {@internal Note: this may still mistake a namespaced function imported via a `use` statement for
+	 * a global function!}
 	 *
 	 * @since 2.1.0
 	 * @since 3.0.0 - Moved from the Sniff class to this class.
@@ -137,8 +137,8 @@ final class ContextHelper {
 	/**
 	 * Check if a particular token is prefixed with a namespace.
 	 *
-	 * @internal This will give a false positive if the file is not namespaced and the token is prefixed
-	 * with `namespace\`.
+	 * {@internal This will give a false positive if the file is not namespaced and the token is prefixed
+	 * with `namespace\`.}
 	 *
 	 * @since 2.1.0
 	 * @since 3.0.0 - Moved from the Sniff class to this class.

--- a/WordPress/Helpers/ListHelper.php
+++ b/WordPress/Helpers/ListHelper.php
@@ -34,8 +34,8 @@ final class ListHelper {
 	/**
 	 * Get a list of the token pointers to the variables being assigned to in a list statement.
 	 *
-	 * @internal No need to take special measures for nested lists. Nested or not,
-	 * each list part can only contain one variable being written to.
+	 * {@internal No need to take special measures for nested lists. Nested or not,
+	 * each list part can only contain one variable being written to.}
 	 *
 	 * @since 2.2.0
 	 * @since 3.0.0 - Moved from the Sniff class to this class.

--- a/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
+++ b/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
@@ -773,8 +773,8 @@ final class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 	/**
 	 * Check that global variables declared via a list construct are prefixed.
 	 *
-	 * @internal No need to take special measures for nested lists. Nested or not,
-	 * each list part can only contain one variable being written to.
+	 * {@internal No need to take special measures for nested lists. Nested or not,
+	 * each list part can only contain one variable being written to.}
 	 *
 	 * @since 2.2.0
 	 *

--- a/WordPress/Sniffs/WP/GlobalVariablesOverrideSniff.php
+++ b/WordPress/Sniffs/WP/GlobalVariablesOverrideSniff.php
@@ -163,8 +163,8 @@ final class GlobalVariablesOverrideSniff extends Sniff {
 	/**
 	 * Check that global variables declared via a list construct are prefixed.
 	 *
-	 * @internal No need to take special measures for nested lists. Nested or not,
-	 * each list part can only contain one variable being written to.
+	 * {@internal No need to take special measures for nested lists. Nested or not,
+	 * each list part can only contain one variable being written to.}
 	 *
 	 * @since 2.2.0
 	 *


### PR DESCRIPTION
... which have two meanings:
* `@internal` stand-alone without braces means that a construct is intended for internal use only.
* `{@internal ....}` with a comment means this is a comment for other devs.