### PR TITLE
Composer: make PHP extension dependencies explicit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,9 @@
 	"require": {
 		"php": ">=5.4",
 		"ext-filter": "*",
+		"ext-libxml": "*",
+		"ext-tokenizer": "*",
+		"ext-xmlreader": "*",
 		"squizlabs/php_codesniffer": "^3.7.2",
 		"phpcsstandards/phpcsutils": "^1.0.8",
 		"phpcsstandards/phpcsextra": "^1.1.0"
@@ -30,6 +33,7 @@
 		"php-parallel-lint/php-console-highlighter": "^1.0.0"
 	},
 	"suggest": {
+		"ext-iconv": "For improved results",
 		"ext-mbstring": "For improved results"
 	},
 	"config": {


### PR DESCRIPTION
PR #1856, which was included in WPCS 2.3.0, introduced a check for strings wrapped in HTML in the `WordPress.WP.I18n` sniff. The underlying code for this check uses the PHP XMLReader extension unconditionally.

This means that the PHP [`XMLReader` extension](https://www.php.net/manual/en/xmlreader.installation.php) and `libxml` are hard requirements for WPCS, but this was not yet annotated as such in the `composer.json` `require` section.

Along the same lines, `iconv` is used conditionally in the `PrefixAllGlobals` sniff, so should be listed as `suggest`.

And well, the dependency on the Tokenizer extension should be obvious ;-)

Fixed now.

Checked using the ComposerRequireChecker tooling: https://github.com/maglnet/ComposerRequireChecker

Note: as this tool relies on an `autoload` requirement in the `composer.json` file, we cannot add it to CI as we use the PHPCS autoloader and should not have the `autoload` directive in our `composer.json` to prevent interference.