### PR TITLE
Code coverage: initial setup for CodeCov

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,25 @@
+codecov:
+  notify:
+    after_n_builds: 4
+
+coverage:
+  round: nearest
+  # Status will be green when coverage is between 90 and 100%.
+  range: "90...100"
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+        paths:
+          - "WordPress"
+    patch:
+      default:
+        threshold: 3%
+        paths:
+          - "WordPress"
+
+ignore:
+  - "WordPress/Tests"
+
+comment: false

--- a/.gitattributes
+++ b/.gitattributes
@@ -6,6 +6,7 @@
 #
 /.gitattributes     export-ignore
 /.gitignore         export-ignore
+/.codecov.yml       export-ignore
 /.phpcs.xml.dist    export-ignore
 /CODE_OF_CONDUCT.md export-ignore
 /phpunit.xml.dist   export-ignore

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [ '5.4', 'latest' ]
+        php: [ '5.4', '7.4', 'latest' ]
         phpcs_version: [ 'lowest', 'dev-master' ]
 
     name: QTest - PHP ${{ matrix.php }} on PHPCS ${{ matrix.phpcs_version }}
@@ -48,7 +48,7 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           ini-values: ${{ steps.set_ini.outputs.PHP_INI }}
-          coverage: none
+          coverage:  ${{ github.ref_name == 'develop' && 'xdebug' || 'none' }}
 
       - name: "Set PHPCS version (master)"
         if: ${{ matrix.phpcs_version != 'lowest' }}
@@ -76,10 +76,23 @@ jobs:
         if: ${{ matrix.phpcs_version == 'dev-master' }}
         run: composer lint -- --checkstyle
 
-      - name: Run the unit tests - PHP 5.4 - 8.0
-        if: ${{ matrix.php < '8.1' && matrix.php != 'latest' }}
+      - name: Run the unit tests without code coverage - PHP 5.4 - 8.0
+        if: ${{ matrix.php == '5.4' && github.ref_name != 'develop' }}
         run: composer run-tests
 
-      - name: Run the unit tests - PHP >= 8.1
-        if: ${{ matrix.php >= '8.1' || matrix.php == 'latest' }}
+      # Until PHPCS supports PHPUnit 9, we cannot run code coverage on PHP 8.0+, so run it on PHP 5.4 and 7.4.
+      - name: Run the unit tests with code coverage - PHP 5.4 - 8.0
+        if: ${{ matrix.php != 'latest' && github.ref_name == 'develop' }}
+        run: composer coverage
+
+      - name: Run the unit tests without code coverage - PHP >= 8.1
+        if: ${{ matrix.php == 'latest' }}
         run: composer run-tests -- --no-configuration --bootstrap=./Tests/bootstrap.php --dont-report-useless-tests
