### PR TITLE
Update the `minimum_wp_version` to WP 6.0

### DIFF
--- a/WordPress/Helpers/MinimumWPVersionTrait.php
+++ b/WordPress/Helpers/MinimumWPVersionTrait.php
@@ -80,7 +80,7 @@ trait MinimumWPVersionTrait {
 	 *
 	 * @var string WordPress version.
 	 */
-	private $default_minimum_wp_version = '5.8';
+	private $default_minimum_wp_version = '6.0';
 
 	/**
 	 * Overrule the minimum supported WordPress version with a command-line/config value.

--- a/WordPress/Tests/WP/DeprecatedFunctionsUnitTest.inc
+++ b/WordPress/Tests/WP/DeprecatedFunctionsUnitTest.inc
@@ -354,16 +354,16 @@ wp_unregister_GLOBALS();
 noindex();
 wp_no_robots();
 wp_sensitive_page_meta();
-
-/*
- * Warning.
- */
 /* ============ WP 5.8 ============ */
 _excerpt_render_inner_columns_blocks();
 /* ============ WP 5.9 ============ */
 readonly();
 /* ============ WP 5.9.1 ============ */
 wp_render_duotone_filter_preset();
+
+/*
+ * Warning.
+ */
 /* ============ WP 6.0 ============ */
 image_attachment_fields_to_save();
 wp_add_iframed_editor_assets_html();

--- a/WordPress/Tests/WP/DeprecatedFunctionsUnitTest.php
+++ b/WordPress/Tests/WP/DeprecatedFunctionsUnitTest.php
@@ -30,7 +30,7 @@ final class DeprecatedFunctionsUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getErrorList() {
 		$start_line = 8;
-		$end_line   = 356;
+		$end_line   = 362;
 		$errors     = array_fill( $start_line, ( ( $end_line - $start_line ) + 1 ), 1 );
 
 		// Unset the lines related to version comments.
@@ -72,8 +72,16 @@ final class DeprecatedFunctionsUnitTest extends AbstractSniffUnitTest {
 			$errors[340],
 			$errors[344],
 			$errors[346],
-			$errors[353]
+			$errors[353],
+			$errors[357],
+			$errors[359],
+			$errors[361]
 		);
+
+		// Temporarily until PHPCS supports PHP 8.2.
+		if ( \PHP_VERSION_ID >= 80200 ) {
+			unset( $errors[360] ); // Function call to readonly.
+		}
 
 		return $errors;
 	}
@@ -84,26 +92,18 @@ final class DeprecatedFunctionsUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of warnings>
 	 */
 	public function getWarningList() {
-		$start_line = 362;
+		$start_line = 368;
 		$end_line   = 413;
 		$warnings   = array_fill( $start_line, ( ( $end_line - $start_line ) + 1 ), 1 );
 
 		// Unset the lines related to version comments.
 		unset(
-			$warnings[363],
-			$warnings[365],
-			$warnings[367],
 			$warnings[373],
 			$warnings[375],
 			$warnings[377],
 			$warnings[387],
 			$warnings[390]
 		);
-
-		// Temporarily until PHPCS supports PHP 8.2.
-		if ( \PHP_VERSION_ID >= 80200 ) {
-			unset( $warnings[364] ); // Function call to readonly.
-		}
 
 		return $warnings;
 	}

--- a/WordPress/Tests/WP/DeprecatedParametersUnitTest.inc
+++ b/WordPress/Tests/WP/DeprecatedParametersUnitTest.inc
@@ -40,6 +40,7 @@ wp_install( is_public: '', user_name: '', user_email: '', deprecated: 'should be
 // All will give an ERROR. The functions are ordered alphabetically.
 
 _future_post_hook( 10, $post );
+_load_remote_block_patterns( $value );
 _wp_post_revision_fields( $foo, 'deprecated' );
 add_option( '', '', [] );
 add_option( '', '', 1.23 );
@@ -95,5 +96,4 @@ wp_upload_bits( '', 'deprecated' );
 xfn_check( '', '', 'deprecated' );
 
 // All will give an WARNING as they have been deprecated after WP 5.8.
-_load_remote_block_patterns( $value );
 global_terms( $foo, 'deprecated' );

--- a/WordPress/Tests/WP/DeprecatedParametersUnitTest.php
+++ b/WordPress/Tests/WP/DeprecatedParametersUnitTest.php
@@ -30,7 +30,7 @@ final class DeprecatedParametersUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getErrorList() {
 		$start_line = 42;
-		$end_line   = 95;
+		$end_line   = 96;
 		$errors     = array_fill( $start_line, ( ( $end_line - $start_line ) + 1 ), 1 );
 
 		$errors[22] = 1;
@@ -41,8 +41,8 @@ final class DeprecatedParametersUnitTest extends AbstractSniffUnitTest {
 		$errors[38] = 1;
 
 		// Override number of errors.
-		$errors[49] = 2;
-		$errors[75] = 2;
+		$errors[50] = 2;
+		$errors[76] = 2;
 
 		return $errors;
 	}
@@ -53,7 +53,7 @@ final class DeprecatedParametersUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of warnings>
 	 */
 	public function getWarningList() {
-		$start_line = 98;
+		$start_line = 99;
 		$end_line   = 99;
 		$errors     = array_fill( $start_line, ( ( $end_line - $start_line ) + 1 ), 1 );
 


### PR DESCRIPTION
The minimum version should be three versions behind the latest WP release, so what with 6.3 being in RC, to be released on August 8th, it should now become 6.0.

Includes updating the tests to match.

Previous: #2121