### PR TITLE
Always use BCFile for find[Start|End]OfStatement()

### DIFF
--- a/WordPress/AbstractArrayAssignmentRestrictionsSniff.php
+++ b/WordPress/AbstractArrayAssignmentRestrictionsSniff.php
@@ -10,6 +10,7 @@
 namespace WordPressCS\WordPress;
 
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\BackCompat\BCFile;
 use PHPCSUtils\Utils\GetTokensAsString;
 use PHPCSUtils\Utils\MessageHelper;
 use PHPCSUtils\Utils\TextStrings;
@@ -176,7 +177,7 @@ abstract class AbstractArrayAssignmentRestrictionsSniff extends Sniff {
 			) {
 				$key      = TextStrings::stripQuotes( $this->tokens[ $keyIdx ]['content'] );
 				$valStart = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $operator + 1 ), null, true );
-				$valEnd   = $this->phpcsFile->findEndOfStatement( $valStart, \T_COLON );
+				$valEnd   = BCFile::findEndOfStatement( $this->phpcsFile, $valStart, \T_COLON );
 				if ( \T_COMMA === $this->tokens[ $valEnd ]['code']
 					|| \T_SEMICOLON === $this->tokens[ $valEnd ]['code']
 				) {

--- a/WordPress/Sniffs/CodeAnalysis/AssignmentInTernaryConditionSniff.php
+++ b/WordPress/Sniffs/CodeAnalysis/AssignmentInTernaryConditionSniff.php
@@ -10,6 +10,7 @@
 namespace WordPressCS\WordPress\Sniffs\CodeAnalysis;
 
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\BackCompat\BCFile;
 use PHPCSUtils\Utils\Parentheses;
 use WordPressCS\WordPress\Sniff;
 
@@ -100,13 +101,13 @@ final class AssignmentInTernaryConditionSniff extends Sniff {
 			$opener = Parentheses::getLastOpener( $this->phpcsFile, $stackPtr );
 			$closer = Parentheses::getLastCloser( $this->phpcsFile, $stackPtr );
 
-			$next_statement_closer = $this->phpcsFile->findEndOfStatement( $stackPtr, array( \T_COLON, \T_CLOSE_PARENTHESIS, \T_CLOSE_SQUARE_BRACKET ) );
+			$next_statement_closer = BCFile::findEndOfStatement( $this->phpcsFile, $stackPtr, array( \T_COLON, \T_CLOSE_PARENTHESIS, \T_CLOSE_SQUARE_BRACKET ) );
 			if ( false !== $next_statement_closer && $next_statement_closer < $closer ) {
 				// Parentheses are unrelated to the ternary.
 				return;
 			}
 
-			$prev_statement_closer = $this->phpcsFile->findStartOfStatement( $stackPtr, array( \T_COLON, \T_OPEN_PARENTHESIS, \T_OPEN_SQUARE_BRACKET ) );
+			$prev_statement_closer = BCFile::findStartOfStatement( $this->phpcsFile, $stackPtr, array( \T_COLON, \T_OPEN_PARENTHESIS, \T_OPEN_SQUARE_BRACKET ) );
 			if ( false !== $prev_statement_closer && $opener < $prev_statement_closer ) {
 				// Parentheses are unrelated to the ternary.
 				return;


### PR DESCRIPTION
All methods in the `BCFile` class have PHPCSUtils native alternatives (which we already use), with the exception of the `findEndOfStatement()` method and the `findStartOfStatement()` method.

To be on the safe side, in case a polyfill is needed in those methods for a future PHP version or for support for PHPCS 4.x, let's consistently use the `BCFile` versions of these methods.