### PR TITLE
Update various function lists

### DIFF
--- a/WordPress/Helpers/EscapingFunctionsTrait.php
+++ b/WordPress/Helpers/EscapingFunctionsTrait.php
@@ -71,6 +71,7 @@ trait EscapingFunctionsTrait {
 		'esc_textarea'               => true,
 		'esc_url_raw'                => true,
 		'esc_url'                    => true,
+		'esc_xml'                    => true,
 		'filter_input'               => true,
 		'filter_var'                 => true,
 		'floatval'                   => true,

--- a/WordPress/Helpers/EscapingFunctionsTrait.php
+++ b/WordPress/Helpers/EscapingFunctionsTrait.php
@@ -162,6 +162,7 @@ trait EscapingFunctionsTrait {
 		'wp_login_form'             => true,
 		'wp_loginout'               => true,
 		'wp_nav_menu'               => true,
+		'wp_readonly'               => true,
 		'wp_register'               => true,
 		'wp_tag_cloud'              => true,
 		'wp_timezone_choice'        => true,

--- a/WordPress/Helpers/EscapingFunctionsTrait.php
+++ b/WordPress/Helpers/EscapingFunctionsTrait.php
@@ -164,6 +164,7 @@ trait EscapingFunctionsTrait {
 		'wp_nav_menu'               => true,
 		'wp_register'               => true,
 		'wp_tag_cloud'              => true,
+		'wp_timezone_choice'        => true,
 		'wp_title'                  => true,
 	);
 

--- a/WordPress/Helpers/EscapingFunctionsTrait.php
+++ b/WordPress/Helpers/EscapingFunctionsTrait.php
@@ -92,6 +92,7 @@ trait EscapingFunctionsTrait {
 		'wp_json_encode'             => true,
 		'wp_kses_allowed_html'       => true,
 		'wp_kses_data'               => true,
+		'wp_kses_one_attr'           => true,
 		'wp_kses_post'               => true,
 		'wp_kses'                    => true,
 	);

--- a/WordPress/Helpers/SanitizingFunctionsTrait.php
+++ b/WordPress/Helpers/SanitizingFunctionsTrait.php
@@ -88,6 +88,7 @@ trait SanitizingFunctionsTrait {
 		'sanitize_title_for_query'   => true,
 		'sanitize_title_with_dashes' => true,
 		'sanitize_title'             => true,
+		'sanitize_url'               => true,
 		'sanitize_user_field'        => true,
 		'sanitize_user'              => true,
 		'validate_file'              => true,

--- a/WordPress/Helpers/SanitizingFunctionsTrait.php
+++ b/WordPress/Helpers/SanitizingFunctionsTrait.php
@@ -96,6 +96,7 @@ trait SanitizingFunctionsTrait {
 		'wp_handle_upload'           => true,
 		'wp_kses_allowed_html'       => true,
 		'wp_kses_data'               => true,
+		'wp_kses_one_attr'           => true,
 		'wp_kses_post'               => true,
 		'wp_kses'                    => true,
 		'wp_parse_id_list'           => true,


### PR DESCRIPTION
### EscapingFunctionsTrait: add esc_xml() to the list of escaping functions

This function was introduced in WP 5.5.

As it's been around for about three years now, I'm not going to special case it with a version check.

Ref: https://core.trac.wordpress.org/ticket/50117

Fixes #1937

### EscapingFunctionsTrait: add wp_timezone_choice() to the list of auto-escaped functions

This function was introduced in WP 2.9.0.

I've looked the code of the function over and agree it can be added to the auto-escaped functions list.

Ref: https://developer.wordpress.org/reference/functions/wp_timezone_choice/

Fixes #1904

### EscapingFunctionsTrait: add wp_readonly() to the list of auto-escaped functions

This function was added in WP 5.9 to replace the `readonly()` function as `readonly` became a reserved keyword in PHP 8.1 (though only partially to allow the WP community some time to catch up).

I'm leaving `readonly()` in the list. While it shouldn't be used anymore, if it is, it still is a valid auto-escaped function.

Ref: https://core.trac.wordpress.org/ticket/53858

### SanitizingFunctionsTrait: add sanitize_url() to the list of sanitization functions

This function was previously deprecated, but has been resurrected in WP 6.1.

Refs:
* https://core.trac.wordpress.org/ticket/55852
* WordPress/WordPress-Coding-Standards#2031
* WordPress/WordPress-Coding-Standards#2189

### [SanitizingFunctions|EscapingFunctions]Trait: add wp_kses_one_attr() to function lists

This function was introduced in WP 4.2.3.

I've done a cursory look-over of the code, but I have not gone down the rabbit-hole of examining all functions involved (and yes, `wp_kses_one_attr()` calls a _lot_ of functions under the hood).

Having said that, @anastis did do a more detailed analysis and included their write-up of it in the ticket, so I'm satisfied that this function can be added to the list.

Based on this write-up, I believe the function should be added to both the `$sanitizingFunctions` list as well as the `$escapingFunctions` list.

Refs:
* https://developer.wordpress.org/reference/functions/wp_kses_one_attr/
* WordPress/WordPress-Coding-Standards#1765#issuecomment-512192213

Fixes #1765