### PR TITLE
IsUnitTestTrait: make sure namespace and class names are checked case-insensitively

### DIFF
--- a/WordPress/Tests/Files/FileNameUnitTest.php
+++ b/WordPress/Tests/Files/FileNameUnitTest.php
@@ -74,6 +74,7 @@ final class FileNameUnitTest extends AbstractSniffUnitTest {
 		 */
 		'test-sample-phpunit.inc'                    => 0,
 		'test-sample-phpunit6.inc'                   => 0,
+		'test-sample-phpunit6-case-insensitive.inc'  => 0,
 		'test-sample-wpunit.inc'                     => 0,
 		'test-sample-custom-unit.1.inc'              => 0,
 		'test-sample-custom-unit.2.inc'              => 0,

--- a/WordPress/Tests/Files/FileNameUnitTests/TestFiles/test-sample-phpunit6-case-insensitive.inc
+++ b/WordPress/Tests/Files/FileNameUnitTests/TestFiles/test-sample-phpunit6-case-insensitive.inc
@@ -1,0 +1,3 @@
+<?php
+// Take note of the `PHPunit` vs `PHPUnit` in the namespace and the `Testcase` vs `TestCase` for the extended class name.
+class TestSample extends PHPunit\Framework\Testcase {}


### PR DESCRIPTION
As PHP treats namespace names and class names case-insensitively, this helper should do so too.

This is a bug fix as the sniff would previously throw false positives for test classes where the case of the class name/extended class name did not match.

Tested by adding an extra test to the `WordPress.Files.FilesName` sniff.