+
+      - name: Send coverage report to Codecov
+        if: ${{ success() && github.ref_name == 'develop' }}
+        uses: codecov/codecov-action@v3
+        with:
+          files: ./build/logs/clover.xml
+          fail_ci_if_error: true
+          verbose: true

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -21,14 +21,35 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [ '5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3' ]
+        php: [ '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '8.0', '8.1', '8.2', '8.3' ]
         phpcs_version: [ 'lowest', 'dev-master' ]
         extensions: [ '' ]
+        coverage: [false]
 
         include:
           - php: '7.4'
             phpcs_version: 'dev-master'
             extensions: ':mbstring' # = Disable Mbstring.
+            coverage: true # Make sure coverage is recorded for this too.
+
+          # Run code coverage builds against high/low PHP and high/low PHPCS.
+          # Note: Until PHPCS supports PHPUnit 9, we cannot run code coverage on PHP 8.0+.
+          - php: '5.4'
+            phpcs_version: 'dev-master'
+            extensions: ''
+            coverage: true
+          - php: '5.4'
+            phpcs_version: 'lowest'
+            extensions: ''
+            coverage: true
+          - php: '7.4'
+            phpcs_version: 'dev-master'
+            extensions: ''
+            coverage: true
+          - php: '7.4'
+            phpcs_version: 'lowest'
+            extensions: ''
+            coverage: true
 
           # Add extra build to test against PHPCS 4.
           #- php: '7.4'
@@ -58,7 +79,7 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           ini-values: ${{ steps.set_ini.outputs.PHP_INI }}
-          coverage: none
+          coverage: ${{ matrix.coverage && 'xdebug' || 'none' }}
           tools: cs2pr
 
       - name: "Set PHPCS version (master)"
@@ -87,10 +108,23 @@ jobs:
         if: ${{ matrix.phpcs_version == 'dev-master' }}
         run: composer lint -- --checkstyle | cs2pr
 
-      - name: Run the unit tests - PHP 5.4 - 8.0
-        if: ${{ matrix.php < '8.1' }}
+      - name: Run the unit tests without code coverage - PHP 5.4 - 8.0
+        if: ${{ matrix.php < '8.1' && matrix.coverage == false }}
         run: composer run-tests
 
-      - name: Run the unit tests - PHP >= 8.1
-        if: ${{ matrix.php >= '8.1' }}
+      - name: Run the unit tests with code coverage - PHP 5.4 - 8.0
+        if: ${{ matrix.php < '8.1' && matrix.coverage == true  }}
+        run: composer coverage
+
+      # Until PHPCS supports PHPUnit 9, we cannot run code coverage on PHP 8.0+.
+      - name: Run the unit tests without code coverage - PHP >= 8.1
+        if: ${{ matrix.php >= '8.1' && matrix.coverage == false  }}
         run: composer run-tests -- --no-configuration --bootstrap=./Tests/bootstrap.php --dont-report-useless-tests
+
+      - name: Send coverage report to Codecov
+        if: ${{ success() && matrix.coverage == true }}
+        uses: codecov/codecov-action@v3
+        with:
+          files: ./build/logs/clover.xml
+          fail_ci_if_error: true
+          verbose: true

--- a/README.md
+++ b/README.md
@@ -6,10 +6,12 @@
 [![Latest Unstable Version](https://img.shields.io/badge/unstable-dev--develop-e68718.svg?maxAge=2419200)](https://packagist.org/packages/wp-coding-standards/wpcs#dev-develop)
 [![Last Commit to Unstable](https://img.shields.io/github/last-commit/WordPress/WordPress-Coding-Standards/develop.svg)](https://github.com/WordPress/WordPress-Coding-Standards/commits/develop)
 
-[![Minimum PHP Version](https://img.shields.io/packagist/php-v/wp-coding-standards/wpcs.svg?maxAge=3600)](https://packagist.org/packages/wp-coding-standards/wpcs)
-[![Tested on PHP 5.4 to 7.4 snapshot](https://img.shields.io/badge/tested%20on-PHP%205.4%20|%205.5%20|%205.6%20|%207.0%20|%207.1%20|%207.2%20|%207.3%20|%207.4snapshot-green.svg?maxAge=2419200)](https://github.com/WordPress/WordPress-Coding-Standards/actions/workflows/unit-tests.yml)
 [![Basic QA checks](https://github.com/WordPress/WordPress-Coding-Standards/actions/workflows/basic-qa.yml/badge.svg)](https://github.com/WordPress/WordPress-Coding-Standards/actions/workflows/basic-qa.yml)
 [![Unit Tests](https://github.com/WordPress/WordPress-Coding-Standards/actions/workflows/unit-tests.yml/badge.svg)](https://github.com/WordPress/WordPress-Coding-Standards/actions/workflows/unit-tests.yml)
+[![codecov.io](https://codecov.io/gh/WordPress/WordPress-Coding-Standards/branch/stable/graph/badge.svg?branch=develop)](https://codecov.io/gh/WordPress/WordPress-Coding-Standards?branch=develop)
+
+[![Minimum PHP Version](https://img.shields.io/packagist/php-v/wp-coding-standards/wpcs.svg?maxAge=3600)](https://packagist.org/packages/wp-coding-standards/wpcs)
+[![Tested on PHP 5.4 to 7.4 snapshot](https://img.shields.io/badge/tested%20on-PHP%205.4%20|%205.5%20|%205.6%20|%207.0%20|%207.1%20|%207.2%20|%207.3%20|%207.4snapshot-green.svg?maxAge=2419200)](https://github.com/WordPress/WordPress-Coding-Standards/actions/workflows/unit-tests.yml)
 
 [![License: MIT](https://poser.pugx.org/wp-coding-standards/wpcs/license)](https://github.com/WordPress/WordPress-Coding-Standards/blob/develop/LICENSE)
 [![Total Downloads](https://poser.pugx.org/wp-coding-standards/wpcs/downloads)](https://packagist.org/packages/wp-coding-standards/wpcs/stats)

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -27,7 +27,7 @@
 	</filter>
 
 	<logging>
-		<log type="coverage-text" target="php://stdout" showUncoveredFiles="true"/>
+		<log type="coverage-text" target="php://stdout" showOnlySummary="true"/>
 		<log type="coverage-clover" target="build/logs/clover.xml"/>
 	</logging>
 


### PR DESCRIPTION
Follow up after PR #2225 and other PRs which added more tests and raised code coverage.

The Codecov service is a way to monitor test vs code coverage of a project over time and allows for the code coverage % + delta to be reported in each PR.

This commit:
* Adds CodeCov configuration and ignores it for creating the package file.
    * Note: by default CodeCov reports back with build statuses (in the table at the bottom of a PR) + posts a really extensive comment on a PR.
        I personally find those comments + mail on each PR terribly annoying and unnecessary when the build statuses are set to required statuses anyway, so I've turned the posting of those comments off (via a setting in the configuration file).
    * Another thing to note is the patch - threshold setting being at `3%` (= 3% deviation allowed). The reason for setting that threshold a little wider is that code removals for fully covered code would otherwise quickly fail builds.
* Adds a badge showing off code coverage to the README.
* Adjusts the GH Actions workflows.
    * For the `test` workflow (PRs), the tests will selectively be run with code coverage (high/low PHP x high/low PHPCS).
    * For the `quicktest` workflow (pushes), which only runs high/low PHP/PHPCS, the code coverage will only be run for (merges to) the `develop` branch.
        This will allow us keep track of code coverage over time, while not slowing down the "quick test" for feature branch pushes.
        Note: I've simplified the conditions a little for this workflow as we only run against two known PHP versions anyway.

Note: As this is a public repo, we shouldn't need a repo secret for the CodeCov token. The normal GHA token will be used (and should work fine).

Refs:
* https://docs.codecov.com/docs
* https://docs.codecov.com/docs/codecovyml-reference

Note: as this PR can only partially be tested without it being merged, minor touch-up may be needed after this initial setup, but 🤞🏻  we should be good.