### PR TITLE
Updates related to branch rename from `master` to `main`

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -17,11 +17,11 @@ Since WPCS employs many sniffs that are part of PHPCS, sometimes an issue will b
 
 ## Branches
 
-Ongoing development will be done in the `develop` branch with merges done into `master` once considered stable.
+Ongoing development will be done in the `develop` branch with merges to `main` once considered stable.
 
 To contribute an improvement to this project, fork the repo and open a pull request to the `develop` branch. Alternatively, if you have push access to this repo, create a feature branch prefixed by `feature/` and then open an intra-repo PR from that branch to `develop`.
 
-Once a commit is made to `develop`, a PR should be opened from `develop` into `master` and named "Next release". This PR will provide collaborators with a forum to discuss the upcoming stable release.
+Once a commit is made to `develop`, a PR should be opened from `develop` to `main` and named "Next release". This PR will provide collaborators with a forum to discuss the upcoming stable release.
 
 # Considerations when writing sniffs
 

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -3,7 +3,7 @@ name: Quick Tests
 on:
   push:
     branches-ignore:
-      - master
+      - main
     paths-ignore:
       - '**.md'
   # Allow manually triggering the workflow.

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -3,7 +3,7 @@ name: Unit Tests
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
   # Allow manually triggering the workflow.
   workflow_dispatch:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1181,7 +1181,7 @@ Initial tagged release.
 
 [Composer PHPCS plugin]: https://github.com/PHPCSStandards/composer-installer
 
-[Unreleased]: https://github.com/WordPress/WordPress-Coding-Standards/compare/master...HEAD
+[Unreleased]: https://github.com/WordPress/WordPress-Coding-Standards/compare/main...HEAD
 [2.3.0]: https://github.com/WordPress/WordPress-Coding-Standards/compare/2.2.1...2.3.0
 [2.2.1]: https://github.com/WordPress/WordPress-Coding-Standards/compare/2.2.0...2.2.1
 [2.2.0]: https://github.com/WordPress/WordPress-Coding-Standards/compare/2.1.1...2.2.0

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ It is strongly suggested to `require` one of these plugins in your project to ha
 
 2. Clone the WordPress standards repository:
 
-        git clone -b master https://github.com/WordPress/WordPress-Coding-Standards.git wpcs
+        git clone -b main https://github.com/WordPress/WordPress-Coding-Standards.git wpcs
 
 3. Add its path to the PHP_CodeSniffer configuration:
 
@@ -111,7 +111,7 @@ To summarize:
 ```bash
 cd ~/projects
 git clone https://github.com/squizlabs/PHP_CodeSniffer.git phpcs
-git clone -b master https://github.com/WordPress/WordPress-Coding-Standards.git wpcs
+git clone -b main https://github.com/WordPress/WordPress-Coding-Standards.git wpcs
 cd phpcs
 ./bin/phpcs --config-set installed_paths ../wpcs
 ```


### PR DESCRIPTION
Branch rename has just been executed via the GH interface. If you have a local clone, make sure you update it/fetch. A note about the rename will be in the changelog and the upgrade guides.

Note: install instructions in the README will be replaced still in a future commit.

Closes #1916