### PR TITLE
Extra: add sniff to discourage the use of "long" closures

### DIFF
--- a/WordPress-Extra/ruleset.xml
+++ b/WordPress-Extra/ruleset.xml
@@ -174,6 +174,15 @@
 	<!-- Detect useless "echo sprintf(...)". -->
 	<rule ref="Universal.CodeAnalysis.NoEchoSprintf"/>
 
+	<!-- Discourage the use of long closures. -->
+	<rule ref="Universal.FunctionDeclarations.NoLongClosures">
+		<properties>
+			<!-- Disable the error. -->
+			<property name="maxLines" value="9999"/>
+		</properties>
+	</rule>
+
+
 	<!--
 	#############################################################################
 	Code style sniffs for more recent PHP features and syntaxes.


### PR DESCRIPTION
Loosely related to the discussion in #1486.

This adds a new sniff to the `WordPress-Extra` ruleset to discourage (`warning`) the use of "long" closures.

By default, the sniff will _warn_ when a closure exceeds 5 lines and throw an error when the closure exceeds 8 lines, though these numbers are configurable. By default, the sniff will only count code lines when determining the closure length and will ignore comment-only and blank lines.

As the intention is to only discourage long closures, the error has been disabled (by setting it to a really high value).

Ref: PHPCSStandards/PHPCSExtra#240

---

:point_right: **To discuss**: should the value for the `recommendedLines` property stay at `5` (sniff default) or do we want to use a different value ?

<details><summary>Some input for this based on a run against WP Core (even though the sniff is being added for `Extra` not `Core`):</summary>
<p>
```
// Stats (metrics) for closure use in WP Core `src`:
Closure length (code only):
        1 lines  => 50 ( 56.18%)
        2 lines  =>  4 (  4.49%)
        3 lines  =>  7 (  7.87%)
        4 lines  =>  4 (  4.49%)
        5 lines  =>  3 (  3.37%)
        6 lines  =>  1 (  1.12%) // Warnings would start from here.
        7 lines  =>  4 (  4.49%)
        8 lines  =>  4 (  4.49%)
        9 lines  =>  1 (  1.12%)
        10 lines =>  3 (  3.37%)
        13 lines =>  1 (  1.12%)
        14 lines =>  1 (  1.12%)
        15 lines =>  1 (  1.12%)
        17 lines =>  1 (  1.12%)
        23 lines =>  1 (  1.12%)
        36 lines =>  1 (  1.12%)
        45 lines =>  1 (  1.12%)
        53 lines =>  1 (  1.12%)
        -------------------------
        total    => 89 (100.00%)

// Stats (metrics) for closure use in WP Core `tests`:
Closure length (code only):
        0 lines  =>    2 (  0.78%)
        1 lines  =>  120 ( 47.06%)
        2 lines  =>   37 ( 14.51%)
        3 lines  =>   26 ( 10.20%)
        4 lines  =>   20 (  7.84%)
        5 lines  =>   10 (  3.92%)
        6 lines  =>    3 (  1.18%) // Warnings would start from here.
        7 lines  =>   11 (  4.31%)
        8 lines  =>    9 (  3.53%)
        9 lines  =>    2 (  0.78%)
        10 lines =>    7 (  2.75%)
        11 lines =>    2 (  0.78%)
        12 lines =>    1 (  0.39%)
        13 lines =>    1 (  0.39%)
        14 lines =>    1 (  0.39%)
        20 lines =>    1 (  0.39%)
        25 lines =>    1 (  0.39%)
        27 lines =>    1 (  0.39%)
        ---------------------------
        total    =>  255 (100.00%)
```
</p>
</details> 
