### PR TITLE
Docs: remove redundant `@package` tags

### DIFF
--- a/WordPress/AbstractArrayAssignmentRestrictionsSniff.php
+++ b/WordPress/AbstractArrayAssignmentRestrictionsSniff.php
@@ -20,13 +20,11 @@ use WordPressCS\WordPress\Sniff;
 /**
  * Restricts array assignment of certain keys.
  *
- * @package WPCS\WordPressCodingStandards
- *
- * @since   0.3.0
- * @since   0.10.0 Class became a proper abstract class. This was already the behaviour.
- *                 Moved the file and renamed the class from
- *                 `\WordPressCS\WordPress\Sniffs\Arrays\ArrayAssignmentRestrictionsSniff` to
- *                 `\WordPressCS\WordPress\AbstractArrayAssignmentRestrictionsSniff`.
+ * @since 0.3.0
+ * @since 0.10.0 Class became a proper abstract class. This was already the behaviour.
+ *               Moved the file and renamed the class from
+ *               `\WordPressCS\WordPress\Sniffs\Arrays\ArrayAssignmentRestrictionsSniff` to
+ *               `\WordPressCS\WordPress\AbstractArrayAssignmentRestrictionsSniff`.
  */
 abstract class AbstractArrayAssignmentRestrictionsSniff extends Sniff {
 

--- a/WordPress/AbstractClassRestrictionsSniff.php
+++ b/WordPress/AbstractClassRestrictionsSniff.php
@@ -19,9 +19,7 @@ use WordPressCS\WordPress\Helpers\RulesetPropertyHelper;
 /**
  * Restricts usage of some classes.
  *
- * @package WPCS\WordPressCodingStandards
- *
- * @since   0.10.0
+ * @since 0.10.0
  */
 abstract class AbstractClassRestrictionsSniff extends AbstractFunctionRestrictionsSniff {
 

--- a/WordPress/AbstractFunctionParameterSniff.php
+++ b/WordPress/AbstractFunctionParameterSniff.php
@@ -15,9 +15,7 @@ use WordPressCS\WordPress\AbstractFunctionRestrictionsSniff;
 /**
  * Advises about parameters used in function calls.
  *
- * @package WPCS\WordPressCodingStandards
- *
- * @since   0.11.0
+ * @since 0.11.0
  */
 abstract class AbstractFunctionParameterSniff extends AbstractFunctionRestrictionsSniff {
 

--- a/WordPress/AbstractFunctionRestrictionsSniff.php
+++ b/WordPress/AbstractFunctionRestrictionsSniff.php
@@ -19,14 +19,12 @@ use WordPressCS\WordPress\Sniff;
 /**
  * Restricts usage of some functions.
  *
- * @package WPCS\WordPressCodingStandards
- *
- * @since   0.3.0
- * @since   0.10.0 Class became a proper abstract class. This was already the behaviour.
- *                 Moved the file and renamed the class from
- *                 `\WordPressCS\WordPress\Sniffs\Functions\FunctionRestrictionsSniff` to
- *                 `\WordPressCS\WordPress\AbstractFunctionRestrictionsSniff`.
- * @since   0.11.0 Extends the WordPressCS native `Sniff` class.
+ * @since 0.3.0
+ * @since 0.10.0 Class became a proper abstract class. This was already the behaviour.
+ *               Moved the file and renamed the class from
+ *               `\WordPressCS\WordPress\Sniffs\Functions\FunctionRestrictionsSniff` to
+ *               `\WordPressCS\WordPress\AbstractFunctionRestrictionsSniff`.
+ * @since 0.11.0 Extends the WordPressCS native `Sniff` class.
  */
 abstract class AbstractFunctionRestrictionsSniff extends Sniff {
 

--- a/WordPress/Helpers/ArrayWalkingFunctionsHelper.php
+++ b/WordPress/Helpers/ArrayWalkingFunctionsHelper.php
@@ -15,9 +15,8 @@ use PHPCSUtils\Utils\PassedParameters;
 /**
  * Helper functions and function lists for checking whether a function applies a callback to an array.
  *
- * @package WPCS\WordPressCodingStandards
- * @since   3.0.0 The property in this class was previously contained in the
- *                `WordPressCS\WordPress\Sniff` class and has been moved here.
+ * @since 3.0.0 The property in this class was previously contained in the
+ *              `WordPressCS\WordPress\Sniff` class and has been moved here.
  */
 final class ArrayWalkingFunctionsHelper {
 

--- a/WordPress/Helpers/ConstantsHelper.php
+++ b/WordPress/Helpers/ConstantsHelper.php
@@ -28,9 +28,8 @@ use WordPressCS\WordPress\Helpers\ContextHelper;
  *
  * @internal
  *
- * @package WPCS\WordPressCodingStandards
- * @since   3.0.0 The method in this class was previously contained in the
- *                `WordPressCS\WordPress\Sniff` class and has been moved here.
+ * @since 3.0.0 The method in this class was previously contained in the
+ *              `WordPressCS\WordPress\Sniff` class and has been moved here.
  */
 final class ConstantsHelper {
 

--- a/WordPress/Helpers/ContextHelper.php
+++ b/WordPress/Helpers/ContextHelper.php
@@ -25,9 +25,8 @@ use PHPCSUtils\Utils\PassedParameters;
  *
  * @internal
  *
- * @package WPCS\WordPressCodingStandards
- * @since   3.0.0 The methods in this class were previously contained in the
- *                `WordPressCS\WordPress\Sniff` class and have been moved here.
+ * @since 3.0.0 The methods in this class were previously contained in the
+ *              `WordPressCS\WordPress\Sniff` class and have been moved here.
  */
 final class ContextHelper {
 

--- a/WordPress/Helpers/DeprecationHelper.php
+++ b/WordPress/Helpers/DeprecationHelper.php
@@ -25,9 +25,8 @@ use PHP_CodeSniffer\Util\Tokens;
  *
  * @internal
  *
- * @package WPCS\WordPressCodingStandards
- * @since   3.0.0 The method in this class was previously contained in the
- *                `WordPressCS\WordPress\Sniff` class and has been moved here.
+ * @since 3.0.0 The method in this class was previously contained in the
+ *              `WordPressCS\WordPress\Sniff` class and has been moved here.
  */
 final class DeprecationHelper {
 

--- a/WordPress/Helpers/EscapingFunctionsTrait.php
+++ b/WordPress/Helpers/EscapingFunctionsTrait.php
@@ -19,10 +19,9 @@ use WordPressCS\WordPress\Helpers\RulesetPropertyHelper;
  * - `customEscapingFunctions`.
  * - `customAutoEscapedFunctions`
  *
- * @package WPCS\WordPressCodingStandards
- * @since   3.0.0 The properties in this trait were previously contained partially in the
- *                `WordPressCS\WordPress\Sniff` class and partially in the `EscapeOutputSniff`
- *                class and have been moved here.
+ * @since 3.0.0 The properties in this trait were previously contained partially in the
+ *              `WordPressCS\WordPress\Sniff` class and partially in the `EscapeOutputSniff`
+ *              class and have been moved here.
  */
 trait EscapingFunctionsTrait {
 

--- a/WordPress/Helpers/FormattingFunctionsHelper.php
+++ b/WordPress/Helpers/FormattingFunctionsHelper.php
@@ -12,9 +12,8 @@ namespace WordPressCS\WordPress\Helpers;
 /**
  * Helper functions and function lists for checking whether a function is a formatting function.
  *
- * @package WPCS\WordPressCodingStandards
- * @since   3.0.0 The property in this class was previously contained in the
- *                `WordPressCS\WordPress\Sniff` class and has been moved here.
+ * @since 3.0.0 The property in this class was previously contained in the
+ *              `WordPressCS\WordPress\Sniff` class and has been moved here.
  */
 final class FormattingFunctionsHelper {
 

--- a/WordPress/Helpers/IsUnitTestTrait.php
+++ b/WordPress/Helpers/IsUnitTestTrait.php
@@ -26,9 +26,8 @@ use WordPressCS\WordPress\Helpers\RulesetPropertyHelper;
  * - The sniff can call the `is_test_class()` method in this trait to verify if a class is
  *   a test class. The `is_test_class()` method will take the custom property into account.
  *
- * @package WPCS\WordPressCodingStandards
- * @since   3.0.0 The properties and method in this trait were previously contained in the
- *                `WordPressCS\WordPress\Sniff` class and have been moved here.
+ * @since 3.0.0 The properties and method in this trait were previously contained in the
+ *              `WordPressCS\WordPress\Sniff` class and have been moved here.
  */
 trait IsUnitTestTrait {
 

--- a/WordPress/Helpers/ListHelper.php
+++ b/WordPress/Helpers/ListHelper.php
@@ -27,9 +27,8 @@ use PHPCSUtils\Utils\Lists;
  *
  * @internal
  *
- * @package WPCS\WordPressCodingStandards
- * @since   3.0.0 The method in this class was previously contained in the
- *                `WordPressCS\WordPress\Sniff` class and has been moved here.
+ * @since 3.0.0 The method in this class was previously contained in the
+ *              `WordPressCS\WordPress\Sniff` class and has been moved here.
  */
 final class ListHelper {
 

--- a/WordPress/Helpers/MinimumWPVersionTrait.php
+++ b/WordPress/Helpers/MinimumWPVersionTrait.php
@@ -22,9 +22,8 @@ use PHPCSUtils\BackCompat\Helper;
  * - After that, the `MinimumWPVersionTrait::$minimum_wp_version` property can be freely used
  *   in the sniff.
  *
- * @package WPCS\WordPressCodingStandards
- * @since   3.0.0 The property and method in this trait were previously contained in the
- *                `WordPressCS\WordPress\Sniff` class and have been moved here.
+ * @since 3.0.0 The property and method in this trait were previously contained in the
+ *              `WordPressCS\WordPress\Sniff` class and have been moved here.
  */
 trait MinimumWPVersionTrait {
 

--- a/WordPress/Helpers/PrintingFunctionsTrait.php
+++ b/WordPress/Helpers/PrintingFunctionsTrait.php
@@ -18,10 +18,9 @@ use WordPressCS\WordPress\Helpers\RulesetPropertyHelper;
  * following `public` property which can be changed from within a custom ruleset:
  * - `customPrintingFunctions`.
  *
- * @package WPCS\WordPressCodingStandards
- * @since   3.0.0 The properties in this trait were previously contained partially in the
- *                `WordPressCS\WordPress\Sniff` class and partially in the `EscapeOutputSniff`
- *                class and have been moved here.
+ * @since 3.0.0 The properties in this trait were previously contained partially in the
+ *              `WordPressCS\WordPress\Sniff` class and partially in the `EscapeOutputSniff`
+ *              class and have been moved here.
  */
 trait PrintingFunctionsTrait {
 

--- a/WordPress/Helpers/RulesetPropertyHelper.php
+++ b/WordPress/Helpers/RulesetPropertyHelper.php
@@ -19,9 +19,8 @@ namespace WordPressCS\WordPress\Helpers;
  *
  * @internal
  *
- * @package WPCS\WordPressCodingStandards
- * @since   3.0.0 The method in this class was previously contained in the
- *                `WordPressCS\WordPress\Sniff` class and has been moved here.
+ * @since 3.0.0 The method in this class was previously contained in the
+ *              `WordPressCS\WordPress\Sniff` class and has been moved here.
  */
 final class RulesetPropertyHelper {
 

--- a/WordPress/Helpers/SanitizingFunctionsTrait.php
+++ b/WordPress/Helpers/SanitizingFunctionsTrait.php
@@ -19,10 +19,9 @@ use WordPressCS\WordPress\Helpers\RulesetPropertyHelper;
  * - `customSanitizingFunctions`.
  * - `customUnslashingSanitizingFunctions`
  *
- * @package WPCS\WordPressCodingStandards
- * @since   3.0.0 The properties in this trait were previously contained partially in the
- *                `WordPressCS\WordPress\Sniff` class and partially in the `NonceVerificationSniff`
- *                and the `ValidatedSanitizedInputSniff` classes and have been moved here.
+ * @since 3.0.0 The properties in this trait were previously contained partially in the
+ *              `WordPressCS\WordPress\Sniff` class and partially in the `NonceVerificationSniff`
+ *              and the `ValidatedSanitizedInputSniff` classes and have been moved here.
  */
 trait SanitizingFunctionsTrait {
 

--- a/WordPress/Helpers/SnakeCaseHelper.php
+++ b/WordPress/Helpers/SnakeCaseHelper.php
@@ -24,9 +24,8 @@ use PHPCSUtils\BackCompat\Helper;
  *
  * @internal
  *
- * @package WPCS\WordPressCodingStandards
- * @since   3.0.0 The method in this class was previously contained in the
- *                `WordPressCS\WordPress\Sniff` class and has been moved here.
+ * @since 3.0.0 The method in this class was previously contained in the
+ *              `WordPressCS\WordPress\Sniff` class and has been moved here.
  */
 final class SnakeCaseHelper {
 

--- a/WordPress/Helpers/UnslashingFunctionsHelper.php
+++ b/WordPress/Helpers/UnslashingFunctionsHelper.php
@@ -12,9 +12,8 @@ namespace WordPressCS\WordPress\Helpers;
 /**
  * Helper functions and function lists for checking whether a function is an unslashing function.
  *
- * @package WPCS\WordPressCodingStandards
- * @since   3.0.0 The property in this class was previously contained in the
- *                `WordPressCS\WordPress\Sniff` class and has been moved here.
+ * @since 3.0.0 The property in this class was previously contained in the
+ *              `WordPressCS\WordPress\Sniff` class and has been moved here.
  */
 final class UnslashingFunctionsHelper {
 

--- a/WordPress/Helpers/ValidationHelper.php
+++ b/WordPress/Helpers/ValidationHelper.php
@@ -21,9 +21,8 @@ use WordPressCS\WordPress\Helpers\VariableHelper;
 /**
  * Helper function for checking whether a token is validated.
  *
- * @package WPCS\WordPressCodingStandards
- * @since   3.0.0 The method in this class was previously contained in the
- *                `WordPressCS\WordPress\Sniff` class and has been moved here.
+ * @since 3.0.0 The method in this class was previously contained in the
+ *              `WordPressCS\WordPress\Sniff` class and has been moved here.
  */
 final class ValidationHelper {
 

--- a/WordPress/Helpers/VariableHelper.php
+++ b/WordPress/Helpers/VariableHelper.php
@@ -27,9 +27,8 @@ use PHPCSUtils\Utils\Parentheses;
  *
  * @internal
  *
- * @package WPCS\WordPressCodingStandards
- * @since   3.0.0 The methods in this class were previously contained in the
- *                `WordPressCS\WordPress\Sniff` class and have been moved here.
+ * @since 3.0.0 The methods in this class were previously contained in the
+ *              `WordPressCS\WordPress\Sniff` class and have been moved here.
  */
 final class VariableHelper {
 

--- a/WordPress/Helpers/WPDBTrait.php
+++ b/WordPress/Helpers/WPDBTrait.php
@@ -17,10 +17,8 @@ use PHPCSUtils\Tokens\Collections;
 /**
  * Helper utilities for sniffs which examine WPDB method calls.
  *
- * @package WPCS\WordPressCodingStandards
- *
- * @since   3.0.0 The method in this trait was previously contained in the
- *                `WordPressCS\WordPress\Sniff` class and has been moved here.
+ * @since 3.0.0 The method in this trait was previously contained in the
+ *              `WordPressCS\WordPress\Sniff` class and has been moved here.
  */
 trait WPDBTrait {
 

--- a/WordPress/Helpers/WPGlobalVariablesHelper.php
+++ b/WordPress/Helpers/WPGlobalVariablesHelper.php
@@ -12,9 +12,8 @@ namespace WordPressCS\WordPress\Helpers;
 /**
  * Helper utilities for recognizing WP global variables.
  *
- * @package WPCS\WordPressCodingStandards
- * @since   3.0.0 The property in this class was previously contained in the
- *                `WordPressCS\WordPress\Sniff` class and has been moved here.
+ * @since 3.0.0 The property in this class was previously contained in the
+ *              `WordPressCS\WordPress\Sniff` class and has been moved here.
  */
 final class WPGlobalVariablesHelper {
 

--- a/WordPress/Helpers/WPHookHelper.php
+++ b/WordPress/Helpers/WPHookHelper.php
@@ -14,9 +14,8 @@ use PHPCSUtils\Utils\PassedParameters;
 /**
  * Helper utilities for recognizing functions related to the WP Hook mechanism.
  *
- * @package WPCS\WordPressCodingStandards
- * @since   3.0.0 The property in this class was previously contained in the
- *                `WordPressCS\WordPress\Sniff` class and has been moved here.
+ * @since 3.0.0 The property in this class was previously contained in the
+ *              `WordPressCS\WordPress\Sniff` class and has been moved here.
  */
 final class WPHookHelper {
 

--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -23,8 +23,7 @@ use WordPressCS\WordPress\Helpers\UnslashingFunctionsHelper;
  *
  * Provides a bootstrap for the sniffs, to reduce code duplication.
  *
- * @package WPCS\WordPressCodingStandards
- * @since   0.4.0
+ * @since 0.4.0
  */
 abstract class Sniff implements PHPCS_Sniff {
 

--- a/WordPress/Sniffs/Arrays/ArrayDeclarationSpacingSniff.php
+++ b/WordPress/Sniffs/Arrays/ArrayDeclarationSpacingSniff.php
@@ -22,24 +22,22 @@ use PHPCSUtils\Utils\PassedParameters;
  * - Checks that associative arrays are multi-line.
  * - Checks that each array item in a multi-line array starts on a new line.
  *
- * @link    https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#indentation
+ * @link https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#indentation
  *
- * @package WPCS\WordPressCodingStandards
- *
- * @since   0.11.0 - The WordPress specific additional checks have now been split off
- *                   from the `WordPress.Arrays.ArrayDeclaration` sniff into this sniff.
- *                 - Added sniffing & fixing for associative arrays.
- * @since   0.12.0 Decoupled this sniff from the upstream sniff completely.
- *                 This sniff now extends the WordPressCS native `Sniff` class instead.
- * @since   0.13.0 Added the last remaining checks from the `WordPress.Arrays.ArrayDeclaration`
- *                 sniff which were not covered elsewhere.
- *                 The `WordPress.Arrays.ArrayDeclaration` sniff has now been deprecated.
- * @since   0.13.0 Class name changed: this class is now namespaced.
- * @since   0.14.0 Single item associative arrays are now by default exempt from the
- *                 "must be multi-line" rule. This behaviour can be changed using the
- *                 `allow_single_item_single_line_associative_arrays` property.
- * @since   3.0.0  Removed various whitespace related checks and fixers in favour of the PHPCSExtra
- *                 `NormalizedArrays.Arrays.ArrayBraceSpacing` sniff.
+ * @since 0.11.0 - The WordPress specific additional checks have now been split off
+ *                 from the `WordPress.Arrays.ArrayDeclaration` sniff into this sniff.
+ *               - Added sniffing & fixing for associative arrays.
+ * @since 0.12.0 Decoupled this sniff from the upstream sniff completely.
+ *               This sniff now extends the WordPressCS native `Sniff` class instead.
+ * @since 0.13.0 Added the last remaining checks from the `WordPress.Arrays.ArrayDeclaration`
+ *               sniff which were not covered elsewhere.
+ *               The `WordPress.Arrays.ArrayDeclaration` sniff has now been deprecated.
+ * @since 0.13.0 Class name changed: this class is now namespaced.
+ * @since 0.14.0 Single item associative arrays are now by default exempt from the
+ *               "must be multi-line" rule. This behaviour can be changed using the
+ *               `allow_single_item_single_line_associative_arrays` property.
+ * @since 3.0.0  Removed various whitespace related checks and fixers in favour of the PHPCSExtra
+ *               `NormalizedArrays.Arrays.ArrayBraceSpacing` sniff.
  */
 final class ArrayDeclarationSpacingSniff extends Sniff {
 

--- a/WordPress/Sniffs/Arrays/ArrayIndentationSniff.php
+++ b/WordPress/Sniffs/Arrays/ArrayIndentationSniff.php
@@ -19,12 +19,10 @@ use PHPCSUtils\Utils\PassedParameters;
 /**
  * Enforces WordPress array indentation for multi-line arrays.
  *
- * @link    https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#indentation
+ * @link https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#indentation
  *
- * @package WPCS\WordPressCodingStandards
- *
- * @since   0.12.0
- * @since   0.13.0 Class name changed: this class is now namespaced.
+ * @since 0.12.0
+ * @since 0.13.0 Class name changed: this class is now namespaced.
  *
  * {@internal This sniff should eventually be pulled upstream as part of a solution
  * for https://github.com/squizlabs/PHP_CodeSniffer/issues/582 }}

--- a/WordPress/Sniffs/Arrays/ArrayKeySpacingRestrictionsSniff.php
+++ b/WordPress/Sniffs/Arrays/ArrayKeySpacingRestrictionsSniff.php
@@ -15,15 +15,13 @@ use WordPressCS\WordPress\Sniff;
 /**
  * Check for proper spacing in array key references.
  *
- * @link    https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#space-usage
+ * @link https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#space-usage
  *
- * @package WPCS\WordPressCodingStandards
- *
- * @since   0.3.0
- * @since   0.7.0  This sniff now has the ability to fix a number of the issues it flags.
- * @since   0.12.0 This class now extends the WordPressCS native `Sniff` class.
- * @since   0.13.0 Class name changed: this class is now namespaced.
- * @since   2.2.0  The sniff now also checks the size of the spacing, if applicable.
+ * @since 0.3.0
+ * @since 0.7.0  This sniff now has the ability to fix a number of the issues it flags.
+ * @since 0.12.0 This class now extends the WordPressCS native `Sniff` class.
+ * @since 0.13.0 Class name changed: this class is now namespaced.
+ * @since 2.2.0  The sniff now also checks the size of the spacing, if applicable.
  */
 final class ArrayKeySpacingRestrictionsSniff extends Sniff {
 

--- a/WordPress/Sniffs/Arrays/MultipleStatementAlignmentSniff.php
+++ b/WordPress/Sniffs/Arrays/MultipleStatementAlignmentSniff.php
@@ -22,11 +22,9 @@ use WordPressCS\WordPress\Sniff;
  * - Allows for new line(s) before a double arrow (configurable).
  * - Allows for handling multi-line array items differently if so desired (configurable).
  *
- * @link    https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#indentation
+ * @link https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#indentation
  *
- * @package WPCS\WordPressCodingStandards
- *
- * @since   0.14.0
+ * @since 0.14.0
  *
  * {@internal This sniff should eventually be pulled upstream as part of a solution
  * for https://github.com/squizlabs/PHP_CodeSniffer/issues/582 }}

--- a/WordPress/Sniffs/CodeAnalysis/AssignmentInTernaryConditionSniff.php
+++ b/WordPress/Sniffs/CodeAnalysis/AssignmentInTernaryConditionSniff.php
@@ -21,12 +21,10 @@ use WordPressCS\WordPress\Sniff;
  *
  * Note: this sniff does not detect variable assignments in ternaries without parentheses!
  *
- * @package WPCS\WordPressCodingStandards
- *
- * @since   0.14.0
- * @since   3.0.0  - The generic "assignment in condition" logic has been removed from the sniff
- *                   in favour of the upstream `Generic.CodeAnalysis.AssignmentInCondition` sniff.
- *                 - The sniff has been renamed from `AssignmentInCondition` to `AssignmentInTernaryCondition`.
+ * @since 0.14.0
+ * @since 3.0.0  - The generic "assignment in condition" logic has been removed from the sniff
+ *                 in favour of the upstream `Generic.CodeAnalysis.AssignmentInCondition` sniff.
+ *               - The sniff has been renamed from `AssignmentInCondition` to `AssignmentInTernaryCondition`.
  *
  * @link https://github.com/squizlabs/PHP_CodeSniffer/pull/1594 Upstream sniff.
  */

--- a/WordPress/Sniffs/CodeAnalysis/EscapedNotTranslatedSniff.php
+++ b/WordPress/Sniffs/CodeAnalysis/EscapedNotTranslatedSniff.php
@@ -18,9 +18,7 @@ use PHPCSUtils\Utils\GetTokensAsString;
  * as calls to the "translate + escape" sister-function due to the presence of
  * more than one parameter.
  *
- * @package WPCS\WordPressCodingStandards
- *
- * @since   2.2.0
+ * @since 2.2.0
  */
 final class EscapedNotTranslatedSniff extends AbstractFunctionParameterSniff {
 

--- a/WordPress/Sniffs/DB/DirectDatabaseQuerySniff.php
+++ b/WordPress/Sniffs/DB/DirectDatabaseQuerySniff.php
@@ -19,16 +19,14 @@ use WordPressCS\WordPress\Sniff;
 /**
  * Flag Database direct queries.
  *
- * @link    https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/#direct-database-queries
+ * @link https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/#direct-database-queries
  *
- * @package WPCS\WordPressCodingStandards
- *
- * @since   0.3.0
- * @since   0.6.0  Removed the add_unique_message() function as it is no longer needed.
- * @since   0.11.0 This class now extends the WordPressCS native `Sniff` class.
- * @since   0.13.0 Class name changed: this class is now namespaced.
- * @since   1.0.0  This sniff has been moved from the `VIP` category to the `DB` category.
- * @since   3.0.0  Support for the very sniff specific WPCS native ignore comment syntax has been removed.
+ * @since 0.3.0
+ * @since 0.6.0  Removed the add_unique_message() function as it is no longer needed.
+ * @since 0.11.0 This class now extends the WordPressCS native `Sniff` class.
+ * @since 0.13.0 Class name changed: this class is now namespaced.
+ * @since 1.0.0  This sniff has been moved from the `VIP` category to the `DB` category.
+ * @since 3.0.0  Support for the very sniff specific WPCS native ignore comment syntax has been removed.
  */
 final class DirectDatabaseQuerySniff extends Sniff {
 

--- a/WordPress/Sniffs/DB/PreparedSQLPlaceholdersSniff.php
+++ b/WordPress/Sniffs/DB/PreparedSQLPlaceholdersSniff.php
@@ -44,12 +44,10 @@ use WordPressCS\WordPress\Sniff;
  * @link https://core.trac.wordpress.org/changeset/41471
  * @link https://core.trac.wordpress.org/changeset/55151
  *
- * @package WPCS\WordPressCodingStandards
- *
  * @since 0.14.0
  * @since 3.0.0 Support for the %i placeholder has been added
  *
- * @uses  \WordPressCS\WordPress\Helpers\MinimumWPVersionTrait::$minimum_wp_version
+ * @uses \WordPressCS\WordPress\Helpers\MinimumWPVersionTrait::$minimum_wp_version
  */
 final class PreparedSQLPlaceholdersSniff extends Sniff {
 

--- a/WordPress/Sniffs/DB/PreparedSQLSniff.php
+++ b/WordPress/Sniffs/DB/PreparedSQLSniff.php
@@ -22,13 +22,11 @@ use WordPressCS\WordPress\Sniff;
  *
  * Makes sure that variables aren't directly interpolated into SQL statements.
  *
- * @link    https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#formatting-sql-statements
+ * @link https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#formatting-sql-statements
  *
- * @package WPCS\WordPressCodingStandards
- *
- * @since   0.8.0
- * @since   0.13.0 Class name changed: this class is now namespaced.
- * @since   1.0.0  This sniff has been moved from the `WP` category to the `DB` category.
+ * @since 0.8.0
+ * @since 0.13.0 Class name changed: this class is now namespaced.
+ * @since 1.0.0  This sniff has been moved from the `WP` category to the `DB` category.
  */
 final class PreparedSQLSniff extends Sniff {
 

--- a/WordPress/Sniffs/DB/RestrictedClassesSniff.php
+++ b/WordPress/Sniffs/DB/RestrictedClassesSniff.php
@@ -19,12 +19,10 @@ use WordPressCS\WordPress\AbstractClassRestrictionsSniff;
  *  helps keep your code forward-compatible and, in cases where results are cached in memory,
  *  it can be many times faster."
  *
- * @link    https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#database-queries
+ * @link https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#database-queries
  *
- * @package WPCS\WordPressCodingStandards
- *
- * @since   0.10.0
- * @since   0.13.0 Class name changed: this class is now namespaced.
+ * @since 0.10.0
+ * @since 0.13.0 Class name changed: this class is now namespaced.
  */
 final class RestrictedClassesSniff extends AbstractClassRestrictionsSniff {
 

--- a/WordPress/Sniffs/DB/RestrictedFunctionsSniff.php
+++ b/WordPress/Sniffs/DB/RestrictedFunctionsSniff.php
@@ -19,12 +19,10 @@ use WordPressCS\WordPress\AbstractFunctionRestrictionsSniff;
  *  helps keep your code forward-compatible and, in cases where results are cached in memory,
  *  it can be many times faster."
  *
- * @link    https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#database-queries
+ * @link https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#database-queries
  *
- * @package WPCS\WordPressCodingStandards
- *
- * @since   0.10.0
- * @since   0.13.0 Class name changed: this class is now namespaced.
+ * @since 0.10.0
+ * @since 0.13.0 Class name changed: this class is now namespaced.
  */
 final class RestrictedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 

--- a/WordPress/Sniffs/DB/SlowDBQuerySniff.php
+++ b/WordPress/Sniffs/DB/SlowDBQuerySniff.php
@@ -14,13 +14,11 @@ use WordPressCS\WordPress\AbstractArrayAssignmentRestrictionsSniff;
 /**
  * Flag potentially slow queries.
  *
- * @link    https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/#uncached-pageload
+ * @link https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/#uncached-pageload
  *
- * @package WPCS\WordPressCodingStandards
- *
- * @since   0.3.0
- * @since   0.13.0 Class name changed: this class is now namespaced.
- * @since   1.0.0  This sniff has been moved from the `VIP` category to the `DB` category.
+ * @since 0.3.0
+ * @since 0.13.0 Class name changed: this class is now namespaced.
+ * @since 1.0.0  This sniff has been moved from the `VIP` category to the `DB` category.
  */
 final class SlowDBQuerySniff extends AbstractArrayAssignmentRestrictionsSniff {
 

--- a/WordPress/Sniffs/DateTime/CurrentTimeTimestampSniff.php
+++ b/WordPress/Sniffs/DateTime/CurrentTimeTimestampSniff.php
@@ -26,9 +26,7 @@ use WordPressCS\WordPress\AbstractFunctionParameterSniff;
  * @link https://core.trac.wordpress.org/ticket/40657
  * @link https://github.com/WordPress/WordPress-Coding-Standards/issues/1791
  *
- * @package WPCS\WordPressCodingStandards
- *
- * @since   2.2.0
+ * @since 2.2.0
  */
 final class CurrentTimeTimestampSniff extends AbstractFunctionParameterSniff {
 

--- a/WordPress/Sniffs/DateTime/RestrictedFunctionsSniff.php
+++ b/WordPress/Sniffs/DateTime/RestrictedFunctionsSniff.php
@@ -14,8 +14,6 @@ use WordPressCS\WordPress\AbstractFunctionRestrictionsSniff;
 /**
  * Forbids the use of various native DateTime related PHP/WP functions and suggests alternatives.
  *
- * @package WPCS\WordPressCodingStandards
- *
  * @since 2.2.0
  */
 final class RestrictedFunctionsSniff extends AbstractFunctionRestrictionsSniff {

--- a/WordPress/Sniffs/Files/FileNameSniff.php
+++ b/WordPress/Sniffs/Files/FileNameSniff.php
@@ -18,22 +18,20 @@ use WordPressCS\WordPress\Helpers\IsUnitTestTrait;
 /**
  * Ensures filenames do not contain underscores and where applicable are prefixed with `class-`.
  *
- * @link    https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#naming-conventions
+ * @link https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#naming-conventions
  *
- * @package WPCS\WordPressCodingStandards
+ * @since 0.1.0
+ * @since 0.11.0 - This sniff will now also check for all lowercase file names.
+ *               - This sniff will now also verify that files containing a class start with `class-`.
+ *               - This sniff will now also verify that files in `wp-includes` containing
+ *                 template tags end in `-template`. Based on @subpackage file DocBlock tag.
+ *               - This sniff will now allow for underscores in file names for certain theme
+ *                 specific exceptions if the `$is_theme` property is set to `true`.
+ * @since 0.12.0 Now extends the WordPressCS native `Sniff` class.
+ * @since 0.13.0 Class name changed: this class is now namespaced.
+ * @since 3.0.0  Test class files are now completely exempt from this rule.
  *
- * @since   0.1.0
- * @since   0.11.0 - This sniff will now also check for all lowercase file names.
- *                 - This sniff will now also verify that files containing a class start with `class-`.
- *                 - This sniff will now also verify that files in `wp-includes` containing
- *                   template tags end in `-template`. Based on @subpackage file DocBlock tag.
- *                 - This sniff will now allow for underscores in file names for certain theme
- *                   specific exceptions if the `$is_theme` property is set to `true`.
- * @since   0.12.0 Now extends the WordPressCS native `Sniff` class.
- * @since   0.13.0 Class name changed: this class is now namespaced.
- * @since   3.0.0  Test class files are now completely exempt from this rule.
- *
- * @uses    \WordPressCS\WordPress\Helpers\IsUnitTestTrait::$custom_test_classes
+ * @uses \WordPressCS\WordPress\Helpers\IsUnitTestTrait::$custom_test_classes
  */
 final class FileNameSniff extends Sniff {
 

--- a/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
+++ b/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
@@ -36,15 +36,13 @@ use WordPressCS\WordPress\Helpers\WPHookHelper;
 /**
  * Verify that everything defined in the global namespace is prefixed with a theme/plugin specific prefix.
  *
- * @package WPCS\WordPressCodingStandards
+ * @since 0.12.0
+ * @since 0.13.0 Class name changed: this class is now namespaced.
+ * @since 1.2.0  Now also checks whether namespaces are prefixed.
+ * @since 2.2.0  - Now also checks variables assigned via the list() construct.
+ *               - Now also ignores global functions which are marked as @deprecated.
  *
- * @since   0.12.0
- * @since   0.13.0 Class name changed: this class is now namespaced.
- * @since   1.2.0  Now also checks whether namespaces are prefixed.
- * @since   2.2.0  - Now also checks variables assigned via the list() construct.
- *                 - Now also ignores global functions which are marked as @deprecated.
- *
- * @uses    \WordPressCS\WordPress\Helpers\IsUnitTestTrait::$custom_test_classes
+ * @uses \WordPressCS\WordPress\Helpers\IsUnitTestTrait::$custom_test_classes
  */
 final class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 

--- a/WordPress/Sniffs/NamingConventions/ValidFunctionNameSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidFunctionNameSniff.php
@@ -21,17 +21,15 @@ use WordPressCS\WordPress\Sniff;
 /**
  * Enforces WordPress function name and method name format, based upon Squiz code.
  *
- * @link    https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#naming-conventions
+ * @link https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#naming-conventions
  *
- * @package WPCS\WordPressCodingStandards
- *
- * @since   0.1.0
- * @since   0.13.0 Class name changed: this class is now namespaced.
- * @since   2.0.0  The `get_name_suggestion()` method has been moved to the
- *                 WordPress native `Sniff` base class as `get_snake_case_name_suggestion()`.
- * @since   2.2.0  Will now ignore functions and methods which are marked as @deprecated.
- * @since   3.0.0  This sniff has been refactored and no longer extends the upstream
- *                 PEAR.NamingConventions.ValidFunctionName sniff.
+ * @since 0.1.0
+ * @since 0.13.0 Class name changed: this class is now namespaced.
+ * @since 2.0.0  The `get_name_suggestion()` method has been moved to the
+ *               WordPress native `Sniff` base class as `get_snake_case_name_suggestion()`.
+ * @since 2.2.0  Will now ignore functions and methods which are marked as @deprecated.
+ * @since 3.0.0  This sniff has been refactored and no longer extends the upstream
+ *               PEAR.NamingConventions.ValidFunctionName sniff.
  */
 final class ValidFunctionNameSniff extends Sniff {
 

--- a/WordPress/Sniffs/NamingConventions/ValidHookNameSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidHookNameSniff.php
@@ -22,13 +22,11 @@ use WordPressCS\WordPress\Helpers\WPHookHelper;
  *
  * Hook names invoked with `do_action_deprecated()` and `apply_filters_deprecated()` are ignored.
  *
- * @link    https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#naming-conventions
+ * @link https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#naming-conventions
  *
- * @package WPCS\WordPressCodingStandards
- *
- * @since   0.10.0
- * @since   0.11.0 Extends the WordPressCS native `AbstractFunctionParameterSniff` class.
- * @since   0.13.0 Class name changed: this class is now namespaced.
+ * @since 0.10.0
+ * @since 0.11.0 Extends the WordPressCS native `AbstractFunctionParameterSniff` class.
+ * @since 0.13.0 Class name changed: this class is now namespaced.
  */
 class ValidHookNameSniff extends AbstractFunctionParameterSniff {
 

--- a/WordPress/Sniffs/NamingConventions/ValidPostTypeSlugSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidPostTypeSlugSniff.php
@@ -23,8 +23,6 @@ use WordPressCS\WordPress\AbstractFunctionParameterSniff;
  *
  * @link https://developer.wordpress.org/reference/functions/register_post_type/
  *
- * @package WPCS\WordPressCodingStandards
- *
  * @since 2.2.0
  */
 final class ValidPostTypeSlugSniff extends AbstractFunctionParameterSniff {

--- a/WordPress/Sniffs/NamingConventions/ValidVariableNameSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidVariableNameSniff.php
@@ -22,16 +22,14 @@ use WordPressCS\WordPress\Helpers\SnakeCaseHelper;
 /**
  * Checks the naming of variables and member variables.
  *
- * @link    https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#naming-conventions
+ * @link https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#naming-conventions
  *
- * @package WPCS\WordPressCodingStandards
- *
- * @since   0.9.0
- * @since   0.13.0 Class name changed: this class is now namespaced.
- * @since   2.0.0  Now offers name suggestions for variables in violation.
+ * @since 0.9.0
+ * @since 0.13.0 Class name changed: this class is now namespaced.
+ * @since 2.0.0  Now offers name suggestions for variables in violation.
  *
  * Last synced with base class January 2022 at commit 4b49a952bf0e2c3863d0a113256bae0d7fe63d52.
- * @link    https://github.com/squizlabs/PHP_CodeSniffer/blob/master/src/Standards/Squiz/Sniffs/NamingConventions/ValidVariableNameSniff.php
+ * @link https://github.com/squizlabs/PHP_CodeSniffer/blob/master/src/Standards/Squiz/Sniffs/NamingConventions/ValidVariableNameSniff.php
  */
 final class ValidVariableNameSniff extends PHPCS_AbstractVariableSniff {
 

--- a/WordPress/Sniffs/PHP/DevelopmentFunctionsSniff.php
+++ b/WordPress/Sniffs/PHP/DevelopmentFunctionsSniff.php
@@ -14,10 +14,8 @@ use WordPressCS\WordPress\AbstractFunctionRestrictionsSniff;
 /**
  * Restrict the use of various development functions.
  *
- * @package WPCS\WordPressCodingStandards
- *
- * @since   0.11.0
- * @since   0.13.0 Class name changed: this class is now namespaced.
+ * @since 0.11.0
+ * @since 0.13.0 Class name changed: this class is now namespaced.
  */
 final class DevelopmentFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 

--- a/WordPress/Sniffs/PHP/DiscouragedPHPFunctionsSniff.php
+++ b/WordPress/Sniffs/PHP/DiscouragedPHPFunctionsSniff.php
@@ -14,11 +14,9 @@ use WordPressCS\WordPress\AbstractFunctionRestrictionsSniff;
 /**
  * Discourages the use of various native PHP functions and suggests alternatives.
  *
- * @package WPCS\WordPressCodingStandards
- *
- * @since   0.11.0
- * @since   0.13.0 Class name changed: this class is now namespaced.
- * @since   0.14.0 `create_function` was moved to the PHP.RestrictedFunctions sniff.
+ * @since 0.11.0
+ * @since 0.13.0 Class name changed: this class is now namespaced.
+ * @since 0.14.0 `create_function` was moved to the PHP.RestrictedFunctions sniff.
  */
 final class DiscouragedPHPFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 

--- a/WordPress/Sniffs/PHP/DontExtractSniff.php
+++ b/WordPress/Sniffs/PHP/DontExtractSniff.php
@@ -14,14 +14,12 @@ use WordPressCS\WordPress\AbstractFunctionRestrictionsSniff;
 /**
  * Restricts the usage of extract().
  *
- * @link    https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#dont-extract
+ * @link https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#dont-extract
  *
- * @package WPCS\WordPressCodingStandards
- *
- * @since   0.10.0 Previously this check was contained within the
- *                 `WordPress.VIP.RestrictedFunctions` sniff.
- * @since   0.13.0 Class name changed: this class is now namespaced.
- * @since   1.0.0  This sniff has been moved from the `Functions` category to the `PHP` category.
+ * @since 0.10.0 Previously this check was contained within the
+ *               `WordPress.VIP.RestrictedFunctions` sniff.
+ * @since 0.13.0 Class name changed: this class is now namespaced.
+ * @since 1.0.0  This sniff has been moved from the `Functions` category to the `PHP` category.
  */
 final class DontExtractSniff extends AbstractFunctionRestrictionsSniff {
 

--- a/WordPress/Sniffs/PHP/IniSetSniff.php
+++ b/WordPress/Sniffs/PHP/IniSetSniff.php
@@ -21,8 +21,6 @@ use WordPressCS\WordPress\AbstractFunctionParameterSniff;
  * - Throws errors for ini directives listed in the disallow-list.
  * - A warning will be thrown in all other cases.
  *
- * @package WPCS\WordPressCodingStandards
- *
  * @since 2.1.0
  */
 final class IniSetSniff extends AbstractFunctionParameterSniff {

--- a/WordPress/Sniffs/PHP/NoSilencedErrorsSniff.php
+++ b/WordPress/Sniffs/PHP/NoSilencedErrorsSniff.php
@@ -22,9 +22,7 @@ use WordPressCS\WordPress\Sniff;
  * of functions, as no amount of error checking can prevent
  * PHP from throwing errors when those functions are used.
  *
- * @package WPCS\WordPressCodingStandards
- *
- * @since   1.1.0
+ * @since 1.1.0
  */
 final class NoSilencedErrorsSniff extends Sniff {
 

--- a/WordPress/Sniffs/PHP/POSIXFunctionsSniff.php
+++ b/WordPress/Sniffs/PHP/POSIXFunctionsSniff.php
@@ -15,15 +15,13 @@ use WordPressCS\WordPress\AbstractFunctionRestrictionsSniff;
  * Perl compatible regular expressions (PCRE, preg_ functions) should be used in preference
  * to their POSIX counterparts.
  *
- * @link    https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#regular-expressions
- * @link    https://php-legacy-docs.zend.com/manual/php5/en/ref.regex
+ * @link https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#regular-expressions
+ * @link https://php-legacy-docs.zend.com/manual/php5/en/ref.regex
  *
- * @package WPCS\WordPressCodingStandards
- *
- * @since   0.10.0 Previously this check was contained within the
- *                 `WordPress.VIP.RestrictedFunctions` and the
- *                 `WordPress.PHP.DiscouragedPHPFunctions` sniffs.
- * @since   0.13.0 Class name changed: this class is now namespaced.
+ * @since 0.10.0 Previously this check was contained within the
+ *               `WordPress.VIP.RestrictedFunctions` and the
+ *               `WordPress.PHP.DiscouragedPHPFunctions` sniffs.
+ * @since 0.13.0 Class name changed: this class is now namespaced.
  */
 final class POSIXFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 

--- a/WordPress/Sniffs/PHP/PregQuoteDelimiterSniff.php
+++ b/WordPress/Sniffs/PHP/PregQuoteDelimiterSniff.php
@@ -15,9 +15,7 @@ use WordPressCS\WordPress\AbstractFunctionParameterSniff;
 /**
  * Flag calling preg_quote() without the second ($delimiter) parameter.
  *
- * @package WPCS\WordPressCodingStandards
- *
- * @since   1.0.0
+ * @since 1.0.0
  */
 final class PregQuoteDelimiterSniff extends AbstractFunctionParameterSniff {
 

--- a/WordPress/Sniffs/PHP/RestrictedPHPFunctionsSniff.php
+++ b/WordPress/Sniffs/PHP/RestrictedPHPFunctionsSniff.php
@@ -14,9 +14,7 @@ use WordPressCS\WordPress\AbstractFunctionRestrictionsSniff;
 /**
  * Forbids the use of various native PHP functions and suggests alternatives.
  *
- * @package WPCS\WordPressCodingStandards
- *
- * @since   0.14.0
+ * @since 0.14.0
  */
 final class RestrictedPHPFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 

--- a/WordPress/Sniffs/PHP/StrictInArraySniff.php
+++ b/WordPress/Sniffs/PHP/StrictInArraySniff.php
@@ -15,15 +15,13 @@ use WordPressCS\WordPress\AbstractFunctionParameterSniff;
 /**
  * Flag calling in_array(), array_search() and array_keys() without true as the third parameter.
  *
- * @package WPCS\WordPressCodingStandards
- *
- * @since   0.9.0
- * @since   0.10.0 - This sniff not only checks for `in_array()`, but also `array_search()`
- *                   and `array_keys()`.
- *                 - The sniff no longer needlessly extends the `ArrayAssignmentRestrictionsSniff`
- *                   class which it didn't use.
- * @since   0.11.0 Refactored to extend the new WordPressCS native `AbstractFunctionParameterSniff` class.
- * @since   0.13.0 Class name changed: this class is now namespaced.
+ * @since 0.9.0
+ * @since 0.10.0 - This sniff not only checks for `in_array()`, but also `array_search()`
+ *                 and `array_keys()`.
+ *               - The sniff no longer needlessly extends the `ArrayAssignmentRestrictionsSniff`
+ *                 class which it didn't use.
+ * @since 0.11.0 Refactored to extend the new WordPressCS native `AbstractFunctionParameterSniff` class.
+ * @since 0.13.0 Class name changed: this class is now namespaced.
  */
 final class StrictInArraySniff extends AbstractFunctionParameterSniff {
 

--- a/WordPress/Sniffs/PHP/TypeCastsSniff.php
+++ b/WordPress/Sniffs/PHP/TypeCastsSniff.php
@@ -19,13 +19,11 @@ use WordPressCS\WordPress\Sniff;
  *
  * Additionally, the use of the (unset) and (binary) casts is discouraged.
  *
- * @link    https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#space-usage
+ * @link https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#space-usage
  *
- * @package WPCS\WordPressCodingStandards
- *
- * @since   1.2.0
- * @since   2.0.0 No longer checks that type casts are lowercase or short form.
- *                Relevant PHPCS native sniffs have been included in the rulesets instead.
+ * @since 1.2.0
+ * @since 2.0.0 No longer checks that type casts are lowercase or short form.
+ *              Relevant PHPCS native sniffs have been included in the rulesets instead.
  */
 final class TypeCastsSniff extends Sniff {
 

--- a/WordPress/Sniffs/PHP/YodaConditionsSniff.php
+++ b/WordPress/Sniffs/PHP/YodaConditionsSniff.php
@@ -16,13 +16,11 @@ use PHPCSUtils\Tokens\Collections;
 /**
  * Enforces Yoda conditional statements.
  *
- * @link    https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#yoda-conditions
+ * @link https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#yoda-conditions
  *
- * @package WPCS\WordPressCodingStandards
- *
- * @since   0.3.0
- * @since   0.12.0 This class now extends the WordPressCS native `Sniff` class.
- * @since   0.13.0 Class name changed: this class is now namespaced.
+ * @since 0.3.0
+ * @since 0.12.0 This class now extends the WordPressCS native `Sniff` class.
+ * @since 0.13.0 Class name changed: this class is now namespaced.
  */
 final class YodaConditionsSniff extends Sniff {
 

--- a/WordPress/Sniffs/Security/EscapeOutputSniff.php
+++ b/WordPress/Sniffs/Security/EscapeOutputSniff.php
@@ -29,25 +29,23 @@ use WordPressCS\WordPress\Helpers\VariableHelper;
 /**
  * Verifies that all outputted strings are escaped.
  *
- * @link    https://developer.wordpress.org/apis/security/data-validation/ WordPress Developer Docs on Data Validation.
+ * @link https://developer.wordpress.org/apis/security/data-validation/ WordPress Developer Docs on Data Validation.
  *
- * @package WPCS\WordPressCodingStandards
+ * @since 2013-06-11
+ * @since 0.4.0  This class now extends the WordPressCS native `Sniff` class.
+ * @since 0.5.0  The various function list properties which used to be contained in this class
+ *               have been moved to the WordPressCS native `Sniff` parent class.
+ * @since 0.12.0 This sniff will now also check for output escaping when using shorthand
+ *               echo tags `<?=`.
+ * @since 0.13.0 Class name changed: this class is now namespaced.
+ * @since 1.0.0  This sniff has been moved from the `XSS` category to the `Security` category.
+ * @since 3.0.0  This class now extends the WordPressCS native
+ *               `AbstractFunctionRestrictionsSniff` class.
+ *               The parent `exclude` property is disabled.
  *
- * @since   2013-06-11
- * @since   0.4.0  This class now extends the WordPressCS native `Sniff` class.
- * @since   0.5.0  The various function list properties which used to be contained in this class
- *                 have been moved to the WordPressCS native `Sniff` parent class.
- * @since   0.12.0 This sniff will now also check for output escaping when using shorthand
- *                 echo tags `<?=`.
- * @since   0.13.0 Class name changed: this class is now namespaced.
- * @since   1.0.0  This sniff has been moved from the `XSS` category to the `Security` category.
- * @since   3.0.0  This class now extends the WordPressCS native
- *                 `AbstractFunctionRestrictionsSniff` class.
- *                 The parent `exclude` property is disabled.
- *
- * @uses    \WordPressCS\WordPress\Helpers\EscapingFunctionsTrait::$customEscapingFunctions
- * @uses    \WordPressCS\WordPress\Helpers\EscapingFunctionsTrait::$customAutoEscapedFunctions
- * @uses    \WordPressCS\WordPress\Helpers\PrintingFunctionsTrait::$customPrintingFunctions
+ * @uses \WordPressCS\WordPress\Helpers\EscapingFunctionsTrait::$customEscapingFunctions
+ * @uses \WordPressCS\WordPress\Helpers\EscapingFunctionsTrait::$customAutoEscapedFunctions
+ * @uses \WordPressCS\WordPress\Helpers\PrintingFunctionsTrait::$customPrintingFunctions
  */
 class EscapeOutputSniff extends AbstractFunctionRestrictionsSniff {
 

--- a/WordPress/Sniffs/Security/NonceVerificationSniff.php
+++ b/WordPress/Sniffs/Security/NonceVerificationSniff.php
@@ -24,17 +24,15 @@ use WordPressCS\WordPress\Sniff;
 /**
  * Checks that nonce verification accompanies form processing.
  *
- * @link    https://developer.wordpress.org/plugins/security/nonces/ Nonces on Plugin Developer Handbook
+ * @link https://developer.wordpress.org/plugins/security/nonces/ Nonces on Plugin Developer Handbook
  *
- * @package WPCS\WordPressCodingStandards
+ * @since 0.5.0
+ * @since 0.13.0 Class name changed: this class is now namespaced.
+ * @since 1.0.0  This sniff has been moved from the `CSRF` category to the `Security` category.
+ * @since 3.0.0  This sniff has received significant updates to its logic and structure.
  *
- * @since   0.5.0
- * @since   0.13.0 Class name changed: this class is now namespaced.
- * @since   1.0.0  This sniff has been moved from the `CSRF` category to the `Security` category.
- * @since   3.0.0  This sniff has received significant updates to its logic and structure.
- *
- * @uses    \WordPressCS\WordPress\Helpers\SanitizingFunctionsTrait::$customSanitizingFunctions
- * @uses    \WordPressCS\WordPress\Helpers\SanitizingFunctionsTrait::$customUnslashingSanitizingFunctions
+ * @uses \WordPressCS\WordPress\Helpers\SanitizingFunctionsTrait::$customSanitizingFunctions
+ * @uses \WordPressCS\WordPress\Helpers\SanitizingFunctionsTrait::$customUnslashingSanitizingFunctions
  */
 class NonceVerificationSniff extends Sniff {
 

--- a/WordPress/Sniffs/Security/PluginMenuSlugSniff.php
+++ b/WordPress/Sniffs/Security/PluginMenuSlugSniff.php
@@ -15,15 +15,13 @@ use WordPressCS\WordPress\AbstractFunctionParameterSniff;
 /**
  * Warn about __FILE__ for page registration.
  *
- * @link    https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/#using-__file__-for-page-registration
+ * @link https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/#using-__file__-for-page-registration
  *
- * @package WPCS\WordPressCodingStandards
- *
- * @since   0.3.0
- * @since   0.11.0 Refactored to extend the new WordPressCS native
- *                 `AbstractFunctionParameterSniff` class.
- * @since   0.13.0 Class name changed: this class is now namespaced.
- * @since   1.0.0  This sniff has been moved from the `VIP` category to the `Security` category.
+ * @since 0.3.0
+ * @since 0.11.0 Refactored to extend the new WordPressCS native
+ *               `AbstractFunctionParameterSniff` class.
+ * @since 0.13.0 Class name changed: this class is now namespaced.
+ * @since 1.0.0  This sniff has been moved from the `VIP` category to the `Security` category.
  */
 final class PluginMenuSlugSniff extends AbstractFunctionParameterSniff {
 

--- a/WordPress/Sniffs/Security/SafeRedirectSniff.php
+++ b/WordPress/Sniffs/Security/SafeRedirectSniff.php
@@ -14,9 +14,7 @@ use WordPressCS\WordPress\AbstractFunctionRestrictionsSniff;
 /**
  * Encourages use of wp_safe_redirect() to avoid open redirect vulnerabilities.
  *
- * @package WPCS\WordPressCodingStandards
- *
- * @since   1.0.0
+ * @since 1.0.0
  */
 final class SafeRedirectSniff extends AbstractFunctionRestrictionsSniff {
 

--- a/WordPress/Sniffs/Security/ValidatedSanitizedInputSniff.php
+++ b/WordPress/Sniffs/Security/ValidatedSanitizedInputSniff.php
@@ -19,18 +19,16 @@ use WordPressCS\WordPress\Sniff;
 /**
  * Flag any non-validated/sanitized input ( _GET / _POST / etc. ).
  *
- * @link    https://github.com/WordPress/WordPress-Coding-Standards/issues/69
+ * @link https://github.com/WordPress/WordPress-Coding-Standards/issues/69
  *
- * @package WPCS\WordPressCodingStandards
+ * @since 0.3.0
+ * @since 0.4.0  This class now extends the WordPressCS native `Sniff` class.
+ * @since 0.5.0  Method getArrayIndexKey() has been moved to the WordPressCS native `Sniff` class.
+ * @since 0.13.0 Class name changed: this class is now namespaced.
+ * @since 1.0.0  This sniff has been moved from the `VIP` category to the `Security` category.
  *
- * @since   0.3.0
- * @since   0.4.0  This class now extends the WordPressCS native `Sniff` class.
- * @since   0.5.0  Method getArrayIndexKey() has been moved to the WordPressCS native `Sniff` class.
- * @since   0.13.0 Class name changed: this class is now namespaced.
- * @since   1.0.0  This sniff has been moved from the `VIP` category to the `Security` category.
- *
- * @uses    \WordPressCS\WordPress\Helpers\SanitizingFunctionsTrait::$customSanitizingFunctions
- * @uses    \WordPressCS\WordPress\Helpers\SanitizingFunctionsTrait::$customUnslashingSanitizingFunctions
+ * @uses \WordPressCS\WordPress\Helpers\SanitizingFunctionsTrait::$customSanitizingFunctions
+ * @uses \WordPressCS\WordPress\Helpers\SanitizingFunctionsTrait::$customUnslashingSanitizingFunctions
  */
 class ValidatedSanitizedInputSniff extends Sniff {
 

--- a/WordPress/Sniffs/Utils/I18nTextDomainFixerSniff.php
+++ b/WordPress/Sniffs/Utils/I18nTextDomainFixerSniff.php
@@ -25,9 +25,7 @@ use WordPressCS\WordPress\Helpers\RulesetPropertyHelper;
  *
  * Note: Without a user-defined configuration in a custom ruleset, this sniff will be ignored.
  *
- * @package WPCS\WordPressCodingStandards
- *
- * @since   1.2.0
+ * @since 1.2.0
  */
 final class I18nTextDomainFixerSniff extends AbstractFunctionParameterSniff {
 

--- a/WordPress/Sniffs/WP/AlternativeFunctionsSniff.php
+++ b/WordPress/Sniffs/WP/AlternativeFunctionsSniff.php
@@ -17,14 +17,12 @@ use WordPressCS\WordPress\Helpers\MinimumWPVersionTrait;
 /**
  * Discourages the use of various functions and suggests (WordPress) alternatives.
  *
- * @package WPCS\WordPressCodingStandards
+ * @since 0.11.0
+ * @since 0.13.0 Class name changed: this class is now namespaced.
+ * @since 1.0.0  - Takes the minimum supported WP version into account.
+ *               - Takes exceptions based on passed parameters into account.
  *
- * @since   0.11.0
- * @since   0.13.0 Class name changed: this class is now namespaced.
- * @since   1.0.0  - Takes the minimum supported WP version into account.
- *                 - Takes exceptions based on passed parameters into account.
- *
- * @uses    \WordPressCS\WordPress\Helpers\MinimumWPVersionTrait::$minimum_wp_version
+ * @uses \WordPressCS\WordPress\Helpers\MinimumWPVersionTrait::$minimum_wp_version
  */
 final class AlternativeFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 

--- a/WordPress/Sniffs/WP/CapabilitiesSniff.php
+++ b/WordPress/Sniffs/WP/CapabilitiesSniff.php
@@ -22,11 +22,9 @@ use WordPressCS\WordPress\Helpers\RulesetPropertyHelper;
  *
  * User capabilities should be used, not roles or deprecated capabilities.
  *
- * @package WPCS\WordPressCodingStandards
+ * @since 3.0.0
  *
- * @since   3.0.0
- *
- * @uses    \WordPressCS\WordPress\Helpers\MinimumWPVersionTrait::$minimum_wp_version
+ * @uses \WordPressCS\WordPress\Helpers\MinimumWPVersionTrait::$minimum_wp_version
  */
 final class CapabilitiesSniff extends AbstractFunctionParameterSniff {
 

--- a/WordPress/Sniffs/WP/CapitalPDangitSniff.php
+++ b/WordPress/Sniffs/WP/CapitalPDangitSniff.php
@@ -21,11 +21,9 @@ use WordPressCS\WordPress\Sniff;
  *
  * Verify the correct spelling of `WordPress` in text strings, comments and OO and namespace names.
  *
- * @package WPCS\WordPressCodingStandards
- *
- * @since   0.12.0
- * @since   0.13.0 Class name changed: this class is now namespaced.
- * @since   3.0.0  Now also checks namespace names.
+ * @since 0.12.0
+ * @since 0.13.0 Class name changed: this class is now namespaced.
+ * @since 3.0.0  Now also checks namespace names.
  */
 final class CapitalPDangitSniff extends Sniff {
 

--- a/WordPress/Sniffs/WP/ClassNameCaseSniff.php
+++ b/WordPress/Sniffs/WP/ClassNameCaseSniff.php
@@ -14,8 +14,6 @@ use WordPressCS\WordPress\AbstractClassRestrictionsSniff;
 /**
  * Verify whether references to WP native classes use the proper casing for the class name.
  *
- * @package WPCS\WordPressCodingStandards
- *
  * @since 3.0.0
  */
 final class ClassNameCaseSniff extends AbstractClassRestrictionsSniff {

--- a/WordPress/Sniffs/WP/CronIntervalSniff.php
+++ b/WordPress/Sniffs/WP/CronIntervalSniff.php
@@ -22,16 +22,14 @@ use WordPressCS\WordPress\Sniff;
 /**
  * Flag cron schedules less than 15 minutes.
  *
- * @link    https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/#cron-schedules-less-than-15-minutes-or-expensive-events
+ * @link https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/#cron-schedules-less-than-15-minutes-or-expensive-events
  *
- * @package WPCS\WordPressCodingStandards
- *
- * @since   0.3.0
- * @since   0.11.0 - Extends the WordPressCS native `Sniff` class.
- *                 - Now deals correctly with WP time constants.
- * @since   0.13.0 Class name changed: this class is now namespaced.
- * @since   0.14.0 The minimum cron interval tested against is now configurable.
- * @since   1.0.0  This sniff has been moved from the `VIP` category to the `WP` category.
+ * @since 0.3.0
+ * @since 0.11.0 - Extends the WordPressCS native `Sniff` class.
+ *               - Now deals correctly with WP time constants.
+ * @since 0.13.0 Class name changed: this class is now namespaced.
+ * @since 0.14.0 The minimum cron interval tested against is now configurable.
+ * @since 1.0.0  This sniff has been moved from the `VIP` category to the `WP` category.
  */
 final class CronIntervalSniff extends Sniff {
 

--- a/WordPress/Sniffs/WP/DeprecatedClassesSniff.php
+++ b/WordPress/Sniffs/WP/DeprecatedClassesSniff.php
@@ -22,15 +22,13 @@ use WordPressCS\WordPress\Helpers\MinimumWPVersionTrait;
  * By default, it is set to presume that a project will support the current
  * WP version and up to three releases before.
  *
- * @package WPCS\WordPressCodingStandards
+ * @since 0.12.0
+ * @since 0.13.0 Class name changed: this class is now namespaced.
+ * @since 0.14.0 Now has the ability to handle minimum supported WP version
+ *               being provided via the command-line or as as <config> value
+ *               in a custom ruleset.
  *
- * @since   0.12.0
- * @since   0.13.0 Class name changed: this class is now namespaced.
- * @since   0.14.0 Now has the ability to handle minimum supported WP version
- *                 being provided via the command-line or as as <config> value
- *                 in a custom ruleset.
- *
- * @uses    \WordPressCS\WordPress\Helpers\MinimumWPVersionTrait::$minimum_wp_version
+ * @uses \WordPressCS\WordPress\Helpers\MinimumWPVersionTrait::$minimum_wp_version
  */
 final class DeprecatedClassesSniff extends AbstractClassRestrictionsSniff {
 

--- a/WordPress/Sniffs/WP/DeprecatedFunctionsSniff.php
+++ b/WordPress/Sniffs/WP/DeprecatedFunctionsSniff.php
@@ -22,15 +22,13 @@ use WordPressCS\WordPress\Helpers\MinimumWPVersionTrait;
  * By default, it is set to presume that a project will support the current
  * WP version and up to three releases before.
  *
- * @package WPCS\WordPressCodingStandards
+ * @since 0.11.0
+ * @since 0.13.0 Class name changed: this class is now namespaced.
+ * @since 0.14.0 Now has the ability to handle minimum supported WP version
+ *               being provided via the command-line or as as <config> value
+ *               in a custom ruleset.
  *
- * @since   0.11.0
- * @since   0.13.0 Class name changed: this class is now namespaced.
- * @since   0.14.0 Now has the ability to handle minimum supported WP version
- *                 being provided via the command-line or as as <config> value
- *                 in a custom ruleset.
- *
- * @uses    \WordPressCS\WordPress\Helpers\MinimumWPVersionTrait::$minimum_wp_version
+ * @uses \WordPressCS\WordPress\Helpers\MinimumWPVersionTrait::$minimum_wp_version
  */
 final class DeprecatedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 

--- a/WordPress/Sniffs/WP/DeprecatedParameterValuesSniff.php
+++ b/WordPress/Sniffs/WP/DeprecatedParameterValuesSniff.php
@@ -19,11 +19,9 @@ use WordPressCS\WordPress\Helpers\MinimumWPVersionTrait;
 /**
  * Check for usage of deprecated parameter values in WP functions and provide alternative based on the parameter passed.
  *
- * @package WPCS\WordPressCodingStandards
+ * @since 1.0.0
  *
- * @since   1.0.0
- *
- * @uses    \WordPressCS\WordPress\Helpers\MinimumWPVersionTrait::$minimum_wp_version
+ * @uses \WordPressCS\WordPress\Helpers\MinimumWPVersionTrait::$minimum_wp_version
  */
 final class DeprecatedParameterValuesSniff extends AbstractFunctionParameterSniff {
 

--- a/WordPress/Sniffs/WP/DeprecatedParametersSniff.php
+++ b/WordPress/Sniffs/WP/DeprecatedParametersSniff.php
@@ -24,15 +24,13 @@ use WordPressCS\WordPress\Helpers\MinimumWPVersionTrait;
  * By default, it is set to presume that a project will support the current
  * WP version and up to three releases before.
  *
- * @package WPCS\WordPressCodingStandards
+ * @since 0.12.0
+ * @since 0.13.0 Class name changed: this class is now namespaced.
+ * @since 0.14.0 Now has the ability to handle minimum supported WP version
+ *               being provided via the command-line or as as <config> value
+ *               in a custom ruleset.
  *
- * @since   0.12.0
- * @since   0.13.0 Class name changed: this class is now namespaced.
- * @since   0.14.0 Now has the ability to handle minimum supported WP version
- *                 being provided via the command-line or as as <config> value
- *                 in a custom ruleset.
- *
- * @uses    \WordPressCS\WordPress\Helpers\MinimumWPVersionTrait::$minimum_wp_version
+ * @uses \WordPressCS\WordPress\Helpers\MinimumWPVersionTrait::$minimum_wp_version
  */
 final class DeprecatedParametersSniff extends AbstractFunctionParameterSniff {
 

--- a/WordPress/Sniffs/WP/DiscouragedConstantsSniff.php
+++ b/WordPress/Sniffs/WP/DiscouragedConstantsSniff.php
@@ -19,9 +19,7 @@ use WordPressCS\WordPress\Helpers\ConstantsHelper;
 /**
  * Warns against usage of discouraged WP CONSTANTS and recommends alternatives.
  *
- * @package WPCS\WordPressCodingStandards
- *
- * @since   0.14.0
+ * @since 0.14.0
  */
 final class DiscouragedConstantsSniff extends AbstractFunctionParameterSniff {
 

--- a/WordPress/Sniffs/WP/DiscouragedFunctionsSniff.php
+++ b/WordPress/Sniffs/WP/DiscouragedFunctionsSniff.php
@@ -14,10 +14,8 @@ use WordPressCS\WordPress\AbstractFunctionRestrictionsSniff;
 /**
  * Discourages the use of various WordPress functions and suggests alternatives.
  *
- * @package WPCS\WordPressCodingStandards
- *
- * @since   0.11.0
- * @since   0.13.0 Class name changed: this class is now namespaced.
+ * @since 0.11.0
+ * @since 0.13.0 Class name changed: this class is now namespaced.
  */
 final class DiscouragedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 

--- a/WordPress/Sniffs/WP/EnqueuedResourceParametersSniff.php
+++ b/WordPress/Sniffs/WP/EnqueuedResourceParametersSniff.php
@@ -25,8 +25,6 @@ use WordPressCS\WordPress\AbstractFunctionParameterSniff;
  * @link https://developer.wordpress.org/reference/functions/wp_register_style/
  * @link https://developer.wordpress.org/reference/functions/wp_enqueue_style/
  *
- * @package WPCS\WordPressCodingStandards
- *
  * @since 1.0.0
  */
 final class EnqueuedResourceParametersSniff extends AbstractFunctionParameterSniff {

--- a/WordPress/Sniffs/WP/EnqueuedResourcesSniff.php
+++ b/WordPress/Sniffs/WP/EnqueuedResourcesSniff.php
@@ -18,13 +18,11 @@ use WordPressCS\WordPress\Sniff;
 /**
  * Makes sure scripts and styles are enqueued and not explicitly echo'd.
  *
- * @link    https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/#inline-resources
+ * @link https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/#inline-resources
  *
- * @package WPCS\WordPressCodingStandards
- *
- * @since   0.3.0
- * @since   0.12.0 This class now extends the WordPressCS native `Sniff` class.
- * @since   0.13.0 Class name changed: this class is now namespaced.
+ * @since 0.3.0
+ * @since 0.12.0 This class now extends the WordPressCS native `Sniff` class.
+ * @since 0.13.0 Class name changed: this class is now namespaced.
  */
 final class EnqueuedResourcesSniff extends Sniff {
 

--- a/WordPress/Sniffs/WP/GlobalVariablesOverrideSniff.php
+++ b/WordPress/Sniffs/WP/GlobalVariablesOverrideSniff.php
@@ -27,18 +27,16 @@ use WordPressCS\WordPress\Sniff;
 /**
  * Warns about overwriting WordPress native global variables.
  *
- * @package WPCS\WordPressCodingStandards
+ * @since 0.3.0
+ * @since 0.4.0  This class now extends the WordPressCS native `Sniff` class.
+ * @since 0.12.0 The $wp_globals property has been moved to the `Sniff` class.
+ * @since 0.13.0 Class name changed: this class is now namespaced.
+ * @since 1.0.0  This sniff has been moved from the `Variables` category to the `WP`
+ *               category and renamed from `GlobalVariables` to `GlobalVariablesOverride`.
+ * @since 1.1.0  The sniff now also detects variables being overriden in the global namespace.
+ * @since 2.2.0  The sniff now also detects variable assignments via the list() construct.
  *
- * @since   0.3.0
- * @since   0.4.0  This class now extends the WordPressCS native `Sniff` class.
- * @since   0.12.0 The $wp_globals property has been moved to the `Sniff` class.
- * @since   0.13.0 Class name changed: this class is now namespaced.
- * @since   1.0.0  This sniff has been moved from the `Variables` category to the `WP`
- *                 category and renamed from `GlobalVariables` to `GlobalVariablesOverride`.
- * @since   1.1.0  The sniff now also detects variables being overriden in the global namespace.
- * @since   2.2.0  The sniff now also detects variable assignments via the list() construct.
- *
- * @uses    \WordPressCS\WordPress\Helpers\IsUnitTestTrait::$custom_test_classes
+ * @uses \WordPressCS\WordPress\Helpers\IsUnitTestTrait::$custom_test_classes
  */
 final class GlobalVariablesOverrideSniff extends Sniff {
 

--- a/WordPress/Sniffs/WP/I18nSniff.php
+++ b/WordPress/Sniffs/WP/I18nSniff.php
@@ -21,24 +21,22 @@ use WordPressCS\WordPress\Helpers\RulesetPropertyHelper;
 /**
  * Makes sure WP internationalization functions are used properly.
  *
- * @link    https://make.wordpress.org/core/handbook/best-practices/internationalization/
- * @link    https://developer.wordpress.org/plugins/internationalization/
+ * @link https://make.wordpress.org/core/handbook/best-practices/internationalization/
+ * @link https://developer.wordpress.org/plugins/internationalization/
  *
- * @package WPCS\WordPressCodingStandards
- *
- * @since   0.10.0
- * @since   0.11.0 - Now also checks for translators comments.
- *                 - Now has the ability to handle text domain set via the command-line
- *                   as a comma-delimited list.
- *                   `phpcs --runtime-set text_domain my-slug,default`
- * @since   0.13.0 Class name changed: this class is now namespaced.
- * @since   1.0.0  This class now extends the WordPressCS native
- *                 `AbstractFunctionRestrictionSniff` class.
- *                 The parent `exclude` property is, however, disabled as it
- *                 would disable the whole sniff.
- * @since   3.0.0  This class now extends the WordPressCS native
- *                 `AbstractFunctionParameterSniff` class.
- *                 The parent `exclude` property is still disabled.
+ * @since 0.10.0
+ * @since 0.11.0 - Now also checks for translators comments.
+ *               - Now has the ability to handle text domain set via the command-line
+ *                 as a comma-delimited list.
+ *                 `phpcs --runtime-set text_domain my-slug,default`
+ * @since 0.13.0 Class name changed: this class is now namespaced.
+ * @since 1.0.0  This class now extends the WordPressCS native
+ *               `AbstractFunctionRestrictionSniff` class.
+ *               The parent `exclude` property is, however, disabled as it
+ *               would disable the whole sniff.
+ * @since 3.0.0  This class now extends the WordPressCS native
+ *               `AbstractFunctionParameterSniff` class.
+ *               The parent `exclude` property is still disabled.
  */
 final class I18nSniff extends AbstractFunctionParameterSniff {
 

--- a/WordPress/Sniffs/WP/PostsPerPageSniff.php
+++ b/WordPress/Sniffs/WP/PostsPerPageSniff.php
@@ -16,16 +16,14 @@ use WordPressCS\WordPress\AbstractArrayAssignmentRestrictionsSniff;
 /**
  * Flag returning high or infinite posts_per_page.
  *
- * @link    https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/#no-limit-queries
+ * @link https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/#no-limit-queries
  *
- * @package WPCS\WordPressCodingStandards
- *
- * @since   0.3.0
- * @since   0.13.0 Class name changed: this class is now namespaced.
- * @since   0.14.0 Added the posts_per_page property.
- * @since   1.0.0  This sniff has been split into two, with the check for high pagination
- *                 limit being part of the WP category, and the check for pagination
- *                 disabling being part of the VIP category.
+ * @since 0.3.0
+ * @since 0.13.0 Class name changed: this class is now namespaced.
+ * @since 0.14.0 Added the posts_per_page property.
+ * @since 1.0.0  This sniff has been split into two, with the check for high pagination
+ *               limit being part of the WP category, and the check for pagination
+ *               disabling being part of the VIP category.
  */
 final class PostsPerPageSniff extends AbstractArrayAssignmentRestrictionsSniff {
 

--- a/WordPress/Sniffs/WhiteSpace/CastStructureSpacingSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/CastStructureSpacingSniff.php
@@ -15,18 +15,16 @@ use PHP_CodeSniffer\Util\Tokens;
 /**
  * Ensure cast statements are preceded by whitespace.
  *
- * @link    https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#space-usage
+ * @link https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#space-usage
  *
- * @package WPCS\WordPressCodingStandards
- *
- * @since   0.3.0
- * @since   0.11.0 This sniff now has the ability to fix the issues it flags.
- * @since   0.11.0 The error level for all errors thrown by this sniff has been raised from warning to error.
- * @since   0.12.0 This class now extends the WordPressCS native `Sniff` class.
- * @since   0.13.0 Class name changed: this class is now namespaced.
- * @since   1.2.0  Removed the `NoSpaceAfterCloseParenthesis` error code in favour of the
- *                 upstream `Generic.Formatting.SpaceAfterCast.NoSpace` error.
- * @since   2.2.0  Added exception for whitespace between spread operator and cast.
+ * @since 0.3.0
+ * @since 0.11.0 This sniff now has the ability to fix the issues it flags.
+ * @since 0.11.0 The error level for all errors thrown by this sniff has been raised from warning to error.
+ * @since 0.12.0 This class now extends the WordPressCS native `Sniff` class.
+ * @since 0.13.0 Class name changed: this class is now namespaced.
+ * @since 1.2.0  Removed the `NoSpaceAfterCloseParenthesis` error code in favour of the
+ *               upstream `Generic.Formatting.SpaceAfterCast.NoSpace` error.
+ * @since 2.2.0  Added exception for whitespace between spread operator and cast.
  */
 final class CastStructureSpacingSniff extends Sniff {
 

--- a/WordPress/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
@@ -15,19 +15,17 @@ use PHP_CodeSniffer\Util\Tokens;
 /**
  * Enforces spacing around logical operators and assignments, based upon Squiz code.
  *
- * @package WPCS\WordPressCodingStandards
- *
- * @since   0.1.0
- * @since   2013-06-11 This sniff no longer supports JS.
- * @since   0.3.0      This sniff now has the ability to fix most errors it flags.
- * @since   0.7.0      This class now extends the WordPressCS native `Sniff` class.
- * @since   0.13.0     Class name changed: this class is now namespaced.
- * @since   3.0.0      Checks related to function declarations have been removed from this sniff.
+ * @since 0.1.0
+ * @since 2013-06-11 This sniff no longer supports JS.
+ * @since 0.3.0      This sniff now has the ability to fix most errors it flags.
+ * @since 0.7.0      This class now extends the WordPressCS native `Sniff` class.
+ * @since 0.13.0     Class name changed: this class is now namespaced.
+ * @since 3.0.0      Checks related to function declarations have been removed from this sniff.
  *
  * Last synced with base class 2017-01-15 at commit b024ad84656c37ef5733c6998ebc1e60957b2277.
  * Note: This class has diverged quite far from the original. All the same, checking occasionally
  * to see if there are upstream fixes made from which this sniff can benefit, is warranted.
- * @link    https://github.com/squizlabs/PHP_CodeSniffer/blob/master/CodeSniffer/Standards/Squiz/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
+ * @link https://github.com/squizlabs/PHP_CodeSniffer/blob/master/CodeSniffer/Standards/Squiz/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
  */
 final class ControlStructureSpacingSniff extends Sniff {
 

--- a/WordPress/Sniffs/WhiteSpace/ObjectOperatorSpacingSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/ObjectOperatorSpacingSniff.php
@@ -19,8 +19,6 @@ use PHP_CodeSniffer\Util\Tokens;
  * Difference with the upstream sniff:
  * - When the `::` operator is used in `::class`, no new line(s) before or after the object operator are allowed.
  *
- * @package WPCS\WordPressCodingStandards
- *
  * @since 3.0.0
  * @link  https://github.com/squizlabs/PHP_CodeSniffer/blob/master/src/Standards/Squiz/Sniffs/WhiteSpace/ObjectOperatorSpacingSniff.php
  */

--- a/WordPress/Sniffs/WhiteSpace/OperatorSpacingSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/OperatorSpacingSniff.php
@@ -18,22 +18,20 @@ use PHP_CodeSniffer\Util\Tokens;
  *
  * "Always put spaces after commas, and on both sides of logical, comparison, string and assignment operators."
  *
- * @link    https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#space-usage
+ * @link https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#space-usage
  *
- * @package WPCS\WordPressCodingStandards
- *
- * @since   0.1.0
- * @since   0.3.0  This sniff now has the ability to fix the issues it flags.
- * @since   0.12.0 This sniff used to be a copy of a very old and outdated version of the
- *                 upstream sniff.
- *                 Now, the sniff defers completely to the upstream sniff, adding just the
- *                 T_BOOLEAN_NOT and the logical operators (`&&` and the like) - via the
- *                 registration method and changing the value of the customizable
- *                 $ignoreNewlines property.
- * @since   0.13.0 Class name changed: this class is now namespaced.
+ * @since 0.1.0
+ * @since 0.3.0  This sniff now has the ability to fix the issues it flags.
+ * @since 0.12.0 This sniff used to be a copy of a very old and outdated version of the
+ *               upstream sniff.
+ *               Now, the sniff defers completely to the upstream sniff, adding just the
+ *               T_BOOLEAN_NOT and the logical operators (`&&` and the like) - via the
+ *               registration method and changing the value of the customizable
+ *               $ignoreNewlines property.
+ * @since 0.13.0 Class name changed: this class is now namespaced.
  *
  * Last verified with base class June 2023 at commit 085b1e091b0f2e451333c0bc26dd50bba39402c4.
- * @link    https://github.com/squizlabs/PHP_CodeSniffer/blob/master/CodeSniffer/Standards/Squiz/Sniffs/WhiteSpace/OperatorSpacingSniff.php
+ * @link https://github.com/squizlabs/PHP_CodeSniffer/blob/master/CodeSniffer/Standards/Squiz/Sniffs/WhiteSpace/OperatorSpacingSniff.php
  */
 final class OperatorSpacingSniff extends PHPCS_Squiz_OperatorSpacingSniff {
 

--- a/WordPress/Tests/Arrays/ArrayDeclarationSpacingUnitTest.php
+++ b/WordPress/Tests/Arrays/ArrayDeclarationSpacingUnitTest.php
@@ -14,10 +14,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 /**
  * Unit test class for the ArrayDeclarationSpacing sniff.
  *
- * @package WPCS\WordPressCodingStandards
- *
- * @since   0.11.0
- * @since   0.13.0 Class name changed: this class is now namespaced.
+ * @since 0.11.0
+ * @since 0.13.0 Class name changed: this class is now namespaced.
  *
  * @covers \WordPressCS\WordPress\Sniffs\Arrays\ArrayDeclarationSpacingSniff
  */

--- a/WordPress/Tests/Arrays/ArrayIndentationUnitTest.php
+++ b/WordPress/Tests/Arrays/ArrayIndentationUnitTest.php
@@ -14,10 +14,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 /**
  * Unit test class for the ArrayIndentation sniff.
  *
- * @package WPCS\WordPressCodingStandards
- *
- * @since   0.12.0
- * @since   0.13.0 Class name changed: this class is now namespaced.
+ * @since 0.12.0
+ * @since 0.13.0 Class name changed: this class is now namespaced.
  *
  * @covers \WordPressCS\WordPress\Sniffs\Arrays\ArrayIndentationSniff
  */

--- a/WordPress/Tests/Arrays/ArrayKeySpacingRestrictionsUnitTest.php
+++ b/WordPress/Tests/Arrays/ArrayKeySpacingRestrictionsUnitTest.php
@@ -14,10 +14,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 /**
  * Unit test class for the ArrayKeySpacingRestrictions sniff.
  *
- * @package WPCS\WordPressCodingStandards
- *
- * @since   0.3.0
- * @since   0.13.0 Class name changed: this class is now namespaced.
+ * @since 0.3.0
+ * @since 0.13.0 Class name changed: this class is now namespaced.
  *
  * @covers \WordPressCS\WordPress\Sniffs\Arrays\ArrayKeySpacingRestrictionsSniff
  */

--- a/WordPress/Tests/Arrays/MultipleStatementAlignmentUnitTest.php
+++ b/WordPress/Tests/Arrays/MultipleStatementAlignmentUnitTest.php
@@ -18,9 +18,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  * 1. Tab-based indentation, long arrays.
  * 2. Space-based indentation, short arrays.
  *
- * @package WPCS\WordPressCodingStandards
- *
- * @since   0.14.0
+ * @since 0.14.0
  *
  * @covers \WordPressCS\WordPress\Sniffs\Arrays\MultipleStatementAlignmentSniff
  */

--- a/WordPress/Tests/CodeAnalysis/AssignmentInTernaryConditionUnitTest.php
+++ b/WordPress/Tests/CodeAnalysis/AssignmentInTernaryConditionUnitTest.php
@@ -14,9 +14,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 /**
  * Unit test class for the AssignmentInTernaryCondition sniff.
  *
- * @package WPCS\WordPressCodingStandards
- *
- * @since   0.14.0
+ * @since 0.14.0
  *
  * @covers \WordPressCS\WordPress\Sniffs\CodeAnalysis\AssignmentInTernaryConditionSniff
  */

--- a/WordPress/Tests/CodeAnalysis/EscapedNotTranslatedUnitTest.php
+++ b/WordPress/Tests/CodeAnalysis/EscapedNotTranslatedUnitTest.php
@@ -14,9 +14,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 /**
  * Unit test class for the EscapedNotTranslated sniff.
  *
- * @package WPCS\WordPressCodingStandards
- *
- * @since   2.2.0
+ * @since 2.2.0
  *
  * @covers \WordPressCS\WordPress\Sniffs\CodeAnalysis\EscapedNotTranslatedSniff
  */

--- a/WordPress/Tests/DB/DirectDatabaseQueryUnitTest.php
+++ b/WordPress/Tests/DB/DirectDatabaseQueryUnitTest.php
@@ -14,11 +14,9 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 /**
  * Unit test class for the DirectDatabaseQuery sniff.
  *
- * @package WPCS\WordPressCodingStandards
- *
- * @since   0.3.0
- * @since   0.13.0 Class name changed: this class is now namespaced.
- * @since   1.0.0  This sniff has been moved from the `VIP` category to the `DB` category.
+ * @since 0.3.0
+ * @since 0.13.0 Class name changed: this class is now namespaced.
+ * @since 1.0.0  This sniff has been moved from the `VIP` category to the `DB` category.
  *
  * @covers \WordPressCS\WordPress\Helpers\RulesetPropertyHelper
  * @covers \WordPressCS\WordPress\Sniffs\DB\DirectDatabaseQuerySniff

--- a/WordPress/Tests/DB/PreparedSQLPlaceholdersUnitTest.php
+++ b/WordPress/Tests/DB/PreparedSQLPlaceholdersUnitTest.php
@@ -14,9 +14,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 /**
  * Unit test class for the PreparedSQLPlaceholders sniff.
  *
- * @package WPCS\WordPressCodingStandards
- *
- * @since   0.14.0
+ * @since 0.14.0
  *
  * @covers \WordPressCS\WordPress\Sniffs\DB\PreparedSQLPlaceholdersSniff
  */

--- a/WordPress/Tests/DB/PreparedSQLUnitTest.php
+++ b/WordPress/Tests/DB/PreparedSQLUnitTest.php
@@ -14,11 +14,9 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 /**
  * Unit test class for the PreparedSQL sniff.
  *
- * @package WPCS\WordPressCodingStandards
- *
- * @since   0.8.0
- * @since   0.13.0 Class name changed: this class is now namespaced.
- * @since   1.0.0  This sniff has been moved from the `WP` category to the `DB` category.
+ * @since 0.8.0
+ * @since 0.13.0 Class name changed: this class is now namespaced.
+ * @since 1.0.0  This sniff has been moved from the `WP` category to the `DB` category.
  *
  * @covers \WordPressCS\WordPress\Helpers\ContextHelper::is_safe_casted
  * @covers \WordPressCS\WordPress\Helpers\FormattingFunctionsHelper

--- a/WordPress/Tests/DB/RestrictedClassesUnitTest.php
+++ b/WordPress/Tests/DB/RestrictedClassesUnitTest.php
@@ -15,11 +15,9 @@ use WordPressCS\WordPress\AbstractFunctionRestrictionsSniff;
 /**
  * Unit test class for the DB_RestrictedClasses sniff.
  *
- * @package WPCS\WordPressCodingStandards
- *
- * @since   0.10.0
- * @since   0.13.0 Class name changed: this class is now namespaced.
- * @since   3.0.0  Renamed the fixtures to create compatibility with PHPCS 4.x/PHPUnit >=8.
+ * @since 0.10.0
+ * @since 0.13.0 Class name changed: this class is now namespaced.
+ * @since 3.0.0  Renamed the fixtures to create compatibility with PHPCS 4.x/PHPUnit >=8.
  *
  * @covers \WordPressCS\WordPress\AbstractClassRestrictionsSniff
  * @covers \WordPressCS\WordPress\Helpers\RulesetPropertyHelper

--- a/WordPress/Tests/DB/RestrictedFunctionsUnitTest.php
+++ b/WordPress/Tests/DB/RestrictedFunctionsUnitTest.php
@@ -15,10 +15,8 @@ use WordPressCS\WordPress\AbstractFunctionRestrictionsSniff;
 /**
  * Unit test class for the DB_RestrictedFunctions sniff.
  *
- * @package WPCS\WordPressCodingStandards
- *
- * @since   0.10.0
- * @since   0.13.0 Class name changed: this class is now namespaced.
+ * @since 0.10.0
+ * @since 0.13.0 Class name changed: this class is now namespaced.
  *
  * @covers \WordPressCS\WordPress\AbstractFunctionRestrictionsSniff
  * @covers \WordPressCS\WordPress\Sniffs\DB\RestrictedFunctionsSniff

--- a/WordPress/Tests/DB/SlowDBQueryUnitTest.php
+++ b/WordPress/Tests/DB/SlowDBQueryUnitTest.php
@@ -14,11 +14,9 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 /**
  * Unit test class for the SlowDBQuery sniff.
  *
- * @package WPCS\WordPressCodingStandards
- *
- * @since   0.3.0
- * @since   0.13.0 Class name changed: this class is now namespaced.
- * @since   1.0.0  This sniff has been moved from the `VIP` category to the `DB` category.
+ * @since 0.3.0
+ * @since 0.13.0 Class name changed: this class is now namespaced.
+ * @since 1.0.0  This sniff has been moved from the `VIP` category to the `DB` category.
  *
  * @covers \WordPressCS\WordPress\AbstractArrayAssignmentRestrictionsSniff
  * @covers \WordPressCS\WordPress\Sniffs\DB\SlowDBQuerySniff

--- a/WordPress/Tests/DateTime/CurrentTimeTimestampUnitTest.php
+++ b/WordPress/Tests/DateTime/CurrentTimeTimestampUnitTest.php
@@ -14,9 +14,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 /**
  * Unit test class for the CurrentTimeTimestamp sniff.
  *
- * @package WPCS\WordPressCodingStandards
- *
- * @since   2.2.0
+ * @since 2.2.0
  *
  * @covers \WordPressCS\WordPress\Sniffs\DateTime\CurrentTimeTimestampSniff
  */

--- a/WordPress/Tests/DateTime/RestrictedFunctionsUnitTest.php
+++ b/WordPress/Tests/DateTime/RestrictedFunctionsUnitTest.php
@@ -14,9 +14,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 /**
  * Unit test class for the DateTime.RestrictedFunctions sniff.
  *
- * @package WPCS\WordPressCodingStandards
- *
- * @since   2.2.0
+ * @since 2.2.0
  *
  * @covers \WordPressCS\WordPress\Sniffs\DateTime\RestrictedFunctionsSniff
  */

--- a/WordPress/Tests/Files/FileNameUnitTest.php
+++ b/WordPress/Tests/Files/FileNameUnitTest.php
@@ -14,11 +14,9 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 /**
  * Unit test class for the FileName sniff.
  *
- * @package WPCS\WordPressCodingStandards
- *
- * @since   2013-06-11
- * @since   0.11.0     Actually added tests ;-)
- * @since   0.13.0     Class name changed: this class is now namespaced.
+ * @since 2013-06-11
+ * @since 0.11.0     Actually added tests ;-)
+ * @since 0.13.0     Class name changed: this class is now namespaced.
  *
  * @covers \WordPressCS\WordPress\Sniffs\Files\FileNameSniff
  */

--- a/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.php
+++ b/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.php
@@ -14,10 +14,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 /**
  * Unit test class for the PrefixAllGlobals sniff.
  *
- * @package WPCS\WordPressCodingStandards
- *
- * @since   0.12.0
- * @since   0.13.0 Class name changed: this class is now namespaced.
+ * @since 0.12.0
+ * @since 0.13.0 Class name changed: this class is now namespaced.
  *
  * @covers \WordPressCS\WordPress\Helpers\IsUnitTestTrait
  * @covers \WordPressCS\WordPress\Sniffs\NamingConventions\PrefixAllGlobalsSniff

--- a/WordPress/Tests/NamingConventions/ValidFunctionNameUnitTest.php
+++ b/WordPress/Tests/NamingConventions/ValidFunctionNameUnitTest.php
@@ -14,10 +14,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 /**
  * Unit test class for the ValidFunctionName sniff.
  *
- * @package WPCS\WordPressCodingStandards
- *
- * @since   2013-06-11
- * @since   0.13.0     Class name changed: this class is now namespaced.
+ * @since 2013-06-11
+ * @since 0.13.0     Class name changed: this class is now namespaced.
  *
  * @covers \WordPressCS\WordPress\Helpers\DeprecationHelper
  * @covers \WordPressCS\WordPress\Sniffs\NamingConventions\ValidFunctionNameSniff

--- a/WordPress/Tests/NamingConventions/ValidHookNameUnitTest.php
+++ b/WordPress/Tests/NamingConventions/ValidHookNameUnitTest.php
@@ -14,10 +14,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 /**
  * Unit test class for the ValidHookName sniff.
  *
- * @package WPCS\WordPressCodingStandards
- *
- * @since   0.10.0
- * @since   0.13.0 Class name changed: this class is now namespaced.
+ * @since 0.10.0
+ * @since 0.13.0 Class name changed: this class is now namespaced.
  *
  * @covers \WordPressCS\WordPress\Helpers\WPHookHelper
  * @covers \WordPressCS\WordPress\Sniffs\NamingConventions\ValidHookNameSniff

--- a/WordPress/Tests/NamingConventions/ValidPostTypeSlugUnitTest.php
+++ b/WordPress/Tests/NamingConventions/ValidPostTypeSlugUnitTest.php
@@ -14,9 +14,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 /**
  * Unit test class for the PostType sniff.
  *
- * @package WPCS\WordPressCodingStandards
- *
- * @since   2.2.0
+ * @since 2.2.0
  *
  * @covers \WordPressCS\WordPress\Sniffs\NamingConventions\ValidPostTypeSlugSniff
  */

--- a/WordPress/Tests/NamingConventions/ValidVariableNameUnitTest.php
+++ b/WordPress/Tests/NamingConventions/ValidVariableNameUnitTest.php
@@ -14,10 +14,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 /**
  * Unit test class for the ValidVariableName sniff.
  *
- * @package WPCS\WordPressCodingStandards
- *
- * @since   0.9.0
- * @since   0.13.0 Class name changed: this class is now namespaced.
+ * @since 0.9.0
+ * @since 0.13.0 Class name changed: this class is now namespaced.
  *
  * @covers \WordPressCS\WordPress\Helpers\SnakeCaseHelper
  * @covers \WordPressCS\WordPress\Sniffs\NamingConventions\ValidVariableNameSniff

--- a/WordPress/Tests/PHP/DevelopmentFunctionsUnitTest.php
+++ b/WordPress/Tests/PHP/DevelopmentFunctionsUnitTest.php
@@ -14,10 +14,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 /**
  * Unit test class for the PHP_DevelopmentFunctions sniff.
  *
- * @package WPCS\WordPressCodingStandards
- *
- * @since   0.11.0
- * @since   0.13.0 Class name changed: this class is now namespaced.
+ * @since 0.11.0
+ * @since 0.13.0 Class name changed: this class is now namespaced.
  *
  * @covers \WordPressCS\WordPress\Sniffs\PHP\DevelopmentFunctionsSniff
  */

--- a/WordPress/Tests/PHP/DiscouragedPHPFunctionsUnitTest.php
+++ b/WordPress/Tests/PHP/DiscouragedPHPFunctionsUnitTest.php
@@ -14,10 +14,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 /**
  * Unit test class for the PHP_DiscouragedPHPFunctions sniff.
  *
- * @package WPCS\WordPressCodingStandards
- *
- * @since   0.11.0
- * @since   0.13.0 Class name changed: this class is now namespaced.
+ * @since 0.11.0
+ * @since 0.13.0 Class name changed: this class is now namespaced.
  *
  * @covers \WordPressCS\WordPress\Sniffs\PHP\DiscouragedPHPFunctionsSniff
  */

--- a/WordPress/Tests/PHP/DontExtractUnitTest.php
+++ b/WordPress/Tests/PHP/DontExtractUnitTest.php
@@ -14,11 +14,9 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 /**
  * Unit test class for the DontExtract sniff.
  *
- * @package WPCS\WordPressCodingStandards
- *
- * @since   0.10.0
- * @since   0.13.0 Class name changed: this class is now namespaced.
- * @since   1.0.0  This sniff has been moved from the `Functions` category to the `PHP` category.
+ * @since 0.10.0
+ * @since 0.13.0 Class name changed: this class is now namespaced.
+ * @since 1.0.0  This sniff has been moved from the `Functions` category to the `PHP` category.
  *
  * @covers \WordPressCS\WordPress\Sniffs\PHP\DontExtractSniff
  */

--- a/WordPress/Tests/PHP/IniSetUnitTest.php
+++ b/WordPress/Tests/PHP/IniSetUnitTest.php
@@ -14,8 +14,6 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 /**
  * Unit test class for the IniSet sniff.
  *
- * @package WPCS\WordPressCodingStandards
- *
  * @since 2.1.0
  *
  * @covers \WordPressCS\WordPress\Sniffs\PHP\IniSetSniff

--- a/WordPress/Tests/PHP/NoSilencedErrorsUnitTest.php
+++ b/WordPress/Tests/PHP/NoSilencedErrorsUnitTest.php
@@ -14,9 +14,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 /**
  * Unit test class for the PHP.NoSilencedErrors sniff.
  *
- * @package WPCS\WordPressCodingStandards
- *
- * @since   1.1.0
+ * @since 1.1.0
  *
  * @covers \WordPressCS\WordPress\Sniffs\PHP\NoSilencedErrorsSniff
  */

--- a/WordPress/Tests/PHP/POSIXFunctionsUnitTest.php
+++ b/WordPress/Tests/PHP/POSIXFunctionsUnitTest.php
@@ -14,10 +14,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 /**
  * Unit test class for the POSIXFunctions sniff.
  *
- * @package WPCS\WordPressCodingStandards
- *
- * @since   0.10.0
- * @since   0.13.0 Class name changed: this class is now namespaced.
+ * @since 0.10.0
+ * @since 0.13.0 Class name changed: this class is now namespaced.
  *
  * @covers \WordPressCS\WordPress\Sniffs\PHP\POSIXFunctionsSniff
  */

--- a/WordPress/Tests/PHP/PregQuoteDelimiterUnitTest.php
+++ b/WordPress/Tests/PHP/PregQuoteDelimiterUnitTest.php
@@ -14,9 +14,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 /**
  * Unit test class for the PregQuoteDelimiter sniff.
  *
- * @package WPCS\WordPressCodingStandards
- *
- * @since   1.0.0
+ * @since 1.0.0
  *
  * @covers \WordPressCS\WordPress\Sniffs\PHP\PregQuoteDelimiterSniff
  */

--- a/WordPress/Tests/PHP/RestrictedPHPFunctionsUnitTest.php
+++ b/WordPress/Tests/PHP/RestrictedPHPFunctionsUnitTest.php
@@ -14,9 +14,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 /**
  * Unit test class for the PHP_DiscouragedPHPFunctions sniff.
  *
- * @package WPCS\WordPressCodingStandards
- *
- * @since   0.14.0
+ * @since 0.14.0
  *
  * @covers \WordPressCS\WordPress\Sniffs\PHP\RestrictedPHPFunctionsSniff
  */

--- a/WordPress/Tests/PHP/StrictInArrayUnitTest.php
+++ b/WordPress/Tests/PHP/StrictInArrayUnitTest.php
@@ -14,10 +14,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 /**
  * Unit test class for the StrictInArray sniff.
  *
- * @package WPCS\WordPressCodingStandards
- *
- * @since   0.9.0
- * @since   0.13.0 Class name changed: this class is now namespaced.
+ * @since 0.9.0
+ * @since 0.13.0 Class name changed: this class is now namespaced.
  *
  * @covers \WordPressCS\WordPress\AbstractFunctionParameterSniff
  * @covers \WordPressCS\WordPress\Sniffs\PHP\StrictInArraySniff

--- a/WordPress/Tests/PHP/TypeCastsUnitTest.php
+++ b/WordPress/Tests/PHP/TypeCastsUnitTest.php
@@ -14,8 +14,6 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 /**
  * Unit test class for the TypeCasts sniff.
  *
- * @package WPCS\WordPressCodingStandards
- *
  * @since 1.2.0
  *
  * @covers \WordPressCS\WordPress\Sniffs\PHP\TypeCastsSniff

--- a/WordPress/Tests/PHP/YodaConditionsUnitTest.php
+++ b/WordPress/Tests/PHP/YodaConditionsUnitTest.php
@@ -14,10 +14,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 /**
  * Unit test class for the YodaConditions sniff.
  *
- * @package WPCS\WordPressCodingStandards
- *
- * @since   0.3.0
- * @since   0.13.0 Class name changed: this class is now namespaced.
+ * @since 0.3.0
+ * @since 0.13.0 Class name changed: this class is now namespaced.
  *
  * @covers \WordPressCS\WordPress\Sniffs\PHP\YodaConditionsSniff
  */

--- a/WordPress/Tests/Security/EscapeOutputUnitTest.php
+++ b/WordPress/Tests/Security/EscapeOutputUnitTest.php
@@ -14,11 +14,9 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 /**
  * Unit test class for the EscapeOutput sniff.
  *
- * @package WPCS\WordPressCodingStandards
- *
- * @since   2013-06-11
- * @since   0.13.0     Class name changed: this class is now namespaced.
- * @since   1.0.0      This sniff has been moved from the `XSS` category to the `Security` category.
+ * @since 2013-06-11
+ * @since 0.13.0     Class name changed: this class is now namespaced.
+ * @since 1.0.0      This sniff has been moved from the `XSS` category to the `Security` category.
  *
  * @covers \WordPressCS\WordPress\Helpers\ArrayWalkingFunctionsHelper
  * @covers \WordPressCS\WordPress\Helpers\ContextHelper::get_safe_cast_tokens

--- a/WordPress/Tests/Security/NonceVerificationUnitTest.php
+++ b/WordPress/Tests/Security/NonceVerificationUnitTest.php
@@ -14,11 +14,9 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 /**
  * Unit test class for the NonceVerification sniff.
  *
- * @package WPCS\WordPressCodingStandards
- *
- * @since   0.5.0
- * @since   0.13.0 Class name changed: this class is now namespaced.
- * @since   1.0.0  This sniff has been moved from the `CSRF` category to the `Security` category.
+ * @since 0.5.0
+ * @since 0.13.0 Class name changed: this class is now namespaced.
+ * @since 1.0.0  This sniff has been moved from the `CSRF` category to the `Security` category.
  *
  * @covers \WordPressCS\WordPress\Helpers\ContextHelper::is_in_function_call
  * @covers \WordPressCS\WordPress\Helpers\ContextHelper::is_in_type_test

--- a/WordPress/Tests/Security/PluginMenuSlugUnitTest.php
+++ b/WordPress/Tests/Security/PluginMenuSlugUnitTest.php
@@ -14,11 +14,9 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 /**
  * Unit test class for the PluginMenuSlug sniff.
  *
- * @package WPCS\WordPressCodingStandards
- *
- * @since   0.3.0
- * @since   0.13.0 Class name changed: this class is now namespaced.
- * @since   1.0.0  This sniff has been moved from the `VIP` category to the `Security` category.
+ * @since 0.3.0
+ * @since 0.13.0 Class name changed: this class is now namespaced.
+ * @since 1.0.0  This sniff has been moved from the `VIP` category to the `Security` category.
  *
  * @covers \WordPressCS\WordPress\Sniffs\Security\PluginMenuSlugSniff
  */

--- a/WordPress/Tests/Security/SafeRedirectUnitTest.php
+++ b/WordPress/Tests/Security/SafeRedirectUnitTest.php
@@ -14,9 +14,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 /**
  * Unit test class for the Security_SafeRedirect sniff.
  *
- * @package WPCS\WordPressCodingStandards
- *
- * @since   1.0.0
+ * @since 1.0.0
  *
  * @covers \WordPressCS\WordPress\Sniffs\Security\SafeRedirectSniff
  */

--- a/WordPress/Tests/Security/ValidatedSanitizedInputUnitTest.php
+++ b/WordPress/Tests/Security/ValidatedSanitizedInputUnitTest.php
@@ -14,11 +14,9 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 /**
  * Unit test class for the ValidatedSanitizedInput sniff.
  *
- * @package WPCS\WordPressCodingStandards
- *
- * @since   0.3.0
- * @since   0.13.0 Class name changed: this class is now namespaced.
- * @since   1.0.0  This sniff has been moved from the `VIP` category to the `Security` category.
+ * @since 0.3.0
+ * @since 0.13.0 Class name changed: this class is now namespaced.
+ * @since 1.0.0  This sniff has been moved from the `VIP` category to the `Security` category.
  *
  * @covers \WordPressCS\WordPress\Helpers\ArrayWalkingFunctionsHelper
  * @covers \WordPressCS\WordPress\Helpers\SanitizingFunctionsTrait

--- a/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.php
+++ b/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.php
@@ -15,9 +15,7 @@ use PHPCSUtils\BackCompat\Helper;
 /**
  * Unit test class for the I18nTextDomainFixer sniff.
  *
- * @package WPCS\WordPressCodingStandards
- *
- * @since   1.2.0
+ * @since 1.2.0
  *
  * @covers \WordPressCS\WordPress\Sniffs\Utils\I18nTextDomainFixerSniff
  */

--- a/WordPress/Tests/WP/AlternativeFunctionsUnitTest.php
+++ b/WordPress/Tests/WP/AlternativeFunctionsUnitTest.php
@@ -14,10 +14,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 /**
  * Unit test class for the WP_AlternativeFunctions sniff.
  *
- * @package WPCS\WordPressCodingStandards
- *
- * @since   0.11.0
- * @since   0.13.0 Class name changed: this class is now namespaced.
+ * @since 0.11.0
+ * @since 0.13.0 Class name changed: this class is now namespaced.
  *
  * @covers \WordPressCS\WordPress\Helpers\MinimumWPVersionTrait
  * @covers \WordPressCS\WordPress\Sniffs\WP\AlternativeFunctionsSniff

--- a/WordPress/Tests/WP/CapabilitiesUnitTest.php
+++ b/WordPress/Tests/WP/CapabilitiesUnitTest.php
@@ -15,8 +15,7 @@ use PHPCSUtils\BackCompat\Helper;
 /**
  * Unit test class for the Capabilities sniff.
  *
- * @package WPCS\WordPressCodingStandards
- * @since   3.0.0
+ * @since 3.0.0
  *
  * @covers \WordPressCS\WordPress\Sniffs\WP\CapabilitiesSniff
  */

--- a/WordPress/Tests/WP/CapitalPDangitUnitTest.php
+++ b/WordPress/Tests/WP/CapitalPDangitUnitTest.php
@@ -14,10 +14,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 /**
  * Unit test class for the CapitalPDangit sniff.
  *
- * @package WPCS\WordPressCodingStandards
- *
- * @since   0.12.0
- * @since   0.13.0 Class name changed: this class is now namespaced.
+ * @since 0.12.0
+ * @since 0.13.0 Class name changed: this class is now namespaced.
  *
  * @covers \WordPressCS\WordPress\Sniffs\WP\CapitalPDangitSniff
  */

--- a/WordPress/Tests/WP/ClassNameCaseUnitTest.php
+++ b/WordPress/Tests/WP/ClassNameCaseUnitTest.php
@@ -14,8 +14,6 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 /**
  * Unit test class for the ClassNameCase sniff.
  *
- * @package WPCS\WordPressCodingStandards
- *
  * @since 3.0.0
  *
  * @covers \WordPressCS\WordPress\Sniffs\WP\ClassNameCaseSniff

--- a/WordPress/Tests/WP/CronIntervalUnitTest.php
+++ b/WordPress/Tests/WP/CronIntervalUnitTest.php
@@ -14,11 +14,9 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 /**
  * Unit test class for the CronInterval sniff.
  *
- * @package WPCS\WordPressCodingStandards
- *
- * @since   0.3.0
- * @since   0.13.0 Class name changed: this class is now namespaced.
- * @since   1.0.0  This sniff has been moved from the `VIP` category to the `WP` category.
+ * @since 0.3.0
+ * @since 0.13.0 Class name changed: this class is now namespaced.
+ * @since 1.0.0  This sniff has been moved from the `VIP` category to the `WP` category.
  *
  * @covers \WordPressCS\WordPress\Sniffs\WP\CronIntervalSniff
  */

--- a/WordPress/Tests/WP/DeprecatedClassesUnitTest.php
+++ b/WordPress/Tests/WP/DeprecatedClassesUnitTest.php
@@ -14,10 +14,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 /**
  * Unit test class for the WP_DeprecatedClasses sniff.
  *
- * @package WPCS\WordPressCodingStandards
- *
- * @since   0.12.0
- * @since   0.13.0 Class name changed: this class is now namespaced.
+ * @since 0.12.0
+ * @since 0.13.0 Class name changed: this class is now namespaced.
  *
  * @covers \WordPressCS\WordPress\Sniffs\WP\DeprecatedClassesSniff
  */

--- a/WordPress/Tests/WP/DeprecatedFunctionsUnitTest.php
+++ b/WordPress/Tests/WP/DeprecatedFunctionsUnitTest.php
@@ -14,10 +14,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 /**
  * Unit test class for the WP_DeprecatedFunctions sniff.
  *
- * @package WPCS\WordPressCodingStandards
- *
- * @since   0.11.0
- * @since   0.13.0 Class name changed: this class is now namespaced.
+ * @since 0.11.0
+ * @since 0.13.0 Class name changed: this class is now namespaced.
  *
  * @covers \WordPressCS\WordPress\Sniffs\WP\DeprecatedFunctionsSniff
  */

--- a/WordPress/Tests/WP/DeprecatedParameterValuesUnitTest.php
+++ b/WordPress/Tests/WP/DeprecatedParameterValuesUnitTest.php
@@ -14,9 +14,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 /**
  * Unit test class for the DeprecatedParameterValues sniff.
  *
- * @package WPCS\WordPressCodingStandards
- *
- * @since   1.0.0
+ * @since 1.0.0
  *
  * @covers \WordPressCS\WordPress\Sniffs\WP\DeprecatedParameterValuesSniff
  */

--- a/WordPress/Tests/WP/DeprecatedParametersUnitTest.php
+++ b/WordPress/Tests/WP/DeprecatedParametersUnitTest.php
@@ -14,10 +14,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 /**
  * Unit test class for the DeprecatedParameters sniff.
  *
- * @package WPCS\WordPressCodingStandards
- *
- * @since   0.12.0
- * @since   0.13.0 Class name changed: this class is now namespaced.
+ * @since 0.12.0
+ * @since 0.13.0 Class name changed: this class is now namespaced.
  *
  * @covers \WordPressCS\WordPress\Sniffs\WP\DeprecatedParametersSniff
  */

--- a/WordPress/Tests/WP/DiscouragedConstantsUnitTest.php
+++ b/WordPress/Tests/WP/DiscouragedConstantsUnitTest.php
@@ -14,8 +14,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 /**
  * Unit test class for the WP_DiscouragedConstants sniff.
  *
- * @package WPCS\WordPressCodingStandards
- * @since   0.14.0
+ * @since 0.14.0
  *
  * @covers \WordPressCS\WordPress\Sniffs\WP\DiscouragedConstantsSniff
  */

--- a/WordPress/Tests/WP/DiscouragedFunctionsUnitTest.php
+++ b/WordPress/Tests/WP/DiscouragedFunctionsUnitTest.php
@@ -14,10 +14,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 /**
  * Unit test class for the WP_DiscouragedFunctions sniff.
  *
- * @package WPCS\WordPressCodingStandards
- *
- * @since   0.11.0
- * @since   0.13.0 Class name changed: this class is now namespaced.
+ * @since 0.11.0
+ * @since 0.13.0 Class name changed: this class is now namespaced.
  *
  * @covers \WordPressCS\WordPress\AbstractFunctionRestrictionsSniff
  * @covers \WordPressCS\WordPress\Helpers\ContextHelper::has_object_operator_before

--- a/WordPress/Tests/WP/EnqueuedResourceParametersUnitTest.php
+++ b/WordPress/Tests/WP/EnqueuedResourceParametersUnitTest.php
@@ -14,9 +14,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 /**
  * Unit test class for the EnqueuedCheck sniff.
  *
- * @package WPCS\WordPressCodingStandards
- *
- * @since   1.0.0
+ * @since 1.0.0
  *
  * @covers \WordPressCS\WordPress\Sniffs\WP\EnqueuedResourceParametersSniff
  */

--- a/WordPress/Tests/WP/EnqueuedResourcesUnitTest.php
+++ b/WordPress/Tests/WP/EnqueuedResourcesUnitTest.php
@@ -14,10 +14,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 /**
  * Unit test class for the EnqueuedResources sniff.
  *
- * @package WPCS\WordPressCodingStandards
- *
- * @since   0.3.0
- * @since   0.13.0 Class name changed: this class is now namespaced.
+ * @since 0.3.0
+ * @since 0.13.0 Class name changed: this class is now namespaced.
  *
  * @covers \WordPressCS\WordPress\Sniffs\WP\EnqueuedResourcesSniff
  */

--- a/WordPress/Tests/WP/GlobalVariablesOverrideUnitTest.php
+++ b/WordPress/Tests/WP/GlobalVariablesOverrideUnitTest.php
@@ -14,12 +14,10 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 /**
  * Unit test class for the GlobalVariables sniff.
  *
- * @package WPCS\WordPressCodingStandards
- *
- * @since   0.3.0
- * @since   0.13.0 Class name changed: this class is now namespaced.
- * @since   1.0.0  This sniff has been moved from the `Variables` category to the `WP`
- *                 category and renamed from `GlobalVariables` to `GlobalVariablesOverride`.
+ * @since 0.3.0
+ * @since 0.13.0 Class name changed: this class is now namespaced.
+ * @since 1.0.0  This sniff has been moved from the `Variables` category to the `WP`
+ *               category and renamed from `GlobalVariables` to `GlobalVariablesOverride`.
  *
  * @covers \WordPressCS\WordPress\Helpers\ListHelper
  * @covers \WordPressCS\WordPress\Helpers\WPGlobalVariablesHelper

--- a/WordPress/Tests/WP/I18nUnitTest.php
+++ b/WordPress/Tests/WP/I18nUnitTest.php
@@ -14,10 +14,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 /**
  * Unit test class for the I18n sniff.
  *
- * @package WPCS\WordPressCodingStandards
- *
- * @since   0.10.0
- * @since   0.13.0 Class name changed: this class is now namespaced.
+ * @since 0.10.0
+ * @since 0.13.0 Class name changed: this class is now namespaced.
  *
  * @covers \WordPressCS\WordPress\Sniffs\WP\I18nSniff
  */

--- a/WordPress/Tests/WP/PostsPerPageUnitTest.php
+++ b/WordPress/Tests/WP/PostsPerPageUnitTest.php
@@ -14,13 +14,11 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 /**
  * Unit test class for the PostsPerPage sniff.
  *
- * @package WPCS\WordPressCodingStandards
- *
- * @since   0.3.0
- * @since   0.13.0 Class name changed: this class is now namespaced.
- * @since   1.0.0  This sniff has been split into two, with the check for high pagination
- *                 limit being part of the WP category, and the check for pagination
- *                 disabling being part of the VIP category.
+ * @since 0.3.0
+ * @since 0.13.0 Class name changed: this class is now namespaced.
+ * @since 1.0.0  This sniff has been split into two, with the check for high pagination
+ *               limit being part of the WP category, and the check for pagination
+ *               disabling being part of the VIP category.
  *
  * @covers \WordPressCS\WordPress\AbstractArrayAssignmentRestrictionsSniff
  * @covers \WordPressCS\WordPress\Sniffs\WP\PostsPerPageSniff

--- a/WordPress/Tests/WhiteSpace/CastStructureSpacingUnitTest.php
+++ b/WordPress/Tests/WhiteSpace/CastStructureSpacingUnitTest.php
@@ -14,10 +14,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 /**
  * Unit test class for the CastStructureSpacing sniff.
  *
- * @package WPCS\WordPressCodingStandards
- *
- * @since   0.3.0
- * @since   0.13.0 Class name changed: this class is now namespaced.
+ * @since 0.3.0
+ * @since 0.13.0 Class name changed: this class is now namespaced.
  *
  * @covers \WordPressCS\WordPress\Sniffs\WhiteSpace\CastStructureSpacingSniff
  */

--- a/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.php
+++ b/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.php
@@ -14,10 +14,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 /**
  * Unit test class for the ControlStructureSpacing sniff.
  *
- * @package WPCS\WordPressCodingStandards
- *
- * @since   2013-06-11
- * @since   0.13.0     Class name changed: this class is now namespaced.
+ * @since 2013-06-11
+ * @since 0.13.0     Class name changed: this class is now namespaced.
  *
  * @covers \WordPressCS\WordPress\Sniffs\WhiteSpace\ControlStructureSpacingSniff
  */

--- a/WordPress/Tests/WhiteSpace/ObjectOperatorSpacingUnitTest.php
+++ b/WordPress/Tests/WhiteSpace/ObjectOperatorSpacingUnitTest.php
@@ -14,8 +14,6 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 /**
  * Unit test class for the ObjectOperatorSpacing sniff.
  *
- * @package WPCS\WordPressCodingStandards
- *
  * @since 3.0.0
  *
  * @covers \WordPressCS\WordPress\Sniffs\WhiteSpace\ObjectOperatorSpacingSniff

--- a/WordPress/Tests/WhiteSpace/OperatorSpacingUnitTest.php
+++ b/WordPress/Tests/WhiteSpace/OperatorSpacingUnitTest.php
@@ -14,12 +14,10 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 /**
  * Unit test class for the OperatorSpacing sniff.
  *
- * @package WPCS\WordPressCodingStandards
- *
- * @since   2013-06-11
- * @since   0.12.0     Now only tests the WPCS specific addition of T_BOOLEAN_NOT.
- *                     The rest of the sniff is unit tested upstream.
- * @since   0.13.0     Class name changed: this class is now namespaced.
+ * @since 2013-06-11
+ * @since 0.12.0     Now only tests the WPCS specific addition of T_BOOLEAN_NOT.
+ *                   The rest of the sniff is unit tested upstream.
+ * @since 0.13.0     Class name changed: this class is now namespaced.
  *
  * @covers \WordPressCS\WordPress\Sniffs\WhiteSpace\OperatorSpacingSniff
  */


### PR DESCRIPTION
`@package` tags are an arcane manner to group related files as belonging to one project.

For projects using namespaces, the current recommendation is to only have `@package` tags when they have supplemental information to the namespace.

That is only in a very limited way the case in WPCS, so I'm proposing to remove the `@package` tags from the WPCS class docblocks, though leaving them for now in the file docblocks.

At the very least, this removed duplicate information for which there is no reason for the duplication.

Includes cleaning up (normalizing) the tag description alignments in the class docblocks.

:point_right: reviewing with whitespace changes ignored should make it easier to see that the only real change is the removal of the package tags.

Refs:
* https://docs.phpdoc.org/3.0/guide/references/phpdoc/tags/package.html#package
* https://github.com/php-fig/fig-standards/blob/master/proposed/phpdoc-tags.md#59-package