### PR TITLE
Codecov config: tweak patch config

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -13,11 +13,7 @@ coverage:
         threshold: 1%
         paths:
           - "WordPress"
-    patch:
-      default:
-        threshold: 3%
-        paths:
-          - "WordPress"
+    patch: off
 
 ignore:
   - "WordPress/Tests"


### PR DESCRIPTION
Another follow up on https://github.com/WordPress/WordPress-Coding-Standards/pull/2338

I'm proposing we turn patch coverage off as it is clearly sprouting nonsense (reporting 66% on changes which didn't touch any code under test (GH Actions changes, doc changes)).