### PR TITLE
Core/Extra: tweak the inclusion of the `Modernize.FunctionCalls.Dirname` sniff

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -50,6 +50,9 @@
 
 		<!-- Linting is done in a separate CI job, no need to duplicate it. -->
 		<exclude name="Generic.PHP.Syntax"/>
+
+		<!-- WPCS still has a PHP 5.4 minimum. -->
+		<exclude name="Modernize.FunctionCalls.Dirname"/>
 	</rule>
 
 	<!-- Check code for cross-version PHP compatibility. -->

--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -923,8 +923,9 @@
 	<!-- Check that class name references use the correct case. -->
 	<rule ref="WordPress.WP.ClassNameCase"/>
 
-	<!-- Check that __DIR__ is favoured over dirname(__FILE__).
+	<!-- Check that __DIR__ is favoured over dirname(__FILE__)
+		 and that dirname( __DIR__, $levels ) is favoured over nested calls to dirname().
 		 See: https://core.trac.wordpress.org/ticket/48082 -->
-	<rule ref="Modernize.FunctionCalls.Dirname.FileConstant"/>
+	<rule ref="Modernize.FunctionCalls.Dirname"/>
 
 </ruleset>

--- a/WordPress-Extra/ruleset.xml
+++ b/WordPress-Extra/ruleset.xml
@@ -5,6 +5,12 @@
 
 	<rule ref="WordPress-Core"/>
 
+	<!-- Silence the "no nested dirnames, use $levels" notice, which is included in Core,
+		 as plugin/themes may still support PHP < 7.0. -->
+	<rule ref="Modernize.FunctionCalls.Dirname.Nested">
+		<severity>0</severity>
+	</rule>
+
 	<!-- Generic PHP best practices.
 		 https://github.com/WordPress/WordPress-Coding-Standards/pull/382 -->
 	<rule ref="Generic.PHP.DeprecatedFunctions"/>


### PR DESCRIPTION
Follow up on #2137

As  WP Core has now dropped support for PHP < 7.0, it can start using the `dirname()` `$levels` parameters. Think:
```php
// PHP < 7.0.
$path = dirname( dirname( dirname( __DIR__ ) ) );

// PHP 7.0+.
$path = dirname( __DIR__, 3 );
```

The `Modernize.FunctionCalls.Dirname` sniff we include also includes a check (and fixer) for that, so we can now include that sniff completely in the `Core` ruleset.

For now, I'm proposing to silence the error code related to the PHP 7.0 modernization opportunity (again) for the `Extra` ruleset as not all plugins/themes will have dropped support for PHP < 7.0 yet.

To be on the safe side, I'm explicitly excluding the whole sniff from the ruleset used for WPCS itself as WPCS still has a PHP 5.4 minimum.
