### PR TITLE
NamingConventions/ValidPostTypeSlug: update the reserved post types list

### DIFF
--- a/WordPress/Sniffs/NamingConventions/ValidPostTypeSlugSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidPostTypeSlugSniff.php
@@ -65,6 +65,8 @@ final class ValidPostTypeSlugSniff extends AbstractFunctionParameterSniff {
 	 *
 	 * Source: {@link https://developer.wordpress.org/reference/functions/register_post_type/#reserved-post-types}
 	 *
+	 * Last update: July 2023 for WP 6.3 at https://github.com/WordPress/wordpress-develop/commit/6281ce432c50345a57768bf53854d9b65b6cdd52
+	 *
 	 * @since 2.2.0
 	 *
 	 * @var array
@@ -84,6 +86,10 @@ final class ValidPostTypeSlugSniff extends AbstractFunctionParameterSniff {
 		'theme'               => true, // Not a WP post type, but prevents other problems.
 		'user_request'        => true,
 		'wp_block'            => true,
+		'wp_global_styles'    => true,
+		'wp_navigation'       => true,
+		'wp_template'         => true,
+		'wp_template_part'    => true,
 	);
 
 	/**

--- a/WordPress/Sniffs/NamingConventions/ValidPostTypeSlugSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidPostTypeSlugSniff.php
@@ -63,25 +63,27 @@ final class ValidPostTypeSlugSniff extends AbstractFunctionParameterSniff {
 	/**
 	 * Array of reserved post type names which can not be used by themes and plugins.
 	 *
+	 * Source: {@link https://developer.wordpress.org/reference/functions/register_post_type/#reserved-post-types}
+	 *
 	 * @since 2.2.0
 	 *
 	 * @var array
 	 */
 	protected $reserved_names = array(
-		'post'                => true,
-		'page'                => true,
+		'action'              => true, // Not a WP post type, but prevents other problems.
 		'attachment'          => true,
-		'revision'            => true,
-		'nav_menu_item'       => true,
+		'author'              => true, // Not a WP post type, but prevents other problems.
 		'custom_css'          => true,
 		'customize_changeset' => true,
+		'nav_menu_item'       => true,
 		'oembed_cache'        => true,
+		'order'               => true, // Not a WP post type, but prevents other problems.
+		'page'                => true,
+		'post'                => true,
+		'revision'            => true,
+		'theme'               => true, // Not a WP post type, but prevents other problems.
 		'user_request'        => true,
 		'wp_block'            => true,
-		'action'              => true,
-		'author'              => true,
-		'order'               => true,
-		'theme'               => true,
 	);
 
 	/**


### PR DESCRIPTION
### NamingConventions/ValidPostTypeSlug: order reserved names alphabetically

This only changes the order of the list. No reserved names were added or removed.

Includes adding a link to the source of the list and adding comments about the items in the "special" list of reserved names, which aren't WP native post types.

### NamingConventions/ValidPostTypeSlug: update the reserved post types list based on WP 6.3-RC1

Based on a scan of WP Core at commit WordPress/wordpress-develop@6281ce4 using a preliminary sniff created for issue #1803.

Manually verified.

Also see: https://wordpress.slack.com/archives/C680YMW9H/p1688270736663219