### PR TITLE
Docs: remove redundant comment

### DIFF
--- a/WordPress/Helpers/MinimumWPVersionTrait.php
+++ b/WordPress/Helpers/MinimumWPVersionTrait.php
@@ -63,9 +63,6 @@ trait MinimumWPVersionTrait {
 	 *               - The property has been renamed from `$minimum_supported_version` to `$minimum_wp_version`.
 	 *               - The CLI option has been renamed from `minimum_supported_wp_version` to `minimum_wp_version`.
 	 *
-	 * @internal When the value of this property is changed, it will also need
-	 *           to be changed in the `WP/AlternativeFunctionsUnitTest.inc` file.
-	 *
 	 * @var string WordPress version.
 	 */
 	public $minimum_wp_version;


### PR DESCRIPTION
Follow up on #2187 which removed the need to reset the `minimum_wp_version` property in test case files to a specific WP version, in favour of allowing a reset to "unset".

This means the version number in the `WP/AlternativeFunctionsUnitTest.inc` test case file doesn't need to be updated anymore when the default value of the `minimum_wp_version` changes, so this comment is now just confusing.