### PR TITLE
WP/DeprecatedClasses: update the class list based on WP 6.3-RC1

### DIFF
--- a/WordPress/Sniffs/WP/DeprecatedClassesSniff.php
+++ b/WordPress/Sniffs/WP/DeprecatedClassesSniff.php
@@ -43,6 +43,8 @@ final class DeprecatedClassesSniff extends AbstractClassRestrictionsSniff {
 	 *
 	 * Version numbers should be fully qualified.
 	 *
+	 * Last update: July 2023 for WP 6.3 at https://github.com/WordPress/wordpress-develop/commit/6281ce432c50345a57768bf53854d9b65b6cdd52
+	 *
 	 * @var array
 	 */
 	private $deprecated_classes = array(
@@ -53,8 +55,14 @@ final class DeprecatedClassesSniff extends AbstractClassRestrictionsSniff {
 			'version' => '3.1.0',
 		),
 
+		// WP 3.7.0.
+		'WP_HTTP_Fsockopen' => array(
+			'alt'     => 'WP_HTTP::request()',
+			'version' => '3.7.0',
+		),
+
 		// WP 4.9.0.
-		'Customize_New_Menu_Section' => array(
+		'WP_Customize_New_Menu_Section' => array(
 			'version' => '4.9.0',
 		),
 		'WP_Customize_New_Menu_Control' => array(
@@ -62,12 +70,23 @@ final class DeprecatedClassesSniff extends AbstractClassRestrictionsSniff {
 		),
 
 		// WP 5.3.0.
+		'WP_Privacy_Data_Export_Requests_Table' => array(
+			'alt'     => 'WP_Privacy_Data_Export_Requests_List_Table',
+			'version' => '5.3.0',
+		),
+		'WP_Privacy_Data_Removal_Requests_Table' => array(
+			'alt'     => 'WP_Privacy_Data_Removal_Requests_List_Table',
+			'version' => '5.3.0',
+		),
 		'Services_JSON' => array(
 			'alt'     => 'The PHP native JSON extension',
 			'version' => '5.3.0',
 		),
+		'Services_JSON_Error' => array(
+			'alt'     => 'The PHP native JSON extension',
+			'version' => '5.3.0',
+		),
 	);
-
 
 	/**
 	 * Groups of classes to restrict.

--- a/WordPress/Tests/WP/DeprecatedClassesUnitTest.inc
+++ b/WordPress/Tests/WP/DeprecatedClassesUnitTest.inc
@@ -13,8 +13,13 @@ echo \WP_User_Search::prepare_query();
 class My_User_Search extends WP_User_Search {}
 class Our_User_Search implements WP_User_Search {}
 $a = (new WP_User_Search())->query();
+/* ============ WP 3.7 ============ */
+$anon = new class extends WP_HTTP_Fsockopen {};
 /* ============ WP 4.9 ============ */
-class Prefix_Menu_section extends Customize_New_Menu_Section {}
+class Prefix_Menu_section extends WP_Customize_New_Menu_Section {}
 WP_Customize_New_Menu_Control::foo();
 /* ============ WP 5.3 ============ */
 $json = new Services_JSON;
+$json = new Services_JSON_Error;
+class Prefix_Menu_section extends WP_Privacy_Data_Export_Requests_Table {}
+WP_Privacy_Data_Removal_Requests_Table::foo();

--- a/WordPress/Tests/WP/DeprecatedClassesUnitTest.php
+++ b/WordPress/Tests/WP/DeprecatedClassesUnitTest.php
@@ -30,11 +30,11 @@ final class DeprecatedClassesUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getErrorList() {
 		$start_line = 9;
-		$end_line   = 20;
+		$end_line   = 25;
 		$errors     = array_fill( $start_line, ( ( $end_line - $start_line ) + 1 ), 1 );
 
 		// Unset the lines related to version comments.
-		unset( $errors[16], $errors[19] );
+		unset( $errors[16], $errors[18], $errors[21] );
 
 		return $errors;
 	}


### PR DESCRIPTION
Based on a scan of WP Core at commit https://github.com/WordPress/wordpress-develop/commit/6281ce432c50345a57768bf53854d9b65b6cdd52 using a preliminary sniff created for issue #1803.

Manually verified.

Includes fixing a typo in the original list.

Previous: #1809 (for WPCS 2.2.0)