### PR TITLE
CS: closures not using `$this` should be static

### DIFF
--- a/WordPress/Sniffs/DB/PreparedSQLPlaceholdersSniff.php
+++ b/WordPress/Sniffs/DB/PreparedSQLPlaceholdersSniff.php
@@ -327,7 +327,7 @@ final class PreparedSQLPlaceholdersSniff extends Sniff {
 				if ( $stripped_content !== $content ) {
 					$vars_without_wpdb = array_filter(
 						TextStrings::getEmbeds( $content ),
-						function ( $symbol ) {
+						static function ( $symbol ) {
 							return preg_match( '`^\{?\$\{?wpdb\??->`', $symbol ) !== 1;
 						}
 					);

--- a/WordPress/Sniffs/DB/PreparedSQLSniff.php
+++ b/WordPress/Sniffs/DB/PreparedSQLSniff.php
@@ -176,7 +176,7 @@ final class PreparedSQLSniff extends Sniff {
 
 				$bad_variables = array_filter(
 					TextStrings::getEmbeds( $this->tokens[ $this->i ]['content'] ),
-					function ( $symbol ) {
+					static function ( $symbol ) {
 						return preg_match( '`^\{?\$\{?wpdb\??->`', $symbol ) !== 1;
 					}
 				);


### PR DESCRIPTION
Inspired by https://github.com/WordPress/WordPress-Coding-Standards/pull/2362#pullrequestreview-1585235527 - this fixes up the other closures in the code base.