### PR TITLE
Composer: update PHPCSUtils + PHPCSExtra

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,8 @@
 		"php": ">=5.4",
 		"ext-filter": "*",
 		"squizlabs/php_codesniffer": "^3.7.2",
-		"phpcsstandards/phpcsutils": "^1.0.7",
-		"phpcsstandards/phpcsextra": "^1.0"
+		"phpcsstandards/phpcsutils": "^1.0.8",
+		"phpcsstandards/phpcsextra": "^1.1.0"
 	},
 	"require-dev": {
 		"phpcompatibility/php-compatibility": "^9.0",


### PR DESCRIPTION
PHPCSUtils released version 1.0.8 with a small bug fix.

PHPCSExtra has just released version 1.1.0. with 7 new sniffs, most of which we'll want to add to WPCS (will be done in follow-up PRs).

Refs:
* https://github.com/PHPCSStandards/PHPCSUtils/releases/tag/1.0.8
* https://github.com/PHPCSStandards/PHPCSExtra/releases/tag/1.1.0