### PR TITLE
AbstractArrayAssignmentRestrictions: remove support for 'callback'

### DIFF
--- a/WordPress/AbstractArrayAssignmentRestrictionsSniff.php
+++ b/WordPress/AbstractArrayAssignmentRestrictionsSniff.php
@@ -95,10 +95,9 @@ abstract class AbstractArrayAssignmentRestrictionsSniff extends Sniff {
 	 *
 	 * Example: groups => array(
 	 *  'groupname' => array(
-	 *      'type'     => 'error' | 'warning',
-	 *      'message'  => 'Descriptive error message. The error message will be passed the $key and $val of the current array assignment.',
-	 *      'keys'     => array( 'key1', 'another_key' ),
-	 *      'callback' => array( 'class', 'method' ), // Optional.
+	 *      'type'    => 'error' | 'warning',
+	 *      'message' => 'Descriptive error message. The error message will be passed the $key and $val of the current array assignment.',
+	 *      'keys'    => array( 'key1', 'another_key' ),
 	 *  )
 	 * )
 	 *
@@ -219,14 +218,12 @@ abstract class AbstractArrayAssignmentRestrictionsSniff extends Sniff {
 				continue;
 			}
 
-			$callback = ( isset( $group['callback'] ) && is_callable( $group['callback'] ) ) ? $group['callback'] : array( $this, 'callback' );
-
 			foreach ( $inst as $key => $assignment ) {
 				if ( ! \in_array( $key, $group['keys'], true ) ) {
 					continue;
 				}
 
-				$output = \call_user_func( $callback, $key, $assignment['value'], $assignment['line'], $group );
+				$output = \call_user_func( array( $this, 'callback' ), $key, $assignment['value'], $assignment['line'], $group );
 
 				if ( ! isset( $output ) || false === $output ) {
 					continue;


### PR DESCRIPTION
👉🏻  **[OPTIONAL/PROPOSAL]**

The `getGroups()` method allows to pass a custom callback for any particular group, however, in practice that array key is never used as the `callback()` method (the default) is declared as `abstract` and therefore **must** be defined in a child class.

I propose to remove support for the `callback` array key from the abstract sniff.

Sniffs which extend this abstract can still use different logic for different groups by applying a switch to the `$group` parameter received in the `callback()`, along the lines of:
```php
public function callback( $key, $val, $line, $group ) {
    switch( $group ) {
        case 'groupA':
            return $this->callback_for_group_A($key, val, $line);
        case 'groupB':
            return $this->callback_for_group_B($key, val, $line);
    }
}
```

I have verified that [none of the sniffs published in public repos and which extend this abstract sniff](https://sourcegraph.com/search?q=context:global+use+WordPressCS%5CWordPress%5CAbstractArrayAssignmentRestrictionsSniff&patternType=standard&case=yes&sm=0&groupBy=group) currently use the `'callback'` key.

Removing the support for the key is a breaking change, but one with low impact based on current usage of the abstract.