### PR TITLE
WP/DeprecatedParameters: update the list based on WP 6.3-RC1

### DIFF
--- a/WordPress/Sniffs/WP/DeprecatedParametersSniff.php
+++ b/WordPress/Sniffs/WP/DeprecatedParametersSniff.php
@@ -51,7 +51,7 @@ final class DeprecatedParametersSniff extends AbstractFunctionParameterSniff {
 	 * Array of function, argument, and default value for deprecated argument.
 	 *
 	 * The functions are ordered alphabetically.
-	 * Last updated for WordPress 4.8.0.
+	 * Last updated for WordPress 6.3.
 	 *
 	 * @since 0.12.0
 	 *
@@ -87,6 +87,13 @@ final class DeprecatedParametersSniff extends AbstractFunctionParameterSniff {
 				'version' => '5.9.0',
 			),
 		),
+		'_wp_post_revision_fields' => array(
+			2 => array(
+				'name'    => 'deprecated',
+				'value'   => false,
+				'version' => '4.5.0',
+			),
+		),
 		'add_option' => array(
 			3 => array(
 				'name'    => 'deprecated',
@@ -113,11 +120,25 @@ final class DeprecatedParametersSniff extends AbstractFunctionParameterSniff {
 				'version' => '0.71',
 			),
 		),
+		'delete_plugins' => array(
+			2 => array(
+				'name'    => 'deprecated',
+				'value'   => '',
+				'version' => '4.0.0',
+			),
+		),
 		'discover_pingback_server_uri' => array(
 			2 => array(
 				'name'    => 'deprecated',
 				'value'   => '',
 				'version' => '2.7.0',
+			),
+		),
+		'get_blog_list' => array(
+			3 => array(
+				'name'    => 'deprecated',
+				'value'   => '',
+				'version' => '3.0.0', // Was previously part of MU.
 			),
 		),
 		'get_category_parents' => array(
@@ -141,6 +162,20 @@ final class DeprecatedParametersSniff extends AbstractFunctionParameterSniff {
 				'version' => '3.0.0', // Was previously part of MU.
 			),
 		),
+		'get_site_option' => array(
+			3 => array(
+				'name'    => 'deprecated',
+				'value'   => true,
+				'version' => '4.4.0',
+			),
+		),
+		'get_terms' => array(
+			2 => array(
+				'name'    => 'deprecated',
+				'value'   => '',
+				'version' => '4.5.0',
+			),
+		),
 		'get_the_author' => array(
 			1 => array(
 				'name'    => 'deprecated',
@@ -162,6 +197,27 @@ final class DeprecatedParametersSniff extends AbstractFunctionParameterSniff {
 				'version' => '4.4.0',
 			),
 		),
+		'global_terms' => array(
+			2 => array(
+				'name'    => 'deprecated',
+				'value'   => '',
+				'version' => '6.1.0',
+			),
+		),
+		'iframe_header' => array(
+			2 => array(
+				'name'    => 'deprecated',
+				'value'   => false,
+				'version' => '4.2.0',
+			),
+		),
+		'install_search_form' => array(
+			1 => array(
+				'name'    => 'deprecated',
+				'value'   => true,
+				'version' => '4.6.0',
+			),
+		),
 		'is_email' => array(
 			2 => array(
 				'name'    => 'deprecated',
@@ -176,11 +232,53 @@ final class DeprecatedParametersSniff extends AbstractFunctionParameterSniff {
 				'version' => '2.7.0',
 			),
 		),
+		'newblog_notify_siteadmin' => array(
+			2 => array(
+				'name'    => 'deprecated',
+				'value'   => '',
+				'version' => '3.0.0',
+			),
+		),
+		'permalink_single_rss' => array(
+			1 => array(
+				'name'    => 'deprecated',
+				'value'   => '',
+				'version' => '2.3.0',
+			),
+		),
+		'redirect_this_site' => array(
+			1 => array(
+				'name'    => 'deprecated',
+				'value'   => '',
+				'version' => '3.0.0',
+			),
+		),
+		'register_meta' => array(
+			4 => array(
+				'name'    => 'deprecated',
+				'value'   => null,
+				'version' => '4.6.0',
+			),
+		),
 		'safecss_filter_attr' => array(
 			2 => array(
 				'name'    => 'deprecated',
 				'value'   => '',
 				'version' => '2.8.1',
+			),
+		),
+		'switch_to_blog' => array(
+			2 => array(
+				'name'    => 'deprecated',
+				'value'   => null,
+				'version' => '3.5.0', // Was previously part of MU.
+			),
+		),
+		'term_description' => array(
+			2 => array(
+				'name'    => 'deprecated',
+				'value'   => null,
+				'version' => '4.9.2',
 			),
 		),
 		'the_attachment_link' => array(
@@ -223,6 +321,13 @@ final class DeprecatedParametersSniff extends AbstractFunctionParameterSniff {
 				'version' => '2.5.0',
 			),
 		),
+		'unregister_setting' => array(
+			3 => array(
+				'name'    => 'deprecated',
+				'value'   => '',
+				'version' => '4.7.0',
+			),
+		),
 		'update_blog_option' => array(
 			4 => array(
 				'name'    => 'deprecated',
@@ -237,6 +342,13 @@ final class DeprecatedParametersSniff extends AbstractFunctionParameterSniff {
 				'version' => '3.1.0',
 			),
 		),
+		'update_posts_count' => array(
+			1 => array(
+				'name'    => 'deprecated',
+				'value'   => '',
+				'version' => '3.0.0',
+			),
+		),
 		'update_user_status' => array(
 			4 => array(
 				'name'    => 'deprecated',
@@ -244,11 +356,18 @@ final class DeprecatedParametersSniff extends AbstractFunctionParameterSniff {
 				'version' => '3.0.2',
 			),
 		),
-		'unregister_setting' => array(
+		'wp_count_terms' => array(
+			2 => array(
+				'name'    => 'deprecated',
+				'value'   => '',
+				'version' => '5.6.0',
+			),
+		),
+		'wp_create_thumbnail' => array(
 			3 => array(
 				'name'    => 'deprecated',
 				'value'   => '',
-				'version' => '4.7.0',
+				'version' => '3.5.0',
 			),
 		),
 		'wp_get_http_headers' => array(
@@ -270,6 +389,13 @@ final class DeprecatedParametersSniff extends AbstractFunctionParameterSniff {
 				'name'    => 'deprecated',
 				'value'   => '',
 				'version' => '2.6.0',
+			),
+		),
+		'wp_login' => array(
+			3 => array(
+				'name'    => 'deprecated',
+				'value'   => '',
+				'version' => '2.5.0',
 			),
 		),
 		'wp_new_user_notification' => array(

--- a/WordPress/Tests/WP/DeprecatedParametersUnitTest.inc
+++ b/WordPress/Tests/WP/DeprecatedParametersUnitTest.inc
@@ -39,6 +39,8 @@ wp_install( is_public: '', user_name: '', user_email: '', deprecated: 'should be
 
 // All will give an ERROR. The functions are ordered alphabetically.
 
+_future_post_hook( 10, $post );
+_wp_post_revision_fields( $foo, 'deprecated' );
 add_option( '', '', [] );
 add_option( '', '', 1.23 );
 add_option( '', '', 10 );
@@ -46,17 +48,29 @@ add_option( '', '', false );
 add_option( '', '', 'deprecated' );
 comments_link( 'deprecated', 'deprecated' );
 convert_chars( '', 'deprecated' );
+delete_plugins( $foo, 'deprecated' );
 discover_pingback_server_uri( '', 'deprecated' );
+get_blog_list( $foo, $bar, 'deprecated' );
 get_category_parents( '', '', '', '', array( 'deprecated') );
 get_delete_post_link( '', 'deprecated' );
 get_last_updated( 'deprecated' );
+get_site_option( $foo, $bar, 'deprecated' );
+get_terms( $foo, 'deprecated' );
 get_the_author( 'deprecated' );
 get_user_option( '', '', 'deprecated' );
 get_wp_title_rss( 'deprecated' );
+iframe_header( $foo, 'deprecated' );
+install_search_form( 'deprecated' );
 is_email( '', 'deprecated' );
 is_email( '', 'false' ); // False as a string not bool.
 load_plugin_textdomain( '', 'deprecated' );
+newblog_notify_siteadmin( $foo, 'deprecated' );
+permalink_single_rss( 'deprecated' );
+redirect_this_site( 'deprecated' );
+register_meta( '', '', '', 'deprecated' );
 safecss_filter_attr( '', 'deprecated' );
+switch_to_blog( $foo, 'deprecated' );
+term_description( $foo, 'deprecated' );
 the_attachment_link( '', '', 'deprecated' );
 the_author( 'deprecated', 'deprecated' );
 the_author_posts_link( 'deprecated' );
@@ -64,17 +78,22 @@ trackback_rdf( 'deprecated' );
 trackback_url( 'deprecated' );
 unregister_setting( '', '', 'deprecated' );
 update_blog_option( '', '', '', 'deprecated' );
+update_blog_status( '', '', '', 'deprecated' );
+update_posts_count( 'deprecated' );
 update_user_status( '', '', '', 'deprecated' );
+wp_count_terms( $foo, 'deprecated' );
+wp_create_thumbnail( $foo, $bar, 'deprecated' );
 wp_get_http_headers( '', 'deprecated' );
 wp_get_sidebars_widgets( 'deprecated' );
 wp_install( '', '', '', '', 'deprecated', 'password', 'language' );
+wp_login( $foo, $bar, 'deprecated' );
 wp_new_user_notification( '', 'deprecated' );
 wp_notify_postauthor( '', 'deprecated' );
 wp_notify_postauthor( '', 'null' ); // Null as a string not null.
 wp_title_rss( 'deprecated' );
 wp_upload_bits( '', 'deprecated' );
 xfn_check( '', '', 'deprecated' );
-_future_post_hook( 10, $post );
 
 // All will give an WARNING as they have been deprecated after WP 5.8.
 _load_remote_block_patterns( $value );
+global_terms( $foo, 'deprecated' );

--- a/WordPress/Tests/WP/DeprecatedParametersUnitTest.php
+++ b/WordPress/Tests/WP/DeprecatedParametersUnitTest.php
@@ -30,7 +30,7 @@ final class DeprecatedParametersUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getErrorList() {
 		$start_line = 42;
-		$end_line   = 77;
+		$end_line   = 95;
 		$errors     = array_fill( $start_line, ( ( $end_line - $start_line ) + 1 ), 1 );
 
 		$errors[22] = 1;
@@ -41,8 +41,8 @@ final class DeprecatedParametersUnitTest extends AbstractSniffUnitTest {
 		$errors[38] = 1;
 
 		// Override number of errors.
-		$errors[47] = 2;
-		$errors[61] = 2;
+		$errors[49] = 2;
+		$errors[75] = 2;
 
 		return $errors;
 	}
@@ -53,8 +53,8 @@ final class DeprecatedParametersUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of warnings>
 	 */
 	public function getWarningList() {
-		$start_line = 80;
-		$end_line   = 80;
+		$start_line = 98;
+		$end_line   = 99;
 		$errors     = array_fill( $start_line, ( ( $end_line - $start_line ) + 1 ), 1 );
 
 		return $errors;


### PR DESCRIPTION
Updates the list of deprecated function parameters in the `WP.DeprecatedParameters` sniff based on the WP 6.3.0-RC1 release.

Based on a scan of WP Core at commit https://github.com/WordPress/wordpress-develop/commit/6281ce432c50345a57768bf53854d9b65b6cdd52 using a preliminary sniff created for issue #1803.

Notes:
* All items in the original list have been manually double-checked and are okay.
* The original list was based on checking for calls to `_deprecated_parameter()`. The prelim sniff also checks the function signature for parameters named `$deprecated*`.
* Where parameters named `$deprecated` were detected without a call to `_deprecated_parameter()` and without a documented good reason not to have that call, the call to `_deprecated_parameter()` should be added and I have a WIP branch ready to add those.
* The "deprecation version" for some of the new additions wasn't always clear, but these have been verified by the Yoast WP Core team based on the above mentioned PR.

Previous: #2173

Also see: WordPress/wordpress-develop#4779