### PR TITLE
Docs: array properties expect arrays

### DIFF
--- a/WordPress/Helpers/IsUnitTestTrait.php
+++ b/WordPress/Helpers/IsUnitTestTrait.php
@@ -61,7 +61,7 @@ trait IsUnitTestTrait {
 	 * @since 3.0.0  Moved from the Sniff class to this dedicated Trait.
 	 *               Renamed from `$custom_test_class_whitelist` to `$custom_test_classes`.
 	 *
-	 * @var string|string[]
+	 * @var string[]
 	 */
 	public $custom_test_classes = array();
 

--- a/WordPress/Sniffs/DB/DirectDatabaseQuerySniff.php
+++ b/WordPress/Sniffs/DB/DirectDatabaseQuerySniff.php
@@ -35,7 +35,7 @@ final class DirectDatabaseQuerySniff extends Sniff {
 	 *
 	 * @since 0.6.0
 	 *
-	 * @var string|string[]
+	 * @var string[]
 	 */
 	public $customCacheGetFunctions = array();
 
@@ -44,7 +44,7 @@ final class DirectDatabaseQuerySniff extends Sniff {
 	 *
 	 * @since 0.6.0
 	 *
-	 * @var string|string[]
+	 * @var string[]
 	 */
 	public $customCacheSetFunctions = array();
 
@@ -53,7 +53,7 @@ final class DirectDatabaseQuerySniff extends Sniff {
 	 *
 	 * @since 0.6.0
 	 *
-	 * @var string|string[]
+	 * @var string[]
 	 */
 	public $customCacheDeleteFunctions = array();
 

--- a/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
+++ b/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
@@ -71,9 +71,9 @@ final class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 	 *
 	 * @since 0.12.0
 	 *
-	 * @var string[]|string
+	 * @var string[]
 	 */
-	public $prefixes = '';
+	public $prefixes = array();
 
 	/**
 	 * Prefix blocklist.

--- a/WordPress/Sniffs/NamingConventions/ValidVariableNameSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidVariableNameSniff.php
@@ -78,7 +78,7 @@ final class ValidVariableNameSniff extends PHPCS_AbstractVariableSniff {
 	 * @since 0.11.0
 	 * @since 3.0.0  Renamed from `$customPropertiesWhitelist` to `$allowed_custom_properties`.
 	 *
-	 * @var string|string[]
+	 * @var string[]
 	 */
 	public $allowed_custom_properties = array();
 

--- a/WordPress/Sniffs/Security/NonceVerificationSniff.php
+++ b/WordPress/Sniffs/Security/NonceVerificationSniff.php
@@ -57,7 +57,7 @@ class NonceVerificationSniff extends Sniff {
 	 *
 	 * @since 0.5.0
 	 *
-	 * @var string|string[]
+	 * @var string[]
 	 */
 	public $customNonceVerificationFunctions = array();
 

--- a/WordPress/Sniffs/Utils/I18nTextDomainFixerSniff.php
+++ b/WordPress/Sniffs/Utils/I18nTextDomainFixerSniff.php
@@ -46,7 +46,7 @@ final class I18nTextDomainFixerSniff extends AbstractFunctionParameterSniff {
 	 *
 	 * @since 1.2.0
 	 *
-	 * @var string[]|string
+	 * @var string[]
 	 */
 	public $old_text_domain;
 

--- a/WordPress/Sniffs/WP/I18nSniff.php
+++ b/WordPress/Sniffs/WP/I18nSniff.php
@@ -89,7 +89,7 @@ final class I18nSniff extends AbstractFunctionParameterSniff {
 	/**
 	 * Text domain.
 	 *
-	 * @var string[]|string
+	 * @var string[]
 	 */
 	public $text_domain;
 


### PR DESCRIPTION
Follow up on #1584, which was included in WPCS 2.0.0.

While PHPCS still supports the _old_ array syntax (comma-delimited string), WPCS no longer has a (WPCS native) tolerance for those properties being passed with the `type="array"` attribute, so these public properties should always be arrays.