### PR TITLE
Tests: Remove redundant placeholder function

### DIFF
--- a/WordPress/Tests/DB/DirectDatabaseQueryUnitTest.inc
+++ b/WordPress/Tests/DB/DirectDatabaseQueryUnitTest.inc
@@ -16,8 +16,8 @@ function bar() {
 	return $listofthings;
 }
 
-function dummy() {
-}
+
+
 
 function baz() {
 	global $wpdb;


### PR DESCRIPTION
It's the only error flagged by a non-inclusive terminology checker.

Originally added in https://github.com/WordPress/WordPress-Coding-Standards/commit/3cd319133d6ff20cc8957450326e4cdf8c97f9a6.

Fixes #1915.