### PR TITLE
Various minor docs fixes

### DIFF
--- a/WordPress/Helpers/ContextHelper.php
+++ b/WordPress/Helpers/ContextHelper.php
@@ -37,7 +37,7 @@ final class ContextHelper {
 	 * @since 3.0.0 - Moved from the Sniff class to this class.
 	 *              - The property visibility was changed from `protected` to `private static`.
 	 *
-	 * @var array
+	 * @var array<int|string, true> Key is token constant, value irrelevant.
 	 */
 	private static $safe_casts = array(
 		\T_INT_CAST    => true,
@@ -58,7 +58,7 @@ final class ContextHelper {
 	 * @since 3.0.0 - Moved from the Sniff class to this class.
 	 *              - The property visibility was changed from `protected` to `private static`.
 	 *
-	 * @var array
+	 * @var array<string, true> Key is function name, value irrelevant.
 	 */
 	private static $typeTestFunctions = array(
 		'is_array'     => true,
@@ -85,7 +85,7 @@ final class ContextHelper {
 	 *
 	 * @since 3.0.0
 	 *
-	 * @var array
+	 * @var array<string, true> Key is function name, value irrelevant.
 	 */
 	private static $key_exists_functions = array(
 		'array_key_exists' => true,
@@ -102,7 +102,7 @@ final class ContextHelper {
 	 * @since 3.0.0 - Moved from the Sniff class to this class.
 	 *              - The property visibility was changed from `protected` to `private static`.
 	 *
-	 * @var array <string function name> => <true|array>
+	 * @var array<string, bool|array>
 	 */
 	private static $arrayCompareFunctions = array(
 		'in_array'     => true,
@@ -327,7 +327,7 @@ final class ContextHelper {
 	 *
 	 * @since 3.0.0
 	 *
-	 * @return array<string, bool>
+	 * @return array<int|string, true>
 	 */
 	public static function get_safe_cast_tokens() {
 		return self::$safe_casts;

--- a/WordPress/Helpers/IsUnitTestTrait.php
+++ b/WordPress/Helpers/IsUnitTestTrait.php
@@ -76,7 +76,7 @@ trait IsUnitTestTrait {
 	 *               - Renamed from `$test_class_whitelist` to `$known_test_classes`.
 	 *               - Visibility changed from protected to private.
 	 *
-	 * @var string[]
+	 * @var array<string, true> Key is class name, value irrelevant.
 	 */
 	private $known_test_classes = array(
 		// Base test cases.
@@ -125,7 +125,7 @@ trait IsUnitTestTrait {
 	 *
 	 * @since 3.0.0
 	 *
-	 * @var array<string, bool>
+	 * @return array<string, bool>
 	 */
 	protected function get_all_test_classes() {
 		if ( array() === $this->all_test_classes

--- a/WordPress/Helpers/SanitizationHelperTrait.php
+++ b/WordPress/Helpers/SanitizationHelperTrait.php
@@ -75,7 +75,7 @@ trait SanitizationHelperTrait {
 	 * @since 3.0.0  - Moved from the Sniff class to this trait.
 	 *               - Visibility changed from protected to private.
 	 *
-	 * @var array<string, bool>
+	 * @var array<string, true>
 	 */
 	private $sanitizingFunctions = array(
 		'_wp_handle_upload'          => true,
@@ -188,7 +188,7 @@ trait SanitizationHelperTrait {
 	 *
 	 * @since 3.0.0
 	 *
-	 * @var array<string, bool>
+	 * @return array<string, bool>
 	 */
 	public function get_sanitizing_functions() {
 		if ( array() === $this->allSanitizingFunctions
@@ -210,7 +210,7 @@ trait SanitizationHelperTrait {
 	 *
 	 * @since 3.0.0
 	 *
-	 * @var array<string, bool>
+	 * @return array<string, bool>
 	 */
 	public function get_sanitizing_and_unslashing_functions() {
 		if ( array() === $this->allUnslashingSanitizingFunctions

--- a/WordPress/Helpers/ValidationHelper.php
+++ b/WordPress/Helpers/ValidationHelper.php
@@ -324,7 +324,7 @@ final class ValidationHelper {
 	 *
 	 * @param string[] $text_strings The input array.
 	 *
-	 * @var array
+	 * @return string[]
 	 */
 	private static function strip_quotes_from_array_values( array $text_strings ) {
 		return array_map( array( 'PHPCSUtils\Utils\TextStrings', 'stripQuotes' ), $text_strings );

--- a/WordPress/Helpers/WPHookHelper.php
+++ b/WordPress/Helpers/WPHookHelper.php
@@ -30,8 +30,8 @@ final class WPHookHelper {
 	 *               - The format of the value has changed from a non-relevant boolean to
 	 *                 an array with the parameter position and name(s) for the hook name parameter.
 	 *
-	 * @var array<string, <string, int|string|array>> Function name as key, array with target
-	 *                                                parameter position and name(s) as value.
+	 * @var array<string, array<string, int|string|string[]>> Function name as key, array with target
+	 *                                                        parameter position and name(s) as value.
 	 */
 	private static $hookInvokeFunctions = array(
 		'do_action' => array(

--- a/WordPress/Sniff.php
+++ b/WordPress/Sniff.php
@@ -94,6 +94,8 @@ abstract class Sniff implements PHPCS_Sniff {
 	 * @since 0.4.0
 	 *
 	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The file currently being processed.
+	 *
+	 * @return void
 	 */
 	protected function init( File $phpcsFile ) {
 		$this->phpcsFile = $phpcsFile;

--- a/WordPress/Sniffs/Arrays/ArrayIndentationSniff.php
+++ b/WordPress/Sniffs/Arrays/ArrayIndentationSniff.php
@@ -521,6 +521,8 @@ final class ArrayIndentationSniff extends Sniff {
 	 * @param int    $expected   Expected nr of spaces (tabs translated to space value).
 	 * @param int    $found      Found nr of spaces (tabs translated to space value).
 	 * @param string $new_indent Whitespace indent replacement content.
+	 *
+	 * @return void
 	 */
 	protected function add_array_alignment_error( $ptr, $error, $error_code, $expected, $found, $new_indent ) {
 
@@ -535,6 +537,8 @@ final class ArrayIndentationSniff extends Sniff {
 	 *
 	 * @param int    $ptr        Stack pointer to the first content on the line.
 	 * @param string $new_indent Whitespace indent replacement content.
+	 *
+	 * @return void
 	 */
 	protected function fix_alignment_error( $ptr, $new_indent ) {
 		if ( 1 === $this->tokens[ $ptr ]['column'] ) {

--- a/WordPress/Sniffs/Arrays/MultipleStatementAlignmentSniff.php
+++ b/WordPress/Sniffs/Arrays/MultipleStatementAlignmentSniff.php
@@ -543,6 +543,8 @@ final class MultipleStatementAlignmentSniff extends Sniff {
 	 * This message may be thrown more than once if the property is being changed inline in a file.
 	 *
 	 * @since 0.14.0
+	 *
+	 * @return void
 	 */
 	protected function validate_align_multiline_items() {
 		$alignMultilineItems = $this->alignMultilineItems;

--- a/WordPress/Sniffs/DateTime/CurrentTimeTimestampSniff.php
+++ b/WordPress/Sniffs/DateTime/CurrentTimeTimestampSniff.php
@@ -44,7 +44,7 @@ final class CurrentTimeTimestampSniff extends AbstractFunctionParameterSniff {
 	 *
 	 * @since 2.2.0
 	 *
-	 * @var array <string function_name> => <bool always needed ?>
+	 * @var array<string, true> Key is function name, value irrelevant.
 	 */
 	protected $target_functions = array(
 		'current_time' => true,

--- a/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
+++ b/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
@@ -81,7 +81,7 @@ final class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 	 * @since 0.12.0
 	 * @since 3.0.0  Renamed from `$prefix_blacklist` to `$prefix_blocklist`.
 	 *
-	 * @var string[]
+	 * @var array<string, true> Key is prefix, value irrelevant.
 	 */
 	protected $prefix_blocklist = array(
 		'wordpress' => true,
@@ -97,7 +97,7 @@ final class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 	 *
 	 * @since 0.12.0
 	 *
-	 * @var string[]
+	 * @var array<string, string>
 	 */
 	private $validated_prefixes = array();
 
@@ -111,7 +111,7 @@ final class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 	 *
 	 * @since 1.2.0
 	 *
-	 * @var array
+	 * @var array<string, array<string, mixed>>
 	 */
 	private $validated_namespace_prefixes = array();
 
@@ -132,7 +132,7 @@ final class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 	 * @since 0.14.0
 	 * @since 3.0.0 Renamed from `$whitelisted_core_hooks` to `$allowed_core_hooks`.
 	 *
-	 * @var array<string, bool>
+	 * @var array<string, true> Key is hook name, value irrelevant.
 	 */
 	protected $allowed_core_hooks = array(
 		'widget_title'   => true,
@@ -152,7 +152,7 @@ final class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 	 * @since 1.0.0
 	 * @since 3.0.0 Renamed from `$whitelisted_core_constants` to `$allowed_core_constants`.
 	 *
-	 * @var array<string, bool>
+	 * @var array<string, true> Key is constant name, value irrelevant.
 	 */
 	protected $allowed_core_constants = array(
 		'ADMIN_COOKIE_PATH'    => true,
@@ -203,7 +203,7 @@ final class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 	 *
 	 * @since 3.0.0.
 	 *
-	 * @var array<string, bool>
+	 * @var array<string, true> Key is function name, value irrelevant.
 	 */
 	protected $pluggable_functions = array(
 		'auth_redirect'                                  => true,
@@ -376,7 +376,7 @@ final class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 	 *
 	 * @since 3.0.0.
 	 *
-	 * @var array<string, bool>
+	 * @var array<string, true> Key is class name, value irrelevant.
 	 */
 	protected $pluggable_classes = array(
 		'TwentyTwenty_Customize'           => true,

--- a/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
+++ b/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
@@ -1186,6 +1186,8 @@ final class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 	 * - complies with the PHP rules for valid function, class, variable, constant names.
 	 *
 	 * @since 0.12.0
+	 *
+	 * @return void
 	 */
 	private function validate_prefixes() {
 		if ( $this->previous_prefixes === $this->prefixes ) {

--- a/WordPress/Sniffs/NamingConventions/ValidPostTypeSlugSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidPostTypeSlugSniff.php
@@ -52,7 +52,7 @@ final class ValidPostTypeSlugSniff extends AbstractFunctionParameterSniff {
 	 *
 	 * @since 2.2.0
 	 *
-	 * @var array List of function names as keys. Value irrelevant.
+	 * @var array<string, true> Key is function name, value irrelevant.
 	 */
 	protected $target_functions = array(
 		'register_post_type' => true,
@@ -67,7 +67,7 @@ final class ValidPostTypeSlugSniff extends AbstractFunctionParameterSniff {
 	 *
 	 * @since 2.2.0
 	 *
-	 * @var array
+	 * @var array<string, true> Key is reserved post type name, value irrelevant.
 	 */
 	protected $reserved_names = array(
 		'action'              => true, // Not a WP post type, but prevents other problems.
@@ -97,7 +97,7 @@ final class ValidPostTypeSlugSniff extends AbstractFunctionParameterSniff {
 	 *
 	 * @since 2.2.0
 	 *
-	 * @var string
+	 * @var array<int|string, int|string>
 	 */
 	private $valid_tokens = array();
 
@@ -122,7 +122,7 @@ final class ValidPostTypeSlugSniff extends AbstractFunctionParameterSniff {
 	 * @since 2.2.0
 	 *
 	 * @param int    $stackPtr        The position of the current token in the stack.
-	 * @param array  $group_name      The name of the group which was matched.
+	 * @param string $group_name      The name of the group which was matched.
 	 * @param string $matched_content The token content (function name) which was matched
 	 *                                in lowercase.
 	 * @param array  $parameters      Array with information about the parameters.

--- a/WordPress/Sniffs/PHP/NoSilencedErrorsSniff.php
+++ b/WordPress/Sniffs/PHP/NoSilencedErrorsSniff.php
@@ -60,7 +60,7 @@ final class NoSilencedErrorsSniff extends Sniff {
 	 * @since 1.1.0
 	 * @since 3.0.0 Renamed from `$custom_whitelist` to `$customAllowedFunctionsList`.
 	 *
-	 * @var array
+	 * @var string[]
 	 */
 	public $customAllowedFunctionsList = array();
 
@@ -81,7 +81,7 @@ final class NoSilencedErrorsSniff extends Sniff {
 	 * @since 1.1.0
 	 * @since 3.0.0 Renamed from `$function_whitelist` to `$allowedFunctionsList`.
 	 *
-	 * @var array <string function name> => <bool true>
+	 * @var array<string, true> Key is function name, value irrelevant.
 	 */
 	protected $allowedFunctionsList = array(
 		// Directory extension.
@@ -154,7 +154,7 @@ final class NoSilencedErrorsSniff extends Sniff {
 	 *
 	 * @since 1.1.0
 	 *
-	 * @var array
+	 * @var array<int|string, int|string>
 	 */
 	private $empty_tokens = array();
 

--- a/WordPress/Sniffs/PHP/PregQuoteDelimiterSniff.php
+++ b/WordPress/Sniffs/PHP/PregQuoteDelimiterSniff.php
@@ -35,7 +35,7 @@ final class PregQuoteDelimiterSniff extends AbstractFunctionParameterSniff {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @var array <string function_name> => <bool>
+	 * @var array<string, true> Key is function name, value irrelevant.
 	 */
 	protected $target_functions = array(
 		'preg_quote' => true,

--- a/WordPress/Sniffs/Security/EscapeOutputSniff.php
+++ b/WordPress/Sniffs/Security/EscapeOutputSniff.php
@@ -403,7 +403,10 @@ class EscapeOutputSniff extends AbstractFunctionRestrictionsSniff {
 
 		$params = PassedParameters::getParameters( $this->phpcsFile, $stackPtr );
 
-		// These functions only need to have their first argument escaped.
+		/*
+		 * These functions only need to have their first argument - `$message` - escaped.
+		 * Note: user_error() is an alias for trigger_error(), so the param names are the same.
+		 */
 		if ( 'trigger_error' === $matched_content || 'user_error' === $matched_content ) {
 			$message_param = PassedParameters::getParameterFromStack( $params, 1, 'message' );
 			if ( false === $message_param ) {
@@ -415,7 +418,7 @@ class EscapeOutputSniff extends AbstractFunctionRestrictionsSniff {
 		}
 
 		/*
-		 * If the first param to `_deprecated_file()` follows the typical `basename( __FILE__ )`
+		 * If the first param to `_deprecated_file()` - `$file` - follows the typical `basename( __FILE__ )`
 		 * pattern, it doesn't need to be escaped.
 		 */
 		if ( '_deprecated_file' === $matched_content ) {

--- a/WordPress/Sniffs/Security/PluginMenuSlugSniff.php
+++ b/WordPress/Sniffs/Security/PluginMenuSlugSniff.php
@@ -44,9 +44,9 @@ final class PluginMenuSlugSniff extends AbstractFunctionParameterSniff {
 	 *               array containing parameter positions to an array with the parameter
 	 *               position as the index and the parameter name as value.
 	 *
-	 * @var array<string, <int, string|array>> Key is the name of the functions being targetted.
-	 *                                         Value is an array with parameter positions as the
-	 *                                         keys and parameter names as the values
+	 * @var array<string, array<int, string|array>> Key is the name of the functions being targetted.
+	 *                                              Value is an array with parameter positions as the
+	 *                                              keys and parameter names as the values
 	 */
 	protected $target_functions = array(
 		'add_comments_page'   => array(

--- a/WordPress/Sniffs/Utils/I18nTextDomainFixerSniff.php
+++ b/WordPress/Sniffs/Utils/I18nTextDomainFixerSniff.php
@@ -262,8 +262,8 @@ final class I18nTextDomainFixerSniff extends AbstractFunctionParameterSniff {
 	 *
 	 * @since 1.2.0
 	 *
-	 * @var array Array key is the header name, the value indicated whether it is a
-	 *            required (true) or optional (false) header.
+	 * @var array<string, bool> Array key is the header name, the value indicated whether it is a
+	 *                          required (true) or optional (false) header.
 	 */
 	private $theme_headers = array(
 		'Theme Name'        => true,
@@ -289,8 +289,8 @@ final class I18nTextDomainFixerSniff extends AbstractFunctionParameterSniff {
 	 *
 	 * @since 1.2.0
 	 *
-	 * @var array Array key is the header name, the value indicated whether it is a
-	 *            required (true) or optional (false) header.
+	 * @var array<string, bool> Array key is the header name, the value indicated whether it is a
+	 *                          required (true) or optional (false) header.
 	 */
 	private $plugin_headers = array(
 		'Plugin Name'       => true,
@@ -345,7 +345,7 @@ final class I18nTextDomainFixerSniff extends AbstractFunctionParameterSniff {
 	 *
 	 * @since 1.2.0
 	 *
-	 * @var integer
+	 * @var int
 	 */
 	private $tab_width = null;
 

--- a/WordPress/Sniffs/WP/CapabilitiesSniff.php
+++ b/WordPress/Sniffs/WP/CapabilitiesSniff.php
@@ -152,7 +152,7 @@ final class CapabilitiesSniff extends AbstractFunctionParameterSniff {
 	 *
 	 * @since 3.0.0
 	 *
-	 * @var array<string, bool> Role available in WP Core.
+	 * @var array<string, true> Key is role available in WP Core, value irrelevant.
 	 */
 	private $core_roles = array(
 		'super_admin'   => true,
@@ -177,7 +177,7 @@ final class CapabilitiesSniff extends AbstractFunctionParameterSniff {
 	 *
 	 * @since 3.0.0
 	 *
-	 * @var array<string, bool> All capabilities available in core.
+	 * @var array<string, true> All capabilities available in core.
 	 */
 	private $core_capabilities = array(
 		'activate_plugin'             => true,
@@ -349,7 +349,7 @@ final class CapabilitiesSniff extends AbstractFunctionParameterSniff {
 	 * @since 3.0.0
 	 *
 	 * @param int    $stackPtr        The position of the current token in the stack.
-	 * @param array  $group_name      The name of the group which was matched.
+	 * @param string $group_name      The name of the group which was matched.
 	 * @param string $matched_content The token content (function name) which was matched
 	 *                                in lowercase.
 	 * @param array  $parameters      Array with information about the parameters.

--- a/WordPress/Sniffs/WP/CronIntervalSniff.php
+++ b/WordPress/Sniffs/WP/CronIntervalSniff.php
@@ -308,6 +308,8 @@ final class CronIntervalSniff extends Sniff {
 	 * Add warning about unclear cron schedule change.
 	 *
 	 * @param int $stackPtr The position of the current token in the stack.
+	 *
+	 * @return void
 	 */
 	public function confused( $stackPtr ) {
 		$this->phpcsFile->addWarning(

--- a/WordPress/Sniffs/WP/DiscouragedConstantsSniff.php
+++ b/WordPress/Sniffs/WP/DiscouragedConstantsSniff.php
@@ -51,8 +51,8 @@ final class DiscouragedConstantsSniff extends AbstractFunctionParameterSniff {
 	 * @since 3.0.0  The format of the value has changed from an integer parameter
 	 *               position to an array with the parameter position and name.
 	 *
-	 * @var array<string, <string, in|string>> Function name as key, array with target
-	 *                                         parameter and name as value.
+	 * @var array<string, array<string, int|string>> Function name as key, array with target
+	 *                                               parameter and name as value.
 	 */
 	protected $target_functions = array(
 		'define' => array(

--- a/WordPress/Sniffs/WP/EnqueuedResourceParametersSniff.php
+++ b/WordPress/Sniffs/WP/EnqueuedResourceParametersSniff.php
@@ -43,7 +43,7 @@ final class EnqueuedResourceParametersSniff extends AbstractFunctionParameterSni
 	 *
 	 * @since 1.0.0
 	 *
-	 * @var array <string function_name> => <bool true>
+	 * @var array<string, true> Key is function name, value irrelevant.
 	 */
 	protected $target_functions = array(
 		'wp_register_script' => true,
@@ -57,7 +57,7 @@ final class EnqueuedResourceParametersSniff extends AbstractFunctionParameterSni
 	 *
 	 * This array is enriched with the $emptyTokens array in the register() method.
 	 *
-	 * @var array
+	 * @var array<int|string, int|string>
 	 */
 	private $false_tokens = array(
 		\T_FALSE => \T_FALSE,
@@ -68,7 +68,7 @@ final class EnqueuedResourceParametersSniff extends AbstractFunctionParameterSni
 	 *
 	 * This array is enriched with the several of the PHPCS token arrays in the register() method.
 	 *
-	 * @var array
+	 * @var array<int|string, int|string>
 	 */
 	private $safe_tokens = array(
 		\T_NULL                     => \T_NULL,

--- a/WordPress/Sniffs/WP/EnqueuedResourcesSniff.php
+++ b/WordPress/Sniffs/WP/EnqueuedResourcesSniff.php
@@ -43,7 +43,8 @@ final class EnqueuedResourcesSniff extends Sniff {
 	 *
 	 * @param int $stackPtr The position of the current token in the stack.
 	 *
-	 * @return int Integer stack pointer to skip forward to.
+	 * @return int|void Integer stack pointer to skip forward or void to continue
+	 *                  normal file processing.
 	 */
 	public function process_token( $stackPtr ) {
 

--- a/WordPress/Sniffs/WP/GlobalVariablesOverrideSniff.php
+++ b/WordPress/Sniffs/WP/GlobalVariablesOverrideSniff.php
@@ -66,7 +66,7 @@ final class GlobalVariablesOverrideSniff extends Sniff {
 	 *
 	 * @since 2.2.0
 	 *
-	 * @var array
+	 * @var array<string, true> Key is variable name, value irrelevant.
 	 */
 	protected $override_allowed = array(
 		'content_width'     => true,

--- a/WordPress/Sniffs/WP/I18nSniff.php
+++ b/WordPress/Sniffs/WP/I18nSniff.php
@@ -99,7 +99,7 @@ final class I18nSniff extends AbstractFunctionParameterSniff {
 	 * @since 0.10.0
 	 * @since 0.11.0 Changed visibility from public to protected.
 	 *
-	 * @var array <string function name> => <string function type>
+	 * @var array<string, string> Key is function name, value is the function type.
 	 */
 	protected $i18n_functions = array(
 		'translate'                      => 'simple',
@@ -146,7 +146,7 @@ final class I18nSniff extends AbstractFunctionParameterSniff {
 	 *
 	 * @since 3.0.0
 	 *
-	 * @var array Array of the parameter positions and names.
+	 * @var array<string, array> Array of the parameter positions and names.
 	 */
 	private $parameter_specs = array(
 		'simple' => array(

--- a/WordPress/Tests/Arrays/ArrayDeclarationSpacingUnitTest.php
+++ b/WordPress/Tests/Arrays/ArrayDeclarationSpacingUnitTest.php
@@ -26,7 +26,7 @@ final class ArrayDeclarationSpacingUnitTest extends AbstractSniffUnitTest {
 	 *
 	 * @param string $testFile The name of the file being tested.
 	 *
-	 * @return array <int line number> => <int number of errors>
+	 * @return array<int, int> Key is the line number, value is the number of expected errors.
 	 */
 	public function getErrorList( $testFile = '' ) {
 
@@ -84,7 +84,7 @@ final class ArrayDeclarationSpacingUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where warnings should occur.
 	 *
-	 * @return array <int line number> => <int number of warnings>
+	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList() {
 		return array();

--- a/WordPress/Tests/Arrays/ArrayIndentationUnitTest.php
+++ b/WordPress/Tests/Arrays/ArrayIndentationUnitTest.php
@@ -48,7 +48,7 @@ final class ArrayIndentationUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where errors should occur.
 	 *
-	 * @return array <int line number> => <int number of errors>
+	 * @return array<int, int> Key is the line number, value is the number of expected errors.
 	 */
 	public function getErrorList() {
 		return array(
@@ -154,7 +154,7 @@ final class ArrayIndentationUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where warnings should occur.
 	 *
-	 * @return array <int line number> => <int number of warnings>
+	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList() {
 		return array();

--- a/WordPress/Tests/Arrays/ArrayKeySpacingRestrictionsUnitTest.php
+++ b/WordPress/Tests/Arrays/ArrayKeySpacingRestrictionsUnitTest.php
@@ -24,7 +24,7 @@ final class ArrayKeySpacingRestrictionsUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where errors should occur.
 	 *
-	 * @return array <int line number> => <int number of errors>
+	 * @return array<int, int> Key is the line number, value is the number of expected errors.
 	 */
 	public function getErrorList() {
 		return array(
@@ -65,7 +65,7 @@ final class ArrayKeySpacingRestrictionsUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where warnings should occur.
 	 *
-	 * @return array <int line number> => <int number of warnings>
+	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList() {
 		return array();

--- a/WordPress/Tests/Arrays/MultipleStatementAlignmentUnitTest.php
+++ b/WordPress/Tests/Arrays/MultipleStatementAlignmentUnitTest.php
@@ -51,7 +51,7 @@ final class MultipleStatementAlignmentUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where errors should occur.
 	 *
-	 * @return array <int line number> => <int number of errors>
+	 * @return array<int, int> Key is the line number, value is the number of expected errors.
 	 */
 	public function getErrorList() {
 		return array(
@@ -62,7 +62,7 @@ final class MultipleStatementAlignmentUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where warnings should occur.
 	 *
-	 * @return array <int line number> => <int number of warnings>
+	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList() {
 		return array(

--- a/WordPress/Tests/CodeAnalysis/AssignmentInTernaryConditionUnitTest.php
+++ b/WordPress/Tests/CodeAnalysis/AssignmentInTernaryConditionUnitTest.php
@@ -23,7 +23,7 @@ final class AssignmentInTernaryConditionUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where errors should occur.
 	 *
-	 * @return array <int line number> => <int number of errors>
+	 * @return array<int, int> Key is the line number, value is the number of expected errors.
 	 */
 	public function getErrorList() {
 		return array();
@@ -32,7 +32,7 @@ final class AssignmentInTernaryConditionUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where warnings should occur.
 	 *
-	 * @return array <int line number> => <int number of warnings>
+	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList() {
 		return array(

--- a/WordPress/Tests/CodeAnalysis/EscapedNotTranslatedUnitTest.php
+++ b/WordPress/Tests/CodeAnalysis/EscapedNotTranslatedUnitTest.php
@@ -23,7 +23,7 @@ final class EscapedNotTranslatedUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where errors should occur.
 	 *
-	 * @return array <int line number> => <int number of errors>
+	 * @return array<int, int> Key is the line number, value is the number of expected errors.
 	 */
 	public function getErrorList() {
 		return array();
@@ -32,7 +32,7 @@ final class EscapedNotTranslatedUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where warnings should occur.
 	 *
-	 * @return array <int line number> => <int number of warnings>
+	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList() {
 		return array(

--- a/WordPress/Tests/DB/DirectDatabaseQueryUnitTest.php
+++ b/WordPress/Tests/DB/DirectDatabaseQueryUnitTest.php
@@ -26,7 +26,7 @@ final class DirectDatabaseQueryUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where errors should occur.
 	 *
-	 * @return array <int line number> => <int number of errors>
+	 * @return array<int, int> Key is the line number, value is the number of expected errors.
 	 */
 	public function getErrorList() {
 		return array();
@@ -35,7 +35,7 @@ final class DirectDatabaseQueryUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where warnings should occur.
 	 *
-	 * @return array <int line number> => <int number of warnings>
+	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList() {
 		return array(

--- a/WordPress/Tests/DB/PreparedSQLPlaceholdersUnitTest.php
+++ b/WordPress/Tests/DB/PreparedSQLPlaceholdersUnitTest.php
@@ -23,7 +23,7 @@ final class PreparedSQLPlaceholdersUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where errors should occur.
 	 *
-	 * @return array <int line number> => <int number of errors>
+	 * @return array<int, int> Key is the line number, value is the number of expected errors.
 	 */
 	public function getErrorList() {
 		return array(
@@ -112,7 +112,7 @@ final class PreparedSQLPlaceholdersUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where warnings should occur.
 	 *
-	 * @return array <int line number> => <int number of warnings>
+	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList() {
 		return array(

--- a/WordPress/Tests/DB/PreparedSQLUnitTest.php
+++ b/WordPress/Tests/DB/PreparedSQLUnitTest.php
@@ -30,7 +30,7 @@ final class PreparedSQLUnitTest extends AbstractSniffUnitTest {
 	 *
 	 * @param string $testFile The name of the file being tested.
 	 *
-	 * @return array <int line number> => <int number of errors>
+	 * @return array<int, int> Key is the line number, value is the number of expected errors.
 	 */
 	public function getErrorList( $testFile = '' ) {
 		switch ( $testFile ) {
@@ -86,7 +86,7 @@ final class PreparedSQLUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where warnings should occur.
 	 *
-	 * @return array <int line number> => <int number of warnings>
+	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList() {
 		return array();

--- a/WordPress/Tests/DB/RestrictedClassesUnitTest.php
+++ b/WordPress/Tests/DB/RestrictedClassesUnitTest.php
@@ -63,7 +63,8 @@ final class RestrictedClassesUnitTest extends AbstractSniffUnitTest {
 	 * Returns the lines where errors should occur.
 	 *
 	 * @param string $testFile The name of the file being tested.
-	 * @return array <int line number> => <int number of errors>
+	 *
+	 * @return array<int, int> Key is the line number, value is the number of expected errors.
 	 */
 	public function getErrorList( $testFile = '' ) {
 		switch ( $testFile ) {
@@ -155,7 +156,7 @@ final class RestrictedClassesUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where warnings should occur.
 	 *
-	 * @return array <int line number> => <int number of warnings>
+	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList() {
 		return array();

--- a/WordPress/Tests/DB/RestrictedClassesUnitTest.php
+++ b/WordPress/Tests/DB/RestrictedClassesUnitTest.php
@@ -33,6 +33,8 @@ final class RestrictedClassesUnitTest extends AbstractSniffUnitTest {
 	 * where we are passing the parameters to.
 	 *
 	 * @before
+	 *
+	 * @return void
 	 */
 	protected function enhanceGroups() {
 		parent::setUp();
@@ -53,6 +55,8 @@ final class RestrictedClassesUnitTest extends AbstractSniffUnitTest {
 	 * Reset the $groups property.
 	 *
 	 * @after
+	 *
+	 * @return void
 	 */
 	protected function resetGroups() {
 		AbstractFunctionRestrictionsSniff::$unittest_groups = array();

--- a/WordPress/Tests/DB/RestrictedFunctionsUnitTest.php
+++ b/WordPress/Tests/DB/RestrictedFunctionsUnitTest.php
@@ -60,7 +60,7 @@ final class RestrictedFunctionsUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where errors should occur.
 	 *
-	 * @return array <int line number> => <int number of errors>
+	 * @return array<int, int> Key is the line number, value is the number of expected errors.
 	 */
 	public function getErrorList() {
 		return array(
@@ -118,7 +118,7 @@ final class RestrictedFunctionsUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where warnings should occur.
 	 *
-	 * @return array <int line number> => <int number of warnings>
+	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList() {
 		return array();

--- a/WordPress/Tests/DB/RestrictedFunctionsUnitTest.php
+++ b/WordPress/Tests/DB/RestrictedFunctionsUnitTest.php
@@ -28,6 +28,8 @@ final class RestrictedFunctionsUnitTest extends AbstractSniffUnitTest {
 	 * AbstractFunctionRestrictionsSniff class.
 	 *
 	 * @before
+	 *
+	 * @return void
 	 */
 	protected function enhanceGroups() {
 		parent::setUp();
@@ -51,6 +53,8 @@ final class RestrictedFunctionsUnitTest extends AbstractSniffUnitTest {
 	 * Reset the $groups property.
 	 *
 	 * @after
+	 *
+	 * @return void
 	 */
 	protected function resetGroups() {
 		AbstractFunctionRestrictionsSniff::$unittest_groups = array();

--- a/WordPress/Tests/DB/SlowDBQueryUnitTest.php
+++ b/WordPress/Tests/DB/SlowDBQueryUnitTest.php
@@ -26,7 +26,7 @@ final class SlowDBQueryUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where errors should occur.
 	 *
-	 * @return array <int line number> => <int number of errors>
+	 * @return array<int, int> Key is the line number, value is the number of expected errors.
 	 */
 	public function getErrorList() {
 		return array();
@@ -35,7 +35,7 @@ final class SlowDBQueryUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where warnings should occur.
 	 *
-	 * @return array <int line number> => <int number of warnings>
+	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList() {
 		return array(

--- a/WordPress/Tests/DateTime/CurrentTimeTimestampUnitTest.php
+++ b/WordPress/Tests/DateTime/CurrentTimeTimestampUnitTest.php
@@ -23,7 +23,7 @@ final class CurrentTimeTimestampUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where errors should occur.
 	 *
-	 * @return array <int line number> => <int number of errors>
+	 * @return array<int, int> Key is the line number, value is the number of expected errors.
 	 */
 	public function getErrorList() {
 		return array(
@@ -37,7 +37,7 @@ final class CurrentTimeTimestampUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where warnings should occur.
 	 *
-	 * @return array <int line number> => <int number of warnings>
+	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList() {
 		return array(

--- a/WordPress/Tests/DateTime/RestrictedFunctionsUnitTest.php
+++ b/WordPress/Tests/DateTime/RestrictedFunctionsUnitTest.php
@@ -23,7 +23,7 @@ final class RestrictedFunctionsUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where errors should occur.
 	 *
-	 * @return array <int line number> => <int number of errors>
+	 * @return array<int, int> Key is the line number, value is the number of expected errors.
 	 */
 	public function getErrorList() {
 		return array(
@@ -35,7 +35,7 @@ final class RestrictedFunctionsUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where warnings should occur.
 	 *
-	 * @return array <int line number> => <int number of warnings>
+	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList() {
 		return array();

--- a/WordPress/Tests/Files/FileNameUnitTest.php
+++ b/WordPress/Tests/Files/FileNameUnitTest.php
@@ -150,7 +150,8 @@ final class FileNameUnitTest extends AbstractSniffUnitTest {
 	 * Returns the lines where errors should occur.
 	 *
 	 * @param string $testFile The name of the file being tested.
-	 * @return array <int line number> => <int number of errors>
+	 *
+	 * @return array<int, int> Key is the line number, value is the number of expected errors.
 	 */
 	public function getErrorList( $testFile = '' ) {
 
@@ -166,7 +167,7 @@ final class FileNameUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where warnings should occur.
 	 *
-	 * @return array <int line number> => <int number of warnings>
+	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList() {
 		return array();

--- a/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.php
+++ b/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.php
@@ -26,7 +26,8 @@ final class PrefixAllGlobalsUnitTest extends AbstractSniffUnitTest {
 	 * Returns the lines where errors should occur.
 	 *
 	 * @param string $testFile The name of the file being tested.
-	 * @return array <int line number> => <int number of errors>
+	 *
+	 * @return array<int, int> Key is the line number, value is the number of expected errors.
 	 */
 	public function getErrorList( $testFile = 'PrefixAllGlobalsUnitTest.1.inc' ) {
 
@@ -116,7 +117,8 @@ final class PrefixAllGlobalsUnitTest extends AbstractSniffUnitTest {
 	 * Returns the lines where warnings should occur.
 	 *
 	 * @param string $testFile The name of the file being tested.
-	 * @return array <int line number> => <int number of warnings>
+	 *
+	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList( $testFile = 'PrefixAllGlobalsUnitTest.1.inc' ) {
 

--- a/WordPress/Tests/NamingConventions/ValidFunctionNameUnitTest.php
+++ b/WordPress/Tests/NamingConventions/ValidFunctionNameUnitTest.php
@@ -25,7 +25,7 @@ final class ValidFunctionNameUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where errors should occur.
 	 *
-	 * @return array <int line number> => <int number of errors>
+	 * @return array<int, int> Key is the line number, value is the number of expected errors.
 	 */
 	public function getErrorList() {
 		return array(
@@ -62,7 +62,7 @@ final class ValidFunctionNameUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where warnings should occur.
 	 *
-	 * @return array <int line number> => <int number of warnings>
+	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList() {
 		return array();

--- a/WordPress/Tests/NamingConventions/ValidHookNameUnitTest.php
+++ b/WordPress/Tests/NamingConventions/ValidHookNameUnitTest.php
@@ -26,7 +26,8 @@ final class ValidHookNameUnitTest extends AbstractSniffUnitTest {
 	 * Returns the lines where errors should occur.
 	 *
 	 * @param string $testFile The name of the file being tested.
-	 * @return array <int line number> => <int number of errors>
+	 *
+	 * @return array<int, int> Key is the line number, value is the number of expected errors.
 	 */
 	public function getErrorList( $testFile = 'ValidHookNameUnitTest.1.inc' ) {
 
@@ -87,7 +88,8 @@ final class ValidHookNameUnitTest extends AbstractSniffUnitTest {
 	 * Returns the lines where warnings should occur.
 	 *
 	 * @param string $testFile The name of the file being tested.
-	 * @return array <int line number> => <int number of warnings>
+	 *
+	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList( $testFile = 'ValidHookNameUnitTest.1.inc' ) {
 

--- a/WordPress/Tests/NamingConventions/ValidPostTypeSlugUnitTest.php
+++ b/WordPress/Tests/NamingConventions/ValidPostTypeSlugUnitTest.php
@@ -37,7 +37,7 @@ final class ValidPostTypeSlugUnitTest extends AbstractSniffUnitTest {
 	 *
 	 * @param string $testFile The name of the file being tested.
 	 *
-	 * @return array <int line number> => <int number of errors>
+	 * @return array<int, int> Key is the line number, value is the number of expected errors.
 	 */
 	public function getErrorList( $testFile = '' ) {
 		switch ( $testFile ) {
@@ -79,7 +79,7 @@ final class ValidPostTypeSlugUnitTest extends AbstractSniffUnitTest {
 	 *
 	 * @param string $testFile The name of the file being tested.
 	 *
-	 * @return array <int line number> => <int number of warnings>
+	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList( $testFile = '' ) {
 		switch ( $testFile ) {

--- a/WordPress/Tests/NamingConventions/ValidVariableNameUnitTest.php
+++ b/WordPress/Tests/NamingConventions/ValidVariableNameUnitTest.php
@@ -25,7 +25,7 @@ final class ValidVariableNameUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where errors should occur.
 	 *
-	 * @return array <int line number> => <int number of errors>
+	 * @return array<int, int> Key is the line number, value is the number of expected errors.
 	 */
 	public function getErrorList() {
 		return array(
@@ -103,7 +103,7 @@ final class ValidVariableNameUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where warnings should occur.
 	 *
-	 * @return array <int line number> => <int number of warnings>
+	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList() {
 		return array();

--- a/WordPress/Tests/PHP/DevelopmentFunctionsUnitTest.php
+++ b/WordPress/Tests/PHP/DevelopmentFunctionsUnitTest.php
@@ -24,7 +24,7 @@ final class DevelopmentFunctionsUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where errors should occur.
 	 *
-	 * @return array <int line number> => <int number of errors>
+	 * @return array<int, int> Key is the line number, value is the number of expected errors.
 	 */
 	public function getErrorList() {
 		return array();
@@ -33,7 +33,7 @@ final class DevelopmentFunctionsUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where warnings should occur.
 	 *
-	 * @return array <int line number> => <int number of warnings>
+	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList() {
 		return array(

--- a/WordPress/Tests/PHP/DiscouragedPHPFunctionsUnitTest.php
+++ b/WordPress/Tests/PHP/DiscouragedPHPFunctionsUnitTest.php
@@ -24,7 +24,7 @@ final class DiscouragedPHPFunctionsUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where errors should occur.
 	 *
-	 * @return array <int line number> => <int number of errors>
+	 * @return array<int, int> Key is the line number, value is the number of expected errors.
 	 */
 	public function getErrorList() {
 		return array();
@@ -33,7 +33,7 @@ final class DiscouragedPHPFunctionsUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where warnings should occur.
 	 *
-	 * @return array <int line number> => <int number of warnings>
+	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList() {
 		return array(

--- a/WordPress/Tests/PHP/DontExtractUnitTest.php
+++ b/WordPress/Tests/PHP/DontExtractUnitTest.php
@@ -25,7 +25,7 @@ final class DontExtractUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where errors should occur.
 	 *
-	 * @return array <int line number> => <int number of errors>
+	 * @return array<int, int> Key is the line number, value is the number of expected errors.
 	 */
 	public function getErrorList() {
 		return array(
@@ -36,7 +36,7 @@ final class DontExtractUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where warnings should occur.
 	 *
-	 * @return array <int line number> => <int number of warnings>
+	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList() {
 		return array();

--- a/WordPress/Tests/PHP/IniSetUnitTest.php
+++ b/WordPress/Tests/PHP/IniSetUnitTest.php
@@ -23,7 +23,7 @@ final class IniSetUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where errors should occur.
 	 *
-	 * @return array <int line number> => <int number of errors>
+	 * @return array<int, int> Key is the line number, value is the number of expected errors.
 	 */
 	public function getErrorList() {
 		return array(
@@ -55,7 +55,7 @@ final class IniSetUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where warnings should occur.
 	 *
-	 * @return array <int line number> => <int number of warnings>
+	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList() {
 		return array(

--- a/WordPress/Tests/PHP/NoSilencedErrorsUnitTest.php
+++ b/WordPress/Tests/PHP/NoSilencedErrorsUnitTest.php
@@ -23,7 +23,7 @@ final class NoSilencedErrorsUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where errors should occur.
 	 *
-	 * @return array <int line number> => <int number of errors>
+	 * @return array<int, int> Key is the line number, value is the number of expected errors.
 	 */
 	public function getErrorList() {
 		return array();
@@ -32,7 +32,7 @@ final class NoSilencedErrorsUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where warnings should occur.
 	 *
-	 * @return array <int line number> => <int number of warnings>
+	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList() {
 		return array(

--- a/WordPress/Tests/PHP/POSIXFunctionsUnitTest.php
+++ b/WordPress/Tests/PHP/POSIXFunctionsUnitTest.php
@@ -24,7 +24,7 @@ final class POSIXFunctionsUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where errors should occur.
 	 *
-	 * @return array <int line number> => <int number of errors>
+	 * @return array<int, int> Key is the line number, value is the number of expected errors.
 	 */
 	public function getErrorList() {
 		return array(
@@ -41,7 +41,7 @@ final class POSIXFunctionsUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where warnings should occur.
 	 *
-	 * @return array <int line number> => <int number of warnings>
+	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList() {
 		return array();

--- a/WordPress/Tests/PHP/PregQuoteDelimiterUnitTest.php
+++ b/WordPress/Tests/PHP/PregQuoteDelimiterUnitTest.php
@@ -23,7 +23,7 @@ final class PregQuoteDelimiterUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where errors should occur.
 	 *
-	 * @return array <int line number> => <int number of errors>
+	 * @return array<int, int> Key is the line number, value is the number of expected errors.
 	 */
 	public function getErrorList() {
 		return array();
@@ -32,7 +32,7 @@ final class PregQuoteDelimiterUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where warnings should occur.
 	 *
-	 * @return array <int line number> => <int number of warnings>
+	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList() {
 		return array(

--- a/WordPress/Tests/PHP/RestrictedPHPFunctionsUnitTest.php
+++ b/WordPress/Tests/PHP/RestrictedPHPFunctionsUnitTest.php
@@ -23,7 +23,7 @@ final class RestrictedPHPFunctionsUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where errors should occur.
 	 *
-	 * @return array <int line number> => <int number of errors>
+	 * @return array<int, int> Key is the line number, value is the number of expected errors.
 	 */
 	public function getErrorList() {
 		return array(
@@ -34,7 +34,7 @@ final class RestrictedPHPFunctionsUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where warnings should occur.
 	 *
-	 * @return array <int line number> => <int number of warnings>
+	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList() {
 		return array();

--- a/WordPress/Tests/PHP/StrictInArrayUnitTest.php
+++ b/WordPress/Tests/PHP/StrictInArrayUnitTest.php
@@ -25,7 +25,7 @@ final class StrictInArrayUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where errors should occur.
 	 *
-	 * @return array <int line number> => <int number of errors>
+	 * @return array<int, int> Key is the line number, value is the number of expected errors.
 	 */
 	public function getErrorList() {
 		return array();
@@ -34,7 +34,7 @@ final class StrictInArrayUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where warnings should occur.
 	 *
-	 * @return array <int line number> => <int number of warnings>
+	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList() {
 		return array(

--- a/WordPress/Tests/PHP/TypeCastsUnitTest.php
+++ b/WordPress/Tests/PHP/TypeCastsUnitTest.php
@@ -23,7 +23,7 @@ final class TypeCastsUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where errors should occur.
 	 *
-	 * @return array <int line number> => <int number of errors>
+	 * @return array<int, int> Key is the line number, value is the number of expected errors.
 	 */
 	public function getErrorList() {
 		return array(
@@ -39,7 +39,7 @@ final class TypeCastsUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where warnings should occur.
 	 *
-	 * @return array <int line number> => <int number of warnings>
+	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList() {
 		return array(

--- a/WordPress/Tests/PHP/YodaConditionsUnitTest.php
+++ b/WordPress/Tests/PHP/YodaConditionsUnitTest.php
@@ -24,7 +24,7 @@ final class YodaConditionsUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where errors should occur.
 	 *
-	 * @return array <int line number> => <int number of errors>
+	 * @return array<int, int> Key is the line number, value is the number of expected errors.
 	 */
 	public function getErrorList() {
 		return array(
@@ -53,7 +53,7 @@ final class YodaConditionsUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where warnings should occur.
 	 *
-	 * @return array <int line number> => <int number of warnings>
+	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList() {
 		return array();

--- a/WordPress/Tests/Security/EscapeOutputUnitTest.php
+++ b/WordPress/Tests/Security/EscapeOutputUnitTest.php
@@ -32,7 +32,7 @@ final class EscapeOutputUnitTest extends AbstractSniffUnitTest {
 	 *
 	 * @param string $testFile The name of the file being tested.
 	 *
-	 * @return array <int line number> => <int number of errors>
+	 * @return array<int, int> Key is the line number, value is the number of expected errors.
 	 */
 	public function getErrorList( $testFile = '' ) {
 		switch ( $testFile ) {
@@ -188,7 +188,7 @@ final class EscapeOutputUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where warnings should occur.
 	 *
-	 * @return array <int line number> => <int number of warnings>
+	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList() {
 		return array();

--- a/WordPress/Tests/Security/NonceVerificationUnitTest.php
+++ b/WordPress/Tests/Security/NonceVerificationUnitTest.php
@@ -31,7 +31,7 @@ final class NonceVerificationUnitTest extends AbstractSniffUnitTest {
 	 *
 	 * @param string $testFile The name of the file being tested.
 	 *
-	 * @return array <int line number> => <int number of errors>
+	 * @return array<int, int> Key is the line number, value is the number of expected errors.
 	 */
 	public function getErrorList( $testFile = '' ) {
 		switch ( $testFile ) {
@@ -98,7 +98,7 @@ final class NonceVerificationUnitTest extends AbstractSniffUnitTest {
 	 *
 	 * @param string $testFile The name of the file being tested.
 	 *
-	 * @return array <int line number> => <int number of warnings>
+	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList( $testFile = '' ) {
 		switch ( $testFile ) {

--- a/WordPress/Tests/Security/PluginMenuSlugUnitTest.php
+++ b/WordPress/Tests/Security/PluginMenuSlugUnitTest.php
@@ -25,7 +25,7 @@ final class PluginMenuSlugUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where errors should occur.
 	 *
-	 * @return array <int line number> => <int number of errors>
+	 * @return array<int, int> Key is the line number, value is the number of expected errors.
 	 */
 	public function getErrorList() {
 		return array();
@@ -34,7 +34,7 @@ final class PluginMenuSlugUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where warnings should occur.
 	 *
-	 * @return array <int line number> => <int number of warnings>
+	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList() {
 		return array(

--- a/WordPress/Tests/Security/SafeRedirectUnitTest.php
+++ b/WordPress/Tests/Security/SafeRedirectUnitTest.php
@@ -23,7 +23,7 @@ final class SafeRedirectUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where errors should occur.
 	 *
-	 * @return array <int line number> => <int number of errors>
+	 * @return array<int, int> Key is the line number, value is the number of expected errors.
 	 */
 	public function getErrorList() {
 		return array();
@@ -32,7 +32,7 @@ final class SafeRedirectUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where warnings should occur.
 	 *
-	 * @return array <int line number> => <int number of warnings>
+	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList() {
 		return array(

--- a/WordPress/Tests/Security/ValidatedSanitizedInputUnitTest.php
+++ b/WordPress/Tests/Security/ValidatedSanitizedInputUnitTest.php
@@ -32,7 +32,7 @@ final class ValidatedSanitizedInputUnitTest extends AbstractSniffUnitTest {
 	 *
 	 * @param string $testFile The name of the file being tested.
 	 *
-	 * @return array <int line number> => <int number of errors>
+	 * @return array<int, int> Key is the line number, value is the number of expected errors.
 	 */
 	public function getErrorList( $testFile = '' ) {
 		switch ( $testFile ) {
@@ -118,7 +118,7 @@ final class ValidatedSanitizedInputUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where warnings should occur.
 	 *
-	 * @return array <int line number> => <int number of warnings>
+	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList() {
 		return array();

--- a/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.php
+++ b/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.php
@@ -49,7 +49,8 @@ final class I18nTextDomainFixerUnitTest extends AbstractSniffUnitTest {
 	 * Returns the lines where errors should occur.
 	 *
 	 * @param string $testFile The name of the file being tested.
-	 * @return array <int line number> => <int number of errors>
+	 *
+	 * @return array<int, int> Key is the line number, value is the number of expected errors.
 	 */
 	public function getErrorList( $testFile = '' ) {
 
@@ -158,7 +159,8 @@ final class I18nTextDomainFixerUnitTest extends AbstractSniffUnitTest {
 	 * Returns the lines where warnings should occur.
 	 *
 	 * @param string $testFile The name of the file being tested.
-	 * @return array <int line number> => <int number of warnings>
+	 *
+	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList( $testFile = '' ) {
 		switch ( $testFile ) {

--- a/WordPress/Tests/WP/AlternativeFunctionsUnitTest.php
+++ b/WordPress/Tests/WP/AlternativeFunctionsUnitTest.php
@@ -25,7 +25,7 @@ final class AlternativeFunctionsUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where errors should occur.
 	 *
-	 * @return array <int line number> => <int number of errors>
+	 * @return array<int, int> Key is the line number, value is the number of expected errors.
 	 */
 	public function getErrorList() {
 		return array();
@@ -34,7 +34,7 @@ final class AlternativeFunctionsUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where warnings should occur.
 	 *
-	 * @return array <int line number> => <int number of warnings>
+	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList() {
 		return array(

--- a/WordPress/Tests/WP/CapabilitiesUnitTest.php
+++ b/WordPress/Tests/WP/CapabilitiesUnitTest.php
@@ -51,7 +51,7 @@ final class CapabilitiesUnitTest extends AbstractSniffUnitTest {
 	 *
 	 * @param string $testFile The name of the file being tested.
 	 *
-	 * @return array <int line number> => <int number of errors>
+	 * @return array<int, int> Key is the line number, value is the number of expected errors.
 	 */
 	public function getErrorList( $testFile = '' ) {
 		switch ( $testFile ) {
@@ -99,7 +99,7 @@ final class CapabilitiesUnitTest extends AbstractSniffUnitTest {
 	 *
 	 * @param string $testFile The name of the file being tested.
 	 *
-	 * @return array <int line number> => <int number of warnings>
+	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList( $testFile = '' ) {
 		switch ( $testFile ) {

--- a/WordPress/Tests/WP/CapitalPDangitUnitTest.php
+++ b/WordPress/Tests/WP/CapitalPDangitUnitTest.php
@@ -24,7 +24,7 @@ final class CapitalPDangitUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where errors should occur.
 	 *
-	 * @return array <int line number> => <int number of errors>
+	 * @return array<int, int> Key is the line number, value is the number of expected errors.
 	 */
 	public function getErrorList() {
 		return array();
@@ -35,7 +35,7 @@ final class CapitalPDangitUnitTest extends AbstractSniffUnitTest {
 	 *
 	 * @param string $testFile The name of the file being tested.
 	 *
-	 * @return array <int line number> => <int number of warnings>
+	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList( $testFile = '' ) {
 		switch ( $testFile ) {

--- a/WordPress/Tests/WP/ClassNameCaseUnitTest.php
+++ b/WordPress/Tests/WP/ClassNameCaseUnitTest.php
@@ -23,7 +23,7 @@ final class ClassNameCaseUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where errors should occur.
 	 *
-	 * @return array <int line number> => <int number of errors>
+	 * @return array<int, int> Key is the line number, value is the number of expected errors.
 	 */
 	public function getErrorList() {
 		return array();
@@ -32,7 +32,7 @@ final class ClassNameCaseUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where warnings should occur.
 	 *
-	 * @return array <int line number> => <int number of warnings>
+	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList() {
 		return array(

--- a/WordPress/Tests/WP/CronIntervalUnitTest.php
+++ b/WordPress/Tests/WP/CronIntervalUnitTest.php
@@ -25,7 +25,7 @@ final class CronIntervalUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where errors should occur.
 	 *
-	 * @return array <int line number> => <int number of errors>
+	 * @return array<int, int> Key is the line number, value is the number of expected errors.
 	 */
 	public function getErrorList() {
 		return array();
@@ -34,7 +34,7 @@ final class CronIntervalUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where warnings should occur.
 	 *
-	 * @return array <int line number> => <int number of warnings>
+	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList() {
 		return array(

--- a/WordPress/Tests/WP/DeprecatedClassesUnitTest.php
+++ b/WordPress/Tests/WP/DeprecatedClassesUnitTest.php
@@ -24,7 +24,7 @@ final class DeprecatedClassesUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where errors should occur.
 	 *
-	 * @return array <int line number> => <int number of errors>
+	 * @return array<int, int> Key is the line number, value is the number of expected errors.
 	 */
 	public function getErrorList() {
 		$start_line = 9;
@@ -40,7 +40,7 @@ final class DeprecatedClassesUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where warnings should occur.
 	 *
-	 * @return array <int line number> => <int number of warnings>
+	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList() {
 		return array();

--- a/WordPress/Tests/WP/DeprecatedFunctionsUnitTest.php
+++ b/WordPress/Tests/WP/DeprecatedFunctionsUnitTest.php
@@ -24,7 +24,7 @@ final class DeprecatedFunctionsUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where errors should occur.
 	 *
-	 * @return array <int line number> => <int number of errors>
+	 * @return array<int, int> Key is the line number, value is the number of expected errors.
 	 */
 	public function getErrorList() {
 		$start_line = 8;
@@ -87,7 +87,7 @@ final class DeprecatedFunctionsUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where warnings should occur.
 	 *
-	 * @return array <int line number> => <int number of warnings>
+	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList() {
 		$start_line = 368;

--- a/WordPress/Tests/WP/DeprecatedParameterValuesUnitTest.php
+++ b/WordPress/Tests/WP/DeprecatedParameterValuesUnitTest.php
@@ -23,7 +23,7 @@ final class DeprecatedParameterValuesUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where errors should occur.
 	 *
-	 * @return array <int line number> => <int number of errors>
+	 * @return array<int, int> Key is the line number, value is the number of expected errors.
 	 */
 	public function getErrorList() {
 		return array(
@@ -58,7 +58,7 @@ final class DeprecatedParameterValuesUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where warnings should occur.
 	 *
-	 * @return array <int line number> => <int number of warnings>
+	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList() {
 		return array();

--- a/WordPress/Tests/WP/DeprecatedParametersUnitTest.php
+++ b/WordPress/Tests/WP/DeprecatedParametersUnitTest.php
@@ -24,7 +24,7 @@ final class DeprecatedParametersUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where errors should occur.
 	 *
-	 * @return array <int line number> => <int number of errors>
+	 * @return array<int, int> Key is the line number, value is the number of expected errors.
 	 */
 	public function getErrorList() {
 		$start_line = 42;
@@ -48,7 +48,7 @@ final class DeprecatedParametersUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where warnings should occur.
 	 *
-	 * @return array <int line number> => <int number of warnings>
+	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList() {
 		$start_line = 99;

--- a/WordPress/Tests/WP/DiscouragedConstantsUnitTest.php
+++ b/WordPress/Tests/WP/DiscouragedConstantsUnitTest.php
@@ -23,7 +23,7 @@ final class DiscouragedConstantsUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where errors should occur.
 	 *
-	 * @return array <int line number> => <int number of errors>
+	 * @return array<int, int> Key is the line number, value is the number of expected errors.
 	 */
 	public function getErrorList() {
 		return array();
@@ -32,7 +32,7 @@ final class DiscouragedConstantsUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where warnings should occur.
 	 *
-	 * @return array <int line number> => <int number of warnings>
+	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList() {
 		return array(

--- a/WordPress/Tests/WP/DiscouragedFunctionsUnitTest.php
+++ b/WordPress/Tests/WP/DiscouragedFunctionsUnitTest.php
@@ -27,7 +27,7 @@ final class DiscouragedFunctionsUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where errors should occur.
 	 *
-	 * @return array <int line number> => <int number of errors>
+	 * @return array<int, int> Key is the line number, value is the number of expected errors.
 	 */
 	public function getErrorList() {
 		return array();
@@ -36,7 +36,7 @@ final class DiscouragedFunctionsUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where warnings should occur.
 	 *
-	 * @return array <int line number> => <int number of warnings>
+	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList() {
 		return array(

--- a/WordPress/Tests/WP/EnqueuedResourceParametersUnitTest.php
+++ b/WordPress/Tests/WP/EnqueuedResourceParametersUnitTest.php
@@ -23,7 +23,7 @@ final class EnqueuedResourceParametersUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where errors should occur.
 	 *
-	 * @return array <int line number> => <int number of errors>
+	 * @return array<int, int> Key is the line number, value is the number of expected errors.
 	 */
 	public function getErrorList() {
 		return array(
@@ -46,7 +46,7 @@ final class EnqueuedResourceParametersUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where warnings should occur.
 	 *
-	 * @return array <int line number> => <int number of warnings>
+	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList() {
 		return array(

--- a/WordPress/Tests/WP/EnqueuedResourcesUnitTest.php
+++ b/WordPress/Tests/WP/EnqueuedResourcesUnitTest.php
@@ -26,7 +26,7 @@ final class EnqueuedResourcesUnitTest extends AbstractSniffUnitTest {
 	 *
 	 * @param string $testFile The name of the file being tested.
 	 *
-	 * @return array <int line number> => <int number of errors>
+	 * @return array<int, int> Key is the line number, value is the number of expected errors.
 	 */
 	public function getErrorList( $testFile = '' ) {
 		switch ( $testFile ) {
@@ -79,7 +79,7 @@ final class EnqueuedResourcesUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where warnings should occur.
 	 *
-	 * @return array <int line number> => <int number of warnings>
+	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList() {
 		return array();

--- a/WordPress/Tests/WP/GlobalVariablesOverrideUnitTest.php
+++ b/WordPress/Tests/WP/GlobalVariablesOverrideUnitTest.php
@@ -30,7 +30,7 @@ final class GlobalVariablesOverrideUnitTest extends AbstractSniffUnitTest {
 	 *
 	 * @param string $testFile The name of the file being tested.
 	 *
-	 * @return array <int line number> => <int number of errors>
+	 * @return array<int, int> Key is the line number, value is the number of expected errors.
 	 */
 	public function getErrorList( $testFile = '' ) {
 		switch ( $testFile ) {
@@ -101,7 +101,7 @@ final class GlobalVariablesOverrideUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where warnings should occur.
 	 *
-	 * @return array <int line number> => <int number of warnings>
+	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList() {
 		return array();

--- a/WordPress/Tests/WP/I18nUnitTest.php
+++ b/WordPress/Tests/WP/I18nUnitTest.php
@@ -43,7 +43,8 @@ final class I18nUnitTest extends AbstractSniffUnitTest {
 	 * Returns the lines where errors should occur.
 	 *
 	 * @param string $testFile The name of the file being tested.
-	 * @return array <int line number> => <int number of errors>
+	 *
+	 * @return array<int, int> Key is the line number, value is the number of expected errors.
 	 */
 	public function getErrorList( $testFile = '' ) {
 
@@ -181,7 +182,8 @@ final class I18nUnitTest extends AbstractSniffUnitTest {
 	 * Returns the lines where warnings should occur.
 	 *
 	 * @param string $testFile The name of the file being tested.
-	 * @return array <int line number> => <int number of warnings>
+	 *
+	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList( $testFile = '' ) {
 		switch ( $testFile ) {

--- a/WordPress/Tests/WP/PostsPerPageUnitTest.php
+++ b/WordPress/Tests/WP/PostsPerPageUnitTest.php
@@ -28,7 +28,7 @@ final class PostsPerPageUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where errors should occur.
 	 *
-	 * @return array <int line number> => <int number of errors>
+	 * @return array<int, int> Key is the line number, value is the number of expected errors.
 	 */
 	public function getErrorList() {
 		return array();
@@ -37,7 +37,7 @@ final class PostsPerPageUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where warnings should occur.
 	 *
-	 * @return array <int line number> => <int number of warnings>
+	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList() {
 		return array(

--- a/WordPress/Tests/WhiteSpace/CastStructureSpacingUnitTest.php
+++ b/WordPress/Tests/WhiteSpace/CastStructureSpacingUnitTest.php
@@ -24,7 +24,7 @@ final class CastStructureSpacingUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where errors should occur.
 	 *
-	 * @return array <int line number> => <int number of errors>
+	 * @return array<int, int> Key is the line number, value is the number of expected errors.
 	 */
 	public function getErrorList() {
 		return array(
@@ -41,7 +41,7 @@ final class CastStructureSpacingUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where warnings should occur.
 	 *
-	 * @return array <int line number> => <int number of warnings>
+	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList() {
 		return array();

--- a/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.php
+++ b/WordPress/Tests/WhiteSpace/ControlStructureSpacingUnitTest.php
@@ -26,7 +26,7 @@ final class ControlStructureSpacingUnitTest extends AbstractSniffUnitTest {
 	 *
 	 * @param string $testFile The name of the file being tested.
 	 *
-	 * @return array <int line number> => <int number of errors>
+	 * @return array<int, int> Key is the line number, value is the number of expected errors.
 	 */
 	public function getErrorList( $testFile = '' ) {
 
@@ -78,7 +78,7 @@ final class ControlStructureSpacingUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where warnings should occur.
 	 *
-	 * @return array <int line number> => <int number of warnings>
+	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList() {
 		return array();

--- a/WordPress/Tests/WhiteSpace/OperatorSpacingUnitTest.php
+++ b/WordPress/Tests/WhiteSpace/OperatorSpacingUnitTest.php
@@ -26,7 +26,7 @@ final class OperatorSpacingUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where errors should occur.
 	 *
-	 * @return array <int line number> => <int number of errors>
+	 * @return array<int, int> Key is the line number, value is the number of expected errors.
 	 */
 	public function getErrorList() {
 		return array(
@@ -48,7 +48,7 @@ final class OperatorSpacingUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where warnings should occur.
 	 *
-	 * @return array <int line number> => <int number of warnings>
+	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList() {
 		return array();


### PR DESCRIPTION
### Various minor doc fixes

### Docs: improve test @return tags

... and use consistent spacing (blank line between param and return tags).

### Docs: more @var/@param/@return tag improvements

Definitely not claiming completeness. This is just another iteration step in improving the documented types.

### Docs: add missing @return tags

While WP tends to omit `@return void` statements, this is not WP and documenting the function return type is a good thing™.