### PR TITLE
Make methods in traits `final`

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -80,6 +80,9 @@
 		<exclude-pattern>/WordPress/Sniffs/Security/(EscapeOutput|NonceVerification|ValidatedSanitizedInput)Sniff\.php$</exclude-pattern>
 	</rule>
 
+	<!-- Enforce that methods in traits are always final. -->
+	<rule ref="Universal.FunctionDeclarations.RequireFinalMethodsInTraits"/>
+
 
 	<!--
 	#############################################################################

--- a/WordPress/Helpers/EscapingFunctionsTrait.php
+++ b/WordPress/Helpers/EscapingFunctionsTrait.php
@@ -214,7 +214,7 @@ trait EscapingFunctionsTrait {
 	 *
 	 * @return bool
 	 */
-	public function is_escaping_function( $functionName ) {
+	final public function is_escaping_function( $functionName ) {
 		if ( array() === $this->allEscapingFunctions
 			|| $this->customEscapingFunctions !== $this->addedCustomEscapingFunctions['escape']
 		) {
@@ -238,7 +238,7 @@ trait EscapingFunctionsTrait {
 	 *
 	 * @return bool
 	 */
-	public function is_auto_escaped_function( $functionName ) {
+	final public function is_auto_escaped_function( $functionName ) {
 		if ( array() === $this->allAutoEscapedFunctions
 			|| $this->customAutoEscapedFunctions !== $this->addedCustomEscapingFunctions['autoescape']
 		) {

--- a/WordPress/Helpers/IsUnitTestTrait.php
+++ b/WordPress/Helpers/IsUnitTestTrait.php
@@ -127,7 +127,7 @@ trait IsUnitTestTrait {
 	 *
 	 * @return array<string, bool>
 	 */
-	protected function get_all_test_classes() {
+	final protected function get_all_test_classes() {
 		if ( array() === $this->all_test_classes
 			|| $this->custom_test_classes !== $this->added_custom_test_classes
 		) {
@@ -179,7 +179,7 @@ trait IsUnitTestTrait {
 	 *
 	 * @return bool True if the class is a unit test class, false otherwise.
 	 */
-	protected function is_test_class( File $phpcsFile, $stackPtr ) {
+	final protected function is_test_class( File $phpcsFile, $stackPtr ) {
 
 		$tokens = $phpcsFile->getTokens();
 

--- a/WordPress/Helpers/MinimumWPVersionTrait.php
+++ b/WordPress/Helpers/MinimumWPVersionTrait.php
@@ -95,7 +95,7 @@ trait MinimumWPVersionTrait {
 	 *
 	 * @return void
 	 */
-	protected function set_minimum_wp_version() {
+	final protected function set_minimum_wp_version() {
 		$minimum_wp_version = '';
 
 		// Use a ruleset provided value if available.
@@ -128,7 +128,7 @@ trait MinimumWPVersionTrait {
 	 *
 	 * @return bool
 	 */
-	protected function wp_version_compare( $version1, $version2, $operator ) {
+	final protected function wp_version_compare( $version1, $version2, $operator ) {
 		$version1 = $this->normalize_version_number( $version1 );
 		$version2 = $this->normalize_version_number( $version2 );
 

--- a/WordPress/Helpers/PrintingFunctionsTrait.php
+++ b/WordPress/Helpers/PrintingFunctionsTrait.php
@@ -92,7 +92,7 @@ trait PrintingFunctionsTrait {
 	 *
 	 * @return array<string, bool>
 	 */
-	public function get_printing_functions() {
+	final public function get_printing_functions() {
 		if ( array() === $this->allPrintingFunctions
 			|| $this->customPrintingFunctions !== $this->addedCustomPrintingFunctions
 		) {
@@ -116,7 +116,7 @@ trait PrintingFunctionsTrait {
 	 *
 	 * @return bool
 	 */
-	public function is_printing_function( $functionName ) {
+	final public function is_printing_function( $functionName ) {
 		return isset( $this->get_printing_functions()[ strtolower( $functionName ) ] );
 	}
 }

--- a/WordPress/Helpers/SanitizationHelperTrait.php
+++ b/WordPress/Helpers/SanitizationHelperTrait.php
@@ -190,7 +190,7 @@ trait SanitizationHelperTrait {
 	 *
 	 * @return array<string, bool>
 	 */
-	public function get_sanitizing_functions() {
+	final public function get_sanitizing_functions() {
 		if ( array() === $this->allSanitizingFunctions
 			|| $this->customSanitizingFunctions !== $this->addedCustomSanitizingFunctions['sanitize']
 		) {
@@ -212,7 +212,7 @@ trait SanitizationHelperTrait {
 	 *
 	 * @return array<string, bool>
 	 */
-	public function get_sanitizing_and_unslashing_functions() {
+	final public function get_sanitizing_and_unslashing_functions() {
 		if ( array() === $this->allUnslashingSanitizingFunctions
 			|| $this->customUnslashingSanitizingFunctions !== $this->addedCustomSanitizingFunctions['unslashsanitize']
 		) {
@@ -236,7 +236,7 @@ trait SanitizationHelperTrait {
 	 *
 	 * @return bool
 	 */
-	public function is_sanitizing_function( $functionName ) {
+	final public function is_sanitizing_function( $functionName ) {
 		return isset( $this->get_sanitizing_functions()[ strtolower( $functionName ) ] );
 	}
 
@@ -249,7 +249,7 @@ trait SanitizationHelperTrait {
 	 *
 	 * @return bool
 	 */
-	public function is_sanitizing_and_unslashing_function( $functionName ) {
+	final public function is_sanitizing_and_unslashing_function( $functionName ) {
 		return isset( $this->get_sanitizing_and_unslashing_functions()[ strtolower( $functionName ) ] );
 	}
 
@@ -266,7 +266,7 @@ trait SanitizationHelperTrait {
 	 *
 	 * @return bool Whether the token is only within a sanitization.
 	 */
-	public function is_only_sanitized( File $phpcsFile, $stackPtr ) {
+	final public function is_only_sanitized( File $phpcsFile, $stackPtr ) {
 		$tokens = $phpcsFile->getTokens();
 
 		// If it isn't being sanitized at all.
@@ -317,7 +317,7 @@ trait SanitizationHelperTrait {
 	 *
 	 * @return bool Whether the token is being sanitized.
 	 */
-	public function is_sanitized( File $phpcsFile, $stackPtr, $unslash_callback = null ) {
+	final public function is_sanitized( File $phpcsFile, $stackPtr, $unslash_callback = null ) {
 		$tokens          = $phpcsFile->getTokens();
 		$require_unslash = is_callable( $unslash_callback );
 

--- a/WordPress/Helpers/WPDBTrait.php
+++ b/WordPress/Helpers/WPDBTrait.php
@@ -47,7 +47,7 @@ trait WPDBTrait {
 	 *
 	 * @return bool Whether this is a $wpdb method call.
 	 */
-	protected function is_wpdb_method_call( File $phpcsFile, $stackPtr, $target_methods ) {
+	final protected function is_wpdb_method_call( File $phpcsFile, $stackPtr, $target_methods ) {
 		$tokens = $phpcsFile->getTokens();
 		if ( isset( $tokens[ $stackPtr ] ) === false ) {
 			return false;


### PR DESCRIPTION
Traits cannot be made `final`, but the methods therein _can_.

There is a caveat though: the class `use`-ing the trait can still overload the method. Also see: https://externals.io/message/120576

In other words: the `final` keyword, in this case, only protects against _child_ classes of the class `use`-ing the trait overloading the method. And as most sniff are now `final` by design, this could be seen as a redundant change.

Having said that, I still think it has value to add the keyword, if only to signal that these method shouldn't be overloaded.

Includes adding a sniff to the WPCS native PHPCS ruleset to enforce this.