### PR TITLE
Docs: add missing `@uses` tags

### DIFF
--- a/WordPress/Sniffs/Security/NonceVerificationSniff.php
+++ b/WordPress/Sniffs/Security/NonceVerificationSniff.php
@@ -27,6 +27,9 @@ use WordPressCS\WordPress\Sniff;
  * @since   0.5.0
  * @since   0.13.0 Class name changed: this class is now namespaced.
  * @since   1.0.0  This sniff has been moved from the `CSRF` category to the `Security` category.
+ *
+ * @uses    \WordPressCS\WordPress\Helpers\SanitizingFunctionsTrait::$customSanitizingFunctions
+ * @uses    \WordPressCS\WordPress\Helpers\SanitizingFunctionsTrait::$customUnslashingSanitizingFunctions
  */
 class NonceVerificationSniff extends Sniff {
 

--- a/WordPress/Sniffs/Security/ValidatedSanitizedInputSniff.php
+++ b/WordPress/Sniffs/Security/ValidatedSanitizedInputSniff.php
@@ -28,6 +28,9 @@ use WordPressCS\WordPress\Sniff;
  * @since   0.5.0  Method getArrayIndexKey() has been moved to the WordPressCS native `Sniff` class.
  * @since   0.13.0 Class name changed: this class is now namespaced.
  * @since   1.0.0  This sniff has been moved from the `VIP` category to the `Security` category.
+ *
+ * @uses    \WordPressCS\WordPress\Helpers\SanitizingFunctionsTrait::$customSanitizingFunctions
+ * @uses    \WordPressCS\WordPress\Helpers\SanitizingFunctionsTrait::$customUnslashingSanitizingFunctions
  */
 class ValidatedSanitizedInputSniff extends Sniff {
 


### PR DESCRIPTION
Follow up on #2259, which moved these `public` properties to the `SanitizingFunctionsTrait`.