### PR TITLE
GH Actions: fix quicktest for `develop`

### DIFF
--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -90,7 +90,7 @@ jobs:
         run: composer run-tests -- --no-configuration --bootstrap=./Tests/bootstrap.php --dont-report-useless-tests
 
       - name: Send coverage report to Codecov
-        if: ${{ success() && github.ref_name == 'develop' }}
+        if: ${{ success() && github.ref_name == 'develop' && matrix.php != 'latest' }}
         uses: codecov/codecov-action@v3
         with:
           files: ./build/logs/clover.xml


### PR DESCRIPTION
Another follow up on #2338

Small tweak to the codecov upload step to not run for PHP `latest`.

_I had to tweak the code a couple of times because of the PHPUnit constraints and clearly forgot to update this condition._