### PR TITLE
Extra: add sniff to detect inefficient "echo sprintf(...)"

### DIFF
--- a/WordPress-Extra/ruleset.xml
+++ b/WordPress-Extra/ruleset.xml
@@ -171,6 +171,9 @@
 		or declare object-oriented structures, but not both. -->
 	<rule ref="Universal.Files.SeparateFunctionsFromOO"/>
 
+	<!-- Detect useless "echo sprintf(...)". -->
+	<rule ref="Universal.CodeAnalysis.NoEchoSprintf"/>
+
 	<!--
 	#############################################################################
 	Code style sniffs for more recent PHP features and syntaxes.


### PR DESCRIPTION
... which ought to be replaced by `printf(...)`.

Ref: PHPCSStandards/PHPCSExtra#242