### PR TITLE
Docs: add `@internal` tag to classes marked as internal API

### DIFF
--- a/WordPress/Helpers/ConstantsHelper.php
+++ b/WordPress/Helpers/ConstantsHelper.php
@@ -26,6 +26,8 @@ use WordPressCS\WordPress\Helpers\ContextHelper;
  * {@internal The functionality in this class will likely be replaced at some point in
  * the future by functions from PHPCSUtils.}
  *
+ * @internal
+ *
  * @package WPCS\WordPressCodingStandards
  * @since   3.0.0 The method in this class was previously contained in the
  *                `WordPressCS\WordPress\Sniff` class and has been moved here.

--- a/WordPress/Helpers/ContextHelper.php
+++ b/WordPress/Helpers/ContextHelper.php
@@ -23,6 +23,8 @@ use PHPCSUtils\Utils\PassedParameters;
  * This also means that it has no promise of backward compatibility. Use at your own risk.
  * ---------------------------------------------------------------------------------------------
  *
+ * @internal
+ *
  * @package WPCS\WordPressCodingStandards
  * @since   3.0.0 The methods in this class were previously contained in the
  *                `WordPressCS\WordPress\Sniff` class and have been moved here.

--- a/WordPress/Helpers/DeprecationHelper.php
+++ b/WordPress/Helpers/DeprecationHelper.php
@@ -23,6 +23,8 @@ use PHP_CodeSniffer\Util\Tokens;
  * {@internal The functionality in this class will likely be replaced at some point in
  * the future by functions from PHPCSUtils.}
  *
+ * @internal
+ *
  * @package WPCS\WordPressCodingStandards
  * @since   3.0.0 The method in this class was previously contained in the
  *                `WordPressCS\WordPress\Sniff` class and has been moved here.

--- a/WordPress/Helpers/ListHelper.php
+++ b/WordPress/Helpers/ListHelper.php
@@ -25,6 +25,8 @@ use PHPCSUtils\Utils\Lists;
  * {@internal The functionality in this class will likely be replaced at some point in
  * the future by functions from PHPCSUtils.}
  *
+ * @internal
+ *
  * @package WPCS\WordPressCodingStandards
  * @since   3.0.0 The method in this class was previously contained in the
  *                `WordPressCS\WordPress\Sniff` class and has been moved here.

--- a/WordPress/Helpers/RulesetPropertyHelper.php
+++ b/WordPress/Helpers/RulesetPropertyHelper.php
@@ -17,6 +17,8 @@ namespace WordPressCS\WordPress\Helpers;
  * This also means that it has no promise of backward compatibility. Use at your own risk.
  * ---------------------------------------------------------------------------------------------
  *
+ * @internal
+ *
  * @package WPCS\WordPressCodingStandards
  * @since   3.0.0 The method in this class was previously contained in the
  *                `WordPressCS\WordPress\Sniff` class and has been moved here.

--- a/WordPress/Helpers/SnakeCaseHelper.php
+++ b/WordPress/Helpers/SnakeCaseHelper.php
@@ -22,6 +22,8 @@ use PHPCSUtils\BackCompat\Helper;
  * {@internal The functionality in this class will likely be replaced at some point in
  * the future by functions from PHPCSUtils.}
  *
+ * @internal
+ *
  * @package WPCS\WordPressCodingStandards
  * @since   3.0.0 The method in this class was previously contained in the
  *                `WordPressCS\WordPress\Sniff` class and has been moved here.

--- a/WordPress/Helpers/VariableHelper.php
+++ b/WordPress/Helpers/VariableHelper.php
@@ -25,6 +25,8 @@ use PHPCSUtils\Utils\Parentheses;
  * {@internal The functionality in this class will likely be replaced at some point in
  * the future by functions from PHPCSUtils.}
  *
+ * @internal
+ *
  * @package WPCS\WordPressCodingStandards
  * @since   3.0.0 The methods in this class were previously contained in the
  *                `WordPressCS\WordPress\Sniff` class and have been moved here.


### PR DESCRIPTION
This adds _"the other"_ `@internal` tag to these classes, also marking the classes as "internal API" via the tag (on top of the notice in the docblock description).