### PR TITLE
DB/DirectDatabaseQuery: 2 fixes for case-insensitivity (PHP + SQL)

### DIFF
--- a/WordPress/Sniffs/DB/DirectDatabaseQuerySniff.php
+++ b/WordPress/Sniffs/DB/DirectDatabaseQuerySniff.php
@@ -202,7 +202,7 @@ final class DirectDatabaseQuerySniff extends Sniff {
 				break;
 			}
 
-			if ( strpos( TextStrings::stripQuotes( $this->tokens[ $_pos ]['content'] ), 'TRUNCATE ' ) === 0 ) {
+			if ( strpos( strtoupper( TextStrings::stripQuotes( $this->tokens[ $_pos ]['content'] ) ), 'TRUNCATE ' ) === 0 ) {
 				// Ignore queries to truncate the database as caching those is irrelevant and they need a direct db query.
 				return;
 			}

--- a/WordPress/Sniffs/DB/DirectDatabaseQuerySniff.php
+++ b/WordPress/Sniffs/DB/DirectDatabaseQuerySniff.php
@@ -185,7 +185,7 @@ final class DirectDatabaseQuerySniff extends Sniff {
 		}
 
 		$methodPtr = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $is_object_call + 1 ), null, true );
-		$method    = $this->tokens[ $methodPtr ]['content'];
+		$method    = strtolower( $this->tokens[ $methodPtr ]['content'] );
 
 		$this->mergeFunctionLists();
 

--- a/WordPress/Tests/DB/DirectDatabaseQueryUnitTest.inc
+++ b/WordPress/Tests/DB/DirectDatabaseQueryUnitTest.inc
@@ -317,3 +317,13 @@ function stay_silent_for_truncate_query() {
 		)
 	);
 }
+
+function stay_silent_for_truncate_query_lowercase_sql_keywords() {
+	global $wpdb;
+	$wpdb->query(
+		$wpdb->prepare(
+			'truncate table `%1$s`',
+			plugin_get_table_name( 'Name' )
+		)
+	);
+}

--- a/WordPress/Tests/DB/DirectDatabaseQueryUnitTest.inc
+++ b/WordPress/Tests/DB/DirectDatabaseQueryUnitTest.inc
@@ -327,3 +327,8 @@ function stay_silent_for_truncate_query_lowercase_sql_keywords() {
 		)
 	);
 }
+
+function method_names_are_caseinsensitive() {
+	global $wpdb;
+	$autoload = $wpdb->Get_Var( $wpdb->Prepare( "SELECT autoload FROM $wpdb->options WHERE option_name = %s", $option_name ) ); // Warning x 2.
+}

--- a/WordPress/Tests/DB/DirectDatabaseQueryUnitTest.php
+++ b/WordPress/Tests/DB/DirectDatabaseQueryUnitTest.php
@@ -92,6 +92,7 @@ final class DirectDatabaseQueryUnitTest extends AbstractSniffUnitTest {
 			288 => 1,
 			300 => 1,
 			306 => 2,
+			333 => 2,
 		);
 	}
 }


### PR DESCRIPTION
### DB/DirectDatabaseQuery: SQL keywords are case-insensitive

This was already handled correctly for `ALTER` etc, but not for the new check for `TRUNCATE` (added in #2186).

Includes test.

### DB/DirectDatabaseQuery: method names are case-insensitive

... so the sniff needs to do the name comparisons in a case-insensitive manner.

Includes test.