### PR TITLE
DateTime/CurrentTimeTimestamp: rename some local variables

### DIFF
--- a/WordPress/Sniffs/DateTime/CurrentTimeTimestampSniff.php
+++ b/WordPress/Sniffs/DateTime/CurrentTimeTimestampSniff.php
@@ -80,14 +80,15 @@ final class CurrentTimeTimestampSniff extends AbstractFunctionParameterSniff {
 			return;
 		}
 
+		$content_type = '';
 		for ( $i = $type_param['start']; $i <= $type_param['end']; $i++ ) {
 			if ( isset( Tokens::$emptyTokens[ $this->tokens[ $i ]['code'] ] ) ) {
 				continue;
 			}
 
 			if ( isset( Tokens::$textStringTokens[ $this->tokens[ $i ]['code'] ] ) ) {
-				$content_first = trim( TextStrings::stripQuotes( $this->tokens[ $i ]['content'] ) );
-				if ( 'U' !== $content_first && 'timestamp' !== $content_first ) {
+				$content_type = trim( TextStrings::stripQuotes( $this->tokens[ $i ]['content'] ) );
+				if ( 'U' !== $content_type && 'timestamp' !== $content_type ) {
 					// Most likely valid use of current_time().
 					return;
 				}
@@ -113,10 +114,10 @@ final class CurrentTimeTimestampSniff extends AbstractFunctionParameterSniff {
 		 */
 		$gmt_param = PassedParameters::getParameterFromStack( $parameters, 2, 'gmt' );
 		if ( is_array( $gmt_param ) ) {
-			$content_second = '';
+			$content_gmt = '';
 			if ( 'true' === $gmt_param['clean'] || '1' === $gmt_param['clean'] ) {
-				$content_second = $gmt_param['clean'];
-				$gmt_true       = true;
+				$content_gmt = $gmt_param['clean'];
+				$gmt_true    = true;
 			}
 		}
 
@@ -140,9 +141,9 @@ final class CurrentTimeTimestampSniff extends AbstractFunctionParameterSniff {
 		$error       = 'Don\'t use current_time() for retrieving a Unix (UTC) timestamp. Use time() instead. Found: %s';
 		$error_code  = 'RequestedUTC';
 
-		$code_snippet = "current_time( '" . $content_first . "'";
-		if ( isset( $content_second ) ) {
-			$code_snippet .= ', ' . $content_second;
+		$code_snippet = "current_time( '" . $content_type . "'";
+		if ( isset( $content_gmt ) ) {
+			$code_snippet .= ', ' . $content_gmt;
 		}
 		$code_snippet .= ' )';
 


### PR DESCRIPTION
... to be more descriptive in the context of named parameters.

Includes defensive coding tweak of making sure the `$content_type` variable is always defined.