### PR TITLE
WP/AlternativeFunctionsSniff::is_local_data_stream(): update param name and docs

### DIFF
--- a/WordPress/Sniffs/WP/AlternativeFunctionsSniff.php
+++ b/WordPress/Sniffs/WP/AlternativeFunctionsSniff.php
@@ -345,24 +345,24 @@ final class AlternativeFunctionsSniff extends AbstractFunctionRestrictionsSniff 
 	}
 
 	/**
-	 * Determine based on the "raw" parameter value, whether a file parameter points to
+	 * Determine based on the "clean" parameter value, whether a file parameter points to
 	 * a local data stream.
 	 *
-	 * @param string $raw_param_value Raw parameter value.
+	 * @param string $clean_param_value Parameter value without comments.
 	 *
 	 * @return bool True if this is a local data stream. False otherwise.
 	 */
-	protected function is_local_data_stream( $raw_param_value ) {
+	protected function is_local_data_stream( $clean_param_value ) {
 
-		$raw_stripped = TextStrings::stripQuotes( $raw_param_value );
-		if ( isset( $this->allowed_local_streams[ $raw_stripped ] )
-			|| isset( $this->allowed_local_stream_constants[ $raw_param_value ] )
+		$stripped = TextStrings::stripQuotes( $clean_param_value );
+		if ( isset( $this->allowed_local_streams[ $stripped ] )
+			|| isset( $this->allowed_local_stream_constants[ $clean_param_value ] )
 		) {
 			return true;
 		}
 
 		foreach ( $this->allowed_local_stream_partials as $partial ) {
-			if ( strpos( $raw_stripped, $partial ) === 0 ) {
+			if ( strpos( $stripped, $partial ) === 0 ) {
 				return true;
 			}
 		}


### PR DESCRIPTION
PR #2169 switched the sniff from using the `'raw'` parameter value to using the `'clean'` (without comments) parameter value, however, the `is_local_data_stream()` method still referred to the `'raw'` value, even though it is now using the `'clean'` value.

Fixed now to prevent future confusion.