### PR TITLE
Sniff: move "missing unslashing" handling to callback function

### DIFF
--- a/WordPress/Sniffs/Security/ValidatedSanitizedInputSniff.php
+++ b/WordPress/Sniffs/Security/ValidatedSanitizedInputSniff.php
@@ -9,6 +9,7 @@
 
 namespace WordPressCS\WordPress\Sniffs\Security;
 
+use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\Utils\TextStrings;
 use WordPressCS\WordPress\Helpers\ContextHelper;
@@ -160,7 +161,7 @@ class ValidatedSanitizedInputSniff extends Sniff {
 		}
 
 		// Now look for sanitizing functions.
-		if ( ! $this->is_sanitized( $stackPtr, true ) ) {
+		if ( ! $this->is_sanitized( $stackPtr, array( $this, 'add_unslash_error' ) ) ) {
 			$this->phpcsFile->addError(
 				'Detected usage of a non-sanitized input variable: %s',
 				$stackPtr,
@@ -168,5 +169,29 @@ class ValidatedSanitizedInputSniff extends Sniff {
 				$error_data
 			);
 		}
+	}
+
+	/**
+	 * Add an error for missing use of unslashing.
+	 *
+	 * @since 0.5.0
+	 * @since 3.0.0 - Moved from the `Sniff` class to this class.
+	 *              - The `$phpcsFile` parameter was added.
+	 *
+	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+	 * @param int                         $stackPtr  The index of the token in the stack
+	 *                                               which is missing unslashing.
+	 *
+	 * @return void
+	 */
+	public function add_unslash_error( File $phpcsFile, $stackPtr ) {
+		$tokens = $phpcsFile->getTokens();
+
+		$phpcsFile->addError(
+			'%s data not unslashed before sanitization. Use wp_unslash() or similar',
+			$stackPtr,
+			'MissingUnslash',
+			array( $tokens[ $stackPtr ]['content'] )
+		);
 	}
 }


### PR DESCRIPTION
As things were, the "missing unslashing" error was being thrown from the `Sniff::is_sanitized()` method, based on whether the `$require_unslash` parameter was set to `true` or `false`.

In my opinion, it should not be the responsibility of utility functions to throw errors/warning, but always of the originating sniff.

This commit replaces the boolean `$require_unslash` parameter for the `Sniff::is_sanitized()` method to a nullable callable `$unslash_callback` parameter.

Instead of letting the `Sniff::is_sanitized()` method throw the error/warning, the callback will now be called and as the originating sniff passes the callback, the originating sniff can now handle the throwing of the error/warning.

To remove any presumptions of the callback being passed, being in the same context as the utility method/originating sniff and having access to the `$phpcsFile` via a property, the callback will receive both the `$phpcsFile` as well as the `$stackPtr` as parameters.

The "missing unslash" check can still be skipped by not passing the parameter or by passing anything non-callable. This maintains the original behaviour for the method for the default value/`false` case.

The `Sniff::add_unslash_error()` method can with this change now be moved to the `ValidatedSanitizedInput` sniff and that sniff will now have full control over the error message and error code.

Note: the callback is called using `call_user_func()` instead of `$callable` to allow some tolerance for the _partially supported callables_, which were deprecated in PHP 8.2. While WPCS itself does not use these, the `ValidatedSanitizedInputSniff` is one of the exceptions which has not been made `final`, so an extending class _could_ use one of the _partially supported callables_ and the `Sniff::is_sanitized()` method should not be the reason that doesn't work.