### PR TITLE
GH Actions/manage-labels: remove label which doesn't exist anymore

### DIFF
--- a/.github/workflows/manage-labels.yml
+++ b/.github/workflows/manage-labels.yml
@@ -21,8 +21,8 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           labels: |
-            Status: Awaiting Feedback
-            Status: Review Ready
+            Status: Awaiting feedback
+            Status: Review ready
 
   on-pr-close:
     runs-on: ubuntu-latest
@@ -35,9 +35,9 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           labels: |
-            Status: Awaiting Feedback
-            Status: close candidate
-            Status: Review Ready
+            Status: Awaiting feedback
+            Status: Close candidate
+            Status: Review ready
 
   on-issue-close:
     runs-on: ubuntu-latest
@@ -50,8 +50,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           labels: |
-            Status: Awaiting Feedback
-            Status: close candidate
-            Status: help wanted
-            Status: good first issue
-            Status: PR Exists
+            Status: Awaiting feedback
+            Status: Close candidate
+            Status: Good first issue
+            Status: Help wanted


### PR DESCRIPTION
As discussed in Slack, I've:
* Removed the `Status: PR Exists` label.
* Reviewed all other labels for consistency in the capitalization of the phrases and made fixes where needed.

This updates the GH Actions workflow which references those labels to match.