### PR TITLE
.gitattributes: minor update

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,14 +4,14 @@
 # If you develop for WPCS using Composer, use `--prefer-source`.
 # https://blog.madewithlove.be/post/gitattributes/
 #
-/.gitattributes export-ignore
-/.gitignore export-ignore
-/.phpcs.xml.dist export-ignore
-/phpunit.xml.dist export-ignore
-/.github export-ignore
-/bin export-ignore
-/Tests export-ignore
-/WordPress/Tests export-ignore
+/.gitattributes     export-ignore
+/.gitignore         export-ignore
+/.phpcs.xml.dist    export-ignore
+/CODE_OF_CONDUCT.md export-ignore
+/phpunit.xml.dist   export-ignore
+/.github            export-ignore
+/Tests              export-ignore
+/WordPress/Tests    export-ignore
 
 #
 # Auto detect text files and perform LF normalization


### PR DESCRIPTION
Verified against the latest status of the repo (removed `bin` dir ref - follow up on #2126).

Includes improving readability.