### PR TITLE
Update documentation (README, CONTRIBUTING) for release of WordPressCS 3.0.0

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,7 @@
 #
 # Exclude these files from release archives.
 # This will also make them unavailable when using Composer with `--prefer-dist`.
-# If you develop for WPCS using Composer, use `--prefer-source`.
+# If you develop for WordPressCS using Composer, use `--prefer-source`.
 # https://blog.madewithlove.be/post/gitattributes/
 #
 /.gitattributes     export-ignore

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -11,7 +11,11 @@ Bug reports containing a minimal code sample which can be used to reproduce the 
 
 ## Upstream Issues
 
-Since WPCS employs many sniffs that are part of PHPCS, sometimes an issue will be caused by a bug in PHPCS and not in WPCS itself. If the error message in question doesn't come from a sniff whose name starts with `WordPress`, the issue is probably a bug in PHPCS itself, and should be [reported there](https://github.com/squizlabs/PHP_CodeSniffer/issues).
+Since WordPressCS employs many sniffs that are part of PHP_CodeSniffer itself or PHPCSExtra, sometimes an issue will be caused by a bug in PHPCS or PHPCSExtra and not in WordPressCS itself.
+If the error message in question doesn't come from a sniff whose name starts with `WordPress`, the issue is probably a bug in PHPCS or PHPCSExtra.
+
+* Bugs for sniffs starting with `Generic`, `PEAR`, `PSR1`, `PSR2`, `PSR12`, `Squiz` or `Zend` should be [reported to PHPCS](https://github.com/squizlabs/PHP_CodeSniffer/issues).
+* Bugs for sniffs starting with `Modernize`, `NormalizedArrays` or `Universal` should be [reported to PHPCSExtra](https://github.com/PHPCSStandards/PHPCSExtra/issues).
 
 # Contributing patches and new features
 
@@ -19,9 +23,8 @@ Since WPCS employs many sniffs that are part of PHPCS, sometimes an issue will b
 
 Ongoing development will be done in the `develop` branch with merges to `main` once considered stable.
 
-To contribute an improvement to this project, fork the repo and open a pull request to the `develop` branch. Alternatively, if you have push access to this repo, create a feature branch prefixed by `feature/` and then open an intra-repo PR from that branch to `develop`.
-
-Once a commit is made to `develop`, a PR should be opened from `develop` to `main` and named "Next release". This PR will provide collaborators with a forum to discuss the upcoming stable release.
+To contribute an improvement to this project, fork the repo, run `composer install`, make your changes to the code, run the unit tests and code style checks by running `composer check-all`, and if all is good, open a pull request to the `develop` branch.
+Alternatively, if you have push access to this repo, create a feature branch prefixed by `feature/` and then open an intra-repo PR from that branch to `develop`.
 
 # Considerations when writing sniffs
 
@@ -37,71 +40,64 @@ When you introduce new `public` sniff properties, or your sniff extends a class 
 ## Pre-requisites
 * WordPress-Coding-Standards
 * PHP_CodeSniffer 3.7.2 or higher
+* PHPCSUtils 1.0.8 or higher
+* PHPCSExtra 1.1.0 or higher
 * PHPUnit 4.x, 5.x, 6.x or 7.x
 
-The WordPress Coding Standards use the `PHP_CodeSniffer` native unit test suite for unit testing the sniffs.
+The WordPress Coding Standards use the `PHP_CodeSniffer` native unit test framework for unit testing the sniffs.
 
-Presuming you have installed `PHP_CodeSniffer` and the WordPress-Coding-Standards as [noted in the README](https://github.com/WordPress/WordPress-Coding-Standards#how-to-use-this), all you need now is `PHPUnit`.
+## Getting ready to test
 
-> N.B.: If you installed WPCS using Composer, make sure you used `--prefer-source` or run `composer install --prefer-source` now to make sure the unit tests are available.
-> Other than that, you're all set already as Composer will have installed PHPUnit for you.
+Presuming you have cloned WordPressCS for development, to run the unit tests you need to make sure you have run `composer install` from the root directory of your WordPressCS git clone.
 
-If you already have PHPUnit installed on your system: Congrats, you're all set.
+## Custom develop setups
 
-## Installing PHPUnit
-
-N.B.: _If you used Composer to install the WordPress Coding Standards, you can skip this step._
-
-You can either navigate to the directory where the `PHP_CodeSniffer` repo is checked out and do `composer install` to install the `dev` dependencies or you can [install PHPUnit](https://phpunit.readthedocs.io/en/7.4/installation.html) as a PHAR file.
-
-You may want to add the directory where PHPUnit is installed to a `PATH` environment variable for your operating system to make the command available everywhere on your system.
-
-## Before running the unit tests
-
-N.B.: _If you used Composer to install the WordPress Coding Standards, you can skip this step._
-
-For the unit tests to work, you need to make sure PHPUnit can find your `PHP_CodeSniffer` install.
-
-The easiest way to do this is to add a `phpunit.xml` file to the root of your WPCS installation and set a `PHPCS_DIR` environment variable from within this file.
-Copy the existing `phpunit.xml.dist` file and add the below `<env>` directive within the `<php>` section. Make sure to adjust the path to reflect your local setup.
-```xml
-	<php>
-		<env name="PHPCS_DIR" value="/path/to/PHP_CodeSniffer/"/>
-	</php>
-```
+If you are developing with a stand-alone PHP_CodeSniffer (git clone) installation and want to use that git clone to test WordPressCS, there are three extra things you need to do:
+1. Install [PHPCSUtils](https://github.com/PHPCSStandards/PHPCSUtils).
+    If you are using a git clone of PHPCS, you may want to `git clone` PHPCSUtils as well.
+2. Register PHPCSUtils with your stand-alone PHP_CodeSniffer installation by running the following commands:
+    ```bash
+    phpcs --config-show
+    ```
+    Copy the value from "installed_paths" and add the path to your local install of PHPCSUtils to it (and the path to WordPressCS if it's not registered with PHPCS yet).
+    Now use the adjusted value to run:
+    ```bash
+    phpcs --config-set installed_paths /path/1,/path/2,/path/3
+    ```
+3. Make sure PHPUnit can find your `PHP_CodeSniffer` install.
+    The most straight-forward way to do this is to add a `phpunit.xml` file to the root of your WordPressCS installation and set a `PHPCS_DIR` environment variable from within this file.
+    Copy the existing `phpunit.xml.dist` file and add the below `<env>` directive within the `<php>` section. Make sure to adjust the path to reflect your local setup.
+    ```xml
+        <php>
+            <env name="PHPCS_DIR" value="/path/to/PHP_CodeSniffer/"/>
+        </php>
+    ```
 
 ## Running the unit tests
 
-* If you didn't install WPCS using Composer, make sure you have registered the directory in which you installed WPCS with PHPCS using:
-    ```sh
-    phpcs --config-set installed_paths path/to/WPCS
-    ```
-* Navigate to the directory in which you installed WPCS.
-* To run the unit tests:
-    ```sh
-    phpunit --filter WordPress --bootstrap="/path/to/PHP_CodeSniffer/tests/bootstrap.php" /path/to/PHP_CodeSniffer/tests/AllTests.php
+From the root of your WordPressCS install, run the unit tests like so:
+```bash
+composer run-tests
 
-    # Or if you've installed WPCS with Composer:
-    composer run-tests
-    ```
+# Or if you want to use a globally installed version of PHPUnit:
+phpunit --filter WordPress /path/to/PHP_CodeSniffer/tests/AllTests.php
+```
 
 Expected output:
 ```
-PHPUnit 7.5.0 by Sebastian Bergmann and contributors.
+PHPUnit 7.5.20 by Sebastian Bergmann and contributors.
 
-Runtime:       PHP 7.2.13
-Configuration: /WordPressCS/phpunit.xml
+Runtime:       PHP 7.4.33
+Configuration: /WordPressCS/phpunit.xml.dist
 
-........................................................          56 / 56 (100%)
+.........................................................         57 / 57 (100%)
 
-152 sniff test files generated 487 unique error codes; 52 were fixable (10.68%)
+201 sniff test files generated 744 unique error codes; 50 were fixable (6%)
 
-Time: 21.36 seconds, Memory: 22.00MB
+Time: 10.19 seconds, Memory: 40.00 MB
 
-OK (56 tests, 0 assertions)
+OK (57 tests, 0 assertions)
 ```
-
-[![asciicast](https://asciinema.org/a/98078.png)](https://asciinema.org/a/98078)
 
 ## Unit Testing conventions
 
@@ -110,17 +106,16 @@ If you look inside the `WordPress/Tests` subdirectory, you'll see the structure 
 Lets take a look at what's inside `POSIXFunctionsUnitTest.php`:
 
 ```php
-...
 namespace WordPressCS\WordPress\Tests\PHP;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
-class POSIXFunctionsUnitTest extends AbstractSniffUnitTest {
+final class POSIXFunctionsUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.
 	 *
-	 * @return array <int line number> => <int number of errors>
+	 * @return array<int, int> Key is the line number, value is the number of expected errors.
 	 */
 	public function getErrorList() {
 		return array(
@@ -132,17 +127,18 @@ class POSIXFunctionsUnitTest extends AbstractSniffUnitTest {
 			24 => 1,
 			26 => 1,
 		);
-
 	}
-...
+
+    ...
+}
 ```
 
-Also note the class name convention. The method `getErrorList()` MUST return an array of line numbers indicating errors (when running `phpcs`) found in `WordPress/Tests/PHP/POSIXFunctionsUnitTest.inc`.
-If you run:
+Also note the class name convention. The method `getErrorList()` MUST return an array of line numbers indicating errors (when running `phpcs`) found in `WordPress/Tests/PHP/POSIXFunctionsUnitTest.inc`. Similarly, the `getWarningList()` method must return an array of line numbers with the number of expected warnings.
+
+If you run the following from the root directory of your WordPressCS clone:
 
 ```sh
-$ cd /path-to-cloned/phpcs
-$ ./bin/phpcs --standard=Wordpress -s /path/to/WordPress/Tests/PHP/POSIXFunctionsUnitTest.inc --sniffs=WordPress.PHP.POSIXFunctions
+$ "vendor/bin/phpcs" --standard=Wordpress -s ./Tests/PHP/POSIXFunctionsUnitTest.inc --sniffs=WordPress.PHP.POSIXFunctions
 ...
 --------------------------------------------------------------------------------
 FOUND 7 ERRORS AFFECTING 7 LINES
@@ -153,23 +149,23 @@ FOUND 7 ERRORS AFFECTING 7 LINES
  16 | ERROR | eregi() has been deprecated since PHP 5.3 and removed in PHP 7.0,
     |       | please use preg_match() instead.
     |       | (WordPress.PHP.POSIXFunctions.ereg_eregi)
- 18 | ERROR | ereg_replace() has been deprecated since PHP 5.3 and removed in PHP
-    |       | 7.0, please use preg_replace() instead.
+ 18 | ERROR | ereg_replace() has been deprecated since PHP 5.3 and removed in
+    |       | PHP 7.0, please use preg_replace() instead.
     |       | (WordPress.PHP.POSIXFunctions.ereg_replace_ereg_replace)
- 20 | ERROR | eregi_replace() has been deprecated since PHP 5.3 and removed in PHP
-    |       | 7.0, please use preg_replace() instead.
+ 20 | ERROR | eregi_replace() has been deprecated since PHP 5.3 and removed in
+    |       | PHP 7.0, please use preg_replace() instead.
     |       | (WordPress.PHP.POSIXFunctions.ereg_replace_eregi_replace)
  22 | ERROR | split() has been deprecated since PHP 5.3 and removed in PHP 7.0,
     |       | please use explode(), str_split() or preg_split() instead.
     |       | (WordPress.PHP.POSIXFunctions.split_split)
- 24 | ERROR | spliti() has been deprecated since PHP 5.3 and removed in PHP 7.0,
-    |       | please use explode(), str_split() or preg_split() instead.
-    |       | (WordPress.PHP.POSIXFunctions.split_spliti)
- 26 | ERROR | sql_regcase() has been deprecated since PHP 5.3 and removed in PHP
-    |       | 7.0, please use preg_match() instead.
+ 24 | ERROR | spliti() has been deprecated since PHP 5.3 and removed in PHP
+    |       | 7.0, please use explode(), str_split() or preg_split()
+    |       | instead. (WordPress.PHP.POSIXFunctions.split_spliti)
+ 26 | ERROR | sql_regcase() has been deprecated since PHP 5.3 and removed in
+    |       | PHP 7.0, please use preg_match() instead.
     |       | (WordPress.PHP.POSIXFunctions.ereg_sql_regcase)
 --------------------------------------------------------------------------------
-....
+...
 ```
 You'll see the line number and number of ERRORs we need to return in the `getErrorList()` method.
 
@@ -177,4 +173,4 @@ The `--sniffs=...` directive limits the output to the sniff you are testing.
 
 ## Code Standards for this project
 
-The sniffs and test files - not test _case_ files! - for WPCS should be written such that they pass the `WordPress-Extra` and the `WordPress-Docs` code standards using the custom ruleset as found in `/.phpcs.xml.dist`.
+The sniffs and test files - not test _case_ files! - for WordPressCS should be written such that they pass the `WordPress-Extra` and the `WordPress-Docs` code standards using the custom ruleset as found in `/.phpcs.xml.dist`.

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -51,7 +51,7 @@
 		<!-- Linting is done in a separate CI job, no need to duplicate it. -->
 		<exclude name="Generic.PHP.Syntax"/>
 
-		<!-- WPCS still has a PHP 5.4 minimum. -->
+		<!-- WordPressCS still has a PHP 5.4 minimum. -->
 		<exclude name="Modernize.FunctionCalls.Dirname"/>
 	</rule>
 

--- a/README.md
+++ b/README.md
@@ -4,18 +4,16 @@
 [![Release Date of the Latest Version](https://img.shields.io/github/release-date/WordPress/WordPress-Coding-Standards.svg?maxAge=1800)](https://github.com/WordPress/WordPress-Coding-Standards/releases)
 :construction:
 [![Latest Unstable Version](https://img.shields.io/badge/unstable-dev--develop-e68718.svg?maxAge=2419200)](https://packagist.org/packages/wp-coding-standards/wpcs#dev-develop)
-[![Last Commit to Unstable](https://img.shields.io/github/last-commit/WordPress/WordPress-Coding-Standards/develop.svg)](https://github.com/WordPress/WordPress-Coding-Standards/commits/develop)
 
 [![Basic QA checks](https://github.com/WordPress/WordPress-Coding-Standards/actions/workflows/basic-qa.yml/badge.svg)](https://github.com/WordPress/WordPress-Coding-Standards/actions/workflows/basic-qa.yml)
 [![Unit Tests](https://github.com/WordPress/WordPress-Coding-Standards/actions/workflows/unit-tests.yml/badge.svg)](https://github.com/WordPress/WordPress-Coding-Standards/actions/workflows/unit-tests.yml)
 [![codecov.io](https://codecov.io/gh/WordPress/WordPress-Coding-Standards/graph/badge.svg?token=UzFYn0RzVG&branch=develop)](https://codecov.io/gh/WordPress/WordPress-Coding-Standards?branch=develop)
 
 [![Minimum PHP Version](https://img.shields.io/packagist/php-v/wp-coding-standards/wpcs.svg?maxAge=3600)](https://packagist.org/packages/wp-coding-standards/wpcs)
-[![Tested on PHP 5.4 to 7.4 snapshot](https://img.shields.io/badge/tested%20on-PHP%205.4%20|%205.5%20|%205.6%20|%207.0%20|%207.1%20|%207.2%20|%207.3%20|%207.4snapshot-green.svg?maxAge=2419200)](https://github.com/WordPress/WordPress-Coding-Standards/actions/workflows/unit-tests.yml)
+[![Tested on PHP 5.4 to 8.3](https://img.shields.io/badge/tested%20on-PHP%205.4%20|%205.5%20|%205.6%20|%207.0%20|%207.1%20|%207.2%20|%207.3%20|%207.4%20|%208.0%20|%208.1%20|%208.2%20|%208.3-green.svg?maxAge=2419200)](https://github.com/WordPress/WordPress-Coding-Standards/actions/workflows/unit-tests.yml)
 
 [![License: MIT](https://poser.pugx.org/wp-coding-standards/wpcs/license)](https://github.com/WordPress/WordPress-Coding-Standards/blob/develop/LICENSE)
 [![Total Downloads](https://poser.pugx.org/wp-coding-standards/wpcs/downloads)](https://packagist.org/packages/wp-coding-standards/wpcs/stats)
-[![Number of Contributors](https://img.shields.io/github/contributors/WordPress/WordPress-Coding-Standards.svg?maxAge=3600)](https://github.com/WordPress/WordPress-Coding-Standards/graphs/contributors)
 
 </div>
 
@@ -23,11 +21,12 @@
 # WordPress Coding Standards for PHP_CodeSniffer
 
 * [Introduction](#introduction)
-* [Project history](#project-history)
+* [Minimum Requirements](#minimum-requirements)
 * [Installation](#installation)
-    + [Requirements](#requirements)
-    + [Composer](#composer)
-    + [Standalone](#standalone)
+    + [Composer Project-based Installation](#composer-project-based-installation)
+    + [Composer Global Installation](#composer-global-installation)
+    + [Updating your WordPressCS install to a newer version](#updating-your-wordpresscs-install-to-a-newer-version)
+    + [Using your WordPressCS install](#using-your-wordpresscs-install)
 * [Rulesets](#rulesets)
     + [Standards subsets](#standards-subsets)
     + [Using a custom ruleset](#using-a-custom-ruleset)
@@ -35,90 +34,80 @@
     + [Recommended additional rulesets](#recommended-additional-rulesets)
 * [How to use](#how-to-use)
     + [Command line](#command-line)
-    + [Using PHPCS and WPCS from within your IDE](#using-phpcs-and-wpcs-from-within-your-ide)
-* [Running your code through WPCS automatically using CI tools](#running-your-code-through-wpcs-automatically-using-ci-tools)
+    + [Using PHPCS and WordPressCS from within your IDE](#using-phpcs-and-wordpresscs-from-within-your-ide)
+* [Running your code through WordPressCS automatically using Continuous Integration tools](#running-your-code-through-wordpresscs-automatically-using-continuous-integration-tools)
 * [Fixing errors or ignoring them](#fixing-errors-or-ignoring-them)
-    + [Tools shipped with WPCS](#tools-shipped-with-wpcs)
+    + [Tools shipped with WordPressCS](#tools-shipped-with-wordpresscs)
 * [Contributing](#contributing)
 * [License](#license)
+
 
 ## Introduction
 
 This project is a collection of [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) rules (sniffs) to validate code developed for WordPress. It ensures code quality and adherence to coding conventions, especially the official [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
 
-## Project history
+## Minimum Requirements
 
- - On 22nd April 2009, the original project from [Urban Giraffe](https://urbangiraffe.com/articles/wordpress-codesniffer-standard/) was packaged and published.
- - In May 2011 the project was forked and [added](https://github.com/WordPress/WordPress-Coding-Standards/commit/04fd547c691ca2baae3fa8e195a46b0c9dd671c5) to GitHub by [Chris Adams](https://chrisadams.me.uk/).
- - In April 2012 [XWP](https://xwp.co/) started to dedicate resources to develop and lead the creation of the sniffs and rulesets for `WordPress-Core`, `WordPress-VIP` (WordPress.com VIP), and `WordPress-Extra`.
- - In May 2015, an initial documentation ruleset was [added](https://github.com/WordPress/WordPress-Coding-Standards/commit/b1a4bf8232a22563ef66f8a529357275a49f47dc#diff-a17c358c3262a26e9228268eb0a7b8c8) as `WordPress-Docs`.
- - In 2015, [J.D. Grimes](https://github.com/JDGrimes) began significant contributions, along with maintenance from [Gary Jones](https://github.com/GaryJones).
- - In 2016, [Juliette Reinders Folmer](https://github.com/jrfnl) began contributing heavily, adding more commits in a year than anyone else in the five years since the project was added to GitHub.
- - In July 2018, version [`1.0.0`](https://github.com/WordPress/WordPress-Coding-Standards/releases/tag/1.0.0) of the project was released.
+The WordPress Coding Standards package requires:
+* PHP 5.4 or higher with the following extensions enabled:
+    - [Filter](https://www.php.net/book.filter)
+    - [libxml](https://www.php.net/book.libxml)
+    - [Tokenizer](https://www.php.net/book.tokenizer)
+    - [XMLReader](https://www.php.net/book.xmlreader)
+* [Composer](https://getcomposer.org/)
+
+For the best results, it is recommended to also ensure the following additional PHP extensions are enabled:
+    - [iconv](https://www.php.net/book.iconv)
+    - [Multibyte String](https://www.php.net/book.mbstring)
 
 ## Installation
 
-### Requirements
+As of WordPressCS 3.0.0, installation via Composer using the below instructions is the only supported type of installation.
 
-The WordPress Coding Standards require PHP 5.4 or higher and [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) version **3.7.2** or higher.
+[Composer](https://getcomposer.org/) will automatically install the project dependencies and register the rulesets from WordPressCS and other external standards with PHP_CodeSniffer using the [Composer PHPCS plugin](https://github.com/PHPCSStandards/composer-installer).
 
-### Composer
+> If you are upgrading from an older WordPressCS version to version 3.0.0, please read the [Upgrade guide for ruleset maintainers and end-users](https://github.com/WordPress/WordPress-Coding-Standards/wiki/Upgrade-Guide-to-WordPressCS-3.0.0-for-ruleset-maintainers) first!
 
-Standards can be installed with the [Composer](https://getcomposer.org/) dependency manager:
+### Composer Project-based Installation
 
-    composer create-project wp-coding-standards/wpcs --no-dev
-
-Running this command will:
-
-1. Install WordPress standards into `wpcs` directory.
-2. Install PHP_CodeSniffer.
-3. Register WordPress standards in PHP_CodeSniffer configuration.
-4. Make `phpcs` command available from `wpcs/vendor/bin`.
-
-For the convenience of using `phpcs` as a global command, you may want to add the path to the `wpcs/vendor/bin` directory to a `PATH` environment variable for your operating system.
-
-#### Installing WPCS as a dependency
-
-When installing the WordPress Coding Standards as a dependency in a larger project, the above mentioned step 3 will not be executed automatically.
-
-There are two actively maintained Composer plugins which can handle the registration of standards with PHP_CodeSniffer for you:
-* [composer-phpcodesniffer-standards-plugin](https://github.com/higidi/composer-phpcodesniffer-standards-plugin)
-* [phpcodesniffer-composer-installer](https://github.com/DealerDirect/phpcodesniffer-composer-installer):"^0.6"
-
-It is strongly suggested to `require` one of these plugins in your project to handle the registration of external standards with PHPCS for you.
-
-### Standalone
-
-1. Install PHP_CodeSniffer by following its [installation instructions](https://github.com/squizlabs/PHP_CodeSniffer#installation) (via Composer, Phar file, PEAR, or Git checkout).
-
-   Do ensure that PHP_CodeSniffer's version matches our [requirements](#requirements), if, for example, you're using [VVV](https://github.com/Varying-Vagrant-Vagrants/VVV).
-
-2. Clone the WordPress standards repository:
-
-        git clone -b main https://github.com/WordPress/WordPress-Coding-Standards.git wpcs
-
-3. Add its path to the PHP_CodeSniffer configuration:
-
-        phpcs --config-set installed_paths /path/to/wpcs
-
-   **Pro-tip:** Alternatively, you can tell PHP_CodeSniffer the path to the WordPress standards by adding the following snippet to your custom ruleset:
-   ```xml
-   <config name="installed_paths" value="/path/to/wpcs" />
-   ```
-
-To summarize:
-
+Run the following from the root of your project:
 ```bash
-cd ~/projects
-git clone https://github.com/squizlabs/PHP_CodeSniffer.git phpcs
-git clone -b main https://github.com/WordPress/WordPress-Coding-Standards.git wpcs
-cd phpcs
-./bin/phpcs --config-set installed_paths ../wpcs
+composer config allow-plugins.dealerdirect/phpcodesniffer-composer-installer true
+composer require --dev wp-coding-standards/wpcs:"^3.0"
 ```
 
-And then add the `~/projects/phpcs/bin` directory to your `PATH` environment variable via your `.bashrc`.
+### Composer Global Installation
 
-You should then see `WordPress-Core` et al listed when you run `phpcs -i`.
+Alternatively, you may want to install this standard globally:
+```bash
+composer global config allow-plugins.dealerdirect/phpcodesniffer-composer-installer true
+composer global require --dev wp-coding-standards/wpcs:"^3.0"
+```
+
+### Updating your WordPressCS install to a newer version
+
+If you installed WordPressCS using either of the above commands, you can upgrade to a newer version as follows:
+```bash
+# Project local install
+composer update wp-coding-standards/wpcs --with-dependencies
+
+# Global install
+composer global update wp-coding-standards/wpcs --with-dependencies
+```
+
+### Using your WordPressCS install
+
+Once you have installed WordPressCS using either of the above commands, use it as follows:
+```bash
+# Project local install
+vendor/bin/phpcs -ps . --standard=WordPress
+
+# Global install
+%USER_DIRECTORY%/Composer/vendor/bin/phpcs -ps . --standard=WordPress
+```
+
+> **Pro-tip**: For the convenience of using `phpcs` as a global command, use the _Global install_ method and add the path to the `%USER_DIRECTORY%/Composer/vendor/bin` directory to the `PATH` environment variable for your operating system.
+
 
 ##  Rulesets
 
@@ -131,117 +120,123 @@ You can use the following as standard names when invoking `phpcs` to select snif
 * `WordPress` - complete set with all of the sniffs in the project
   - `WordPress-Core` - main ruleset for [WordPress core coding standards](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/)
   - `WordPress-Docs` - additional ruleset for [WordPress inline documentation standards](https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/)
-  - `WordPress-Extra` - extended ruleset for recommended best practices, not sufficiently covered in the WordPress core coding standards
+  - `WordPress-Extra` - extended ruleset with recommended best practices, not sufficiently covered in the WordPress core coding standards
     - includes `WordPress-Core`
-
-**Note:** The WPCS package used to include a `WordPress-VIP` ruleset and associated sniffs, prior to WPCS 2.0.0.
-The `WordPress-VIP` ruleset was originally intended to aid with the [WordPress.com VIP coding requirements](https://docs.wpvip.com/technical-references/code-review/), but has been superseded. It is recommended to use the [official VIP coding standards](https://github.com/Automattic/VIP-Coding-Standards) ruleset instead for checking code against the VIP platform requirements.
 
 ### Using a custom ruleset
 
-If you need to further customize the selection of sniffs for your project - you can create a custom ruleset file. When you name this file either `.phpcs.xml`, `phpcs.xml`, `.phpcs.xml.dist` or `phpcs.xml.dist`, PHP_CodeSniffer will automatically locate it as long as it is placed in the directory from which you run the CodeSniffer or in a directory above it. If you follow these naming conventions you don't have to supply a `--standard` arg. For more info, read about [using a default configuration file](https://github.com/squizlabs/PHP_CodeSniffer/wiki/Advanced-Usage#using-a-default-configuration-file). See also provided [`phpcs.xml.dist.sample`](phpcs.xml.dist.sample) file and [fully annotated example](https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml) in the PHP_CodeSniffer documentation.
+If you need to further customize the selection of sniffs for your project - you can create a custom ruleset file.
+
+When you name this file either `.phpcs.xml`, `phpcs.xml`, `.phpcs.xml.dist` or `phpcs.xml.dist`, PHP_CodeSniffer will automatically locate it as long as it is placed in the directory from which you run the CodeSniffer or in a directory above it. If you follow these naming conventions you don't have to supply a `--standard` CLI argument.
+
+For more info, read about [using a default configuration file](https://github.com/squizlabs/PHP_CodeSniffer/wiki/Advanced-Usage#using-a-default-configuration-file). See also the provided WordPressCS [`phpcs.xml.dist.sample`](phpcs.xml.dist.sample) file and the [fully annotated example ruleset](https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml) in the PHP_CodeSniffer documentation.
 
 ### Customizing sniff behaviour
 
-The WordPress Coding Standard contains a number of sniffs which are configurable. This means that you can turn parts of the sniff on or off, or change the behaviour by setting a property for the sniff in your custom `.phpcs.xml.dist` file.
+The WordPress Coding Standard contains a number of sniffs which are configurable. This means that you can turn parts of the sniff on or off, or change the behaviour by setting a property for the sniff in your custom `[.]phpcs.xml[.dist]` file.
 
-You can find a complete list of all the properties you can change in the [wiki](https://github.com/WordPress/WordPress-Coding-Standards/wiki/Customizable-sniff-properties).
+You can find a complete list of all the properties you can change for the WordPressCS sniffs in the [wiki](https://github.com/WordPress/WordPress-Coding-Standards/wiki/Customizable-sniff-properties).
+
+WordPressCS also uses sniffs from PHPCSExtra and from PHP_CodeSniffer itself.
+The [README for PHPCSExtra](https://github.com/PHPCSStandards/PHPCSExtra) contains information on the properties which can be set for the sniff from PHPCSExtra.
+Information on custom properties which can be set for sniffs from PHP_CodeSniffer can be found in the [PHP_CodeSniffer wiki](https://github.com/squizlabs/PHP_CodeSniffer/wiki/Customisable-Sniff-Properties).
+
 
 ### Recommended additional rulesets
 
+#### PHPCompatibility
+
 The [PHPCompatibility](https://github.com/PHPCompatibility/PHPCompatibility) ruleset and its subset [PHPCompatibilityWP](https://github.com/PHPCompatibility/PHPCompatibilityWP) come highly recommended.
-The [PHPCompatibility](https://github.com/PHPCompatibility/PHPCompatibility) sniffs are designed to analyse your code for cross-PHP version compatibility.
+The [PHPCompatibility](https://github.com/PHPCompatibility/PHPCompatibility) sniffs are designed to analyse your code for cross-version PHP compatibility.
 
 The [PHPCompatibilityWP](https://github.com/PHPCompatibility/PHPCompatibilityWP) ruleset is based on PHPCompatibility, but specifically crafted to prevent false positives for projects which expect to run within the context of WordPress, i.e. core, plugins and themes.
 
 Install either as a separate ruleset and run it separately against your code or add it to your custom ruleset, like so:
 ```xml
-<config name="testVersion" value="5.6-"/>
+<config name="testVersion" value="7.0-"/>
 <rule ref="PHPCompatibilityWP">
     <include-pattern>*\.php$</include-pattern>
 </rule>
 ```
 
-Whichever way you run it, do make sure you set the `testVersion` to run the sniffs against. The `testVersion` determines for which PHP versions you will receive compatibility information. The recommended setting for this at this moment is  `5.6-` to support the same PHP versions as WordPress Core supports.
+Whichever way you run it, do make sure you set the `testVersion` to run the sniffs against. The `testVersion` determines for which PHP versions you will receive compatibility information. The recommended setting for this at this moment is  `7.0-` to support the same PHP versions as WordPress Core supports.
 
 For more information about setting the `testVersion`, see:
 * [PHPCompatibility: Sniffing your code for compatibility with specific PHP version(s)](https://github.com/PHPCompatibility/PHPCompatibility#sniffing-your-code-for-compatibility-with-specific-php-versions)
 * [PHPCompatibility: Using a custom ruleset](https://github.com/PHPCompatibility/PHPCompatibility#using-a-custom-ruleset)
+
+#### VariableAnalysis
+
+For some additional checks around (undefined/unused) variables, the [`VariableAnalysis`](https://github.com/sirbrillig/phpcs-variable-analysis/) standard is a handy addition.
+
+#### VIP Coding Standards
+
+For those projects which deploy to the WordPress VIP platform, it is recommended to also use the [official WordPress VIP coding standards](https://github.com/Automattic/VIP-Coding-Standards) ruleset.
+
 
 ## How to use
 
 ### Command line
 
 Run the `phpcs` command line tool on a given file or directory, for example:
-
-    phpcs --standard=WordPress wp-load.php
+```bash
+vendor/bin/phpcs --standard=WordPress wp-load.php
+```
 
 Will result in following output:
+```
+--------------------------------------------------------------------------------
+FOUND 6 ERRORS AND 4 WARNINGS AFFECTING 5 LINES
+--------------------------------------------------------------------------------
+  36 | WARNING | error_reporting() can lead to full path disclosure.
+  36 | WARNING | error_reporting() found. Changing configuration values at
+     |         | runtime is strongly discouraged.
+  52 | WARNING | Silencing errors is strongly discouraged. Use proper error
+     |         | checking instead. Found: @file_exists( dirname(...
+  52 | WARNING | Silencing errors is strongly discouraged. Use proper error
+     |         | checking instead. Found: @file_exists( dirname(...
+  75 | ERROR   | Overriding WordPress globals is prohibited. Found assignment
+     |         | to $path
+  78 | ERROR   | Detected usage of a possibly undefined superglobal array
+     |         | index: $_SERVER['REQUEST_URI']. Use isset() or empty() to
+     |         | check the index exists before using it
+  78 | ERROR   | $_SERVER['REQUEST_URI'] not unslashed before sanitization. Use
+     |         | wp_unslash() or similar
+  78 | ERROR   | Detected usage of a non-sanitized input variable:
+     |         | $_SERVER['REQUEST_URI']
+ 104 | ERROR   | All output should be run through an escaping function (see the
+     |         | Security sections in the WordPress Developer Handbooks), found
+     |         | '$die'.
+ 104 | ERROR   | All output should be run through an escaping function (see the
+     |         | Security sections in the WordPress Developer Handbooks), found
+     |         | '__'.
+--------------------------------------------------------------------------------
+```
 
-	------------------------------------------------------------------------------------------
-	FOUND 8 ERRORS AND 10 WARNINGS AFFECTING 11 LINES
-	------------------------------------------------------------------------------------------
-	 24 | WARNING | [ ] error_reporting() can lead to full path disclosure.
-	 24 | WARNING | [ ] error_reporting() found. Changing configuration at runtime is rarely
-	    |         |     necessary.
-	 37 | WARNING | [x] "require_once" is a statement not a function; no parentheses are
-	    |         |     required
-	 39 | WARNING | [ ] Silencing errors is discouraged
-	 39 | WARNING | [ ] Silencing errors is discouraged
-	 42 | WARNING | [x] "require_once" is a statement not a function; no parentheses are
-	    |         |     required
-	 46 | ERROR   | [ ] Inline comments must end in full-stops, exclamation marks, or
-	    |         |     question marks
-	 46 | ERROR   | [x] There must be no blank line following an inline comment
-	 49 | WARNING | [x] "require_once" is a statement not a function; no parentheses are
-	    |         |     required
-	 54 | WARNING | [x] "require_once" is a statement not a function; no parentheses are
-	    |         |     required
-	 63 | WARNING | [ ] Detected access of super global var $_SERVER, probably needs manual
-	    |         |     inspection.
-	 63 | ERROR   | [ ] Detected usage of a non-validated input variable: $_SERVER
-	 63 | ERROR   | [ ] Missing wp_unslash() before sanitization.
-	 63 | ERROR   | [ ] Detected usage of a non-sanitized input variable: $_SERVER
-	 69 | WARNING | [x] "require_once" is a statement not a function; no parentheses are
-	    |         |     required
-	 74 | ERROR   | [ ] Inline comments must end in full-stops, exclamation marks, or
-	    |         |     question marks
-	 92 | ERROR   | [ ] All output should be run through an escaping function (see the
-	    |         |     Security sections in the WordPress Developer Handbooks), found
-	    |         |     '$die'.
-	 92 | ERROR   | [ ] All output should be run through an escaping function (see the
-	    |         |     Security sections in the WordPress Developer Handbooks), found '__'.
-	------------------------------------------------------------------------------------------
-	PHPCBF CAN FIX THE 6 MARKED SNIFF VIOLATIONS AUTOMATICALLY
-	------------------------------------------------------------------------------------------
+### Using PHPCS and WordPressCS from within your IDE
 
-### Using PHPCS and WPCS from within your IDE
-
-* **PhpStorm** : Please see "[PHP Code Sniffer with WordPress Coding Standards Integration](https://confluence.jetbrains.com/display/PhpStorm/WordPress+Development+using+PhpStorm#WordPressDevelopmentusingPhpStorm-PHPCodeSnifferwithWordPressCodingStandardsIntegrationinPhpStorm)" in the PhpStorm documentation.
-* **Sublime Text** : Please see "[Setting up WPCS to work in Sublime Text](https://github.com/WordPress/WordPress-Coding-Standards/wiki/Setting-up-WPCS-to-work-in-Sublime-Text)" in the wiki.
-* **Atom**: Please see "[Setting up WPCS to work in Atom](https://github.com/WordPress/WordPress-Coding-Standards/wiki/Setting-up-WPCS-to-work-in-Atom)" in the wiki.
-* **Visual Studio**: Please see "[Setting up PHP CodeSniffer in Visual Studio Code](https://tommcfarlin.com/php-codesniffer-in-visual-studio-code/)", a tutorial by Tom McFarlin.
-* **Eclipse with XAMPP**: Please see "[Setting up WPCS when using Eclipse with XAMPP](https://github.com/WordPress/WordPress-Coding-Standards/wiki/How-to-use-WPCS-with-Eclipse-and-XAMPP)" in the wiki.
+The [wiki](https://github.com/WordPress/WordPress-Coding-Standards/wiki) contains links to various in- and external tutorials about setting up WordPressCS to work in your IDE.
 
 
-## Running your code through WPCS automatically using CI tools
+## Running your code through WordPressCS automatically using Continuous Integration tools
 
 - [Running in GitHub Actions](https://github.com/WordPress/WordPress-Coding-Standards/wiki/Running-in-GitHub-Actions)
 - [Running in Travis](https://github.com/WordPress/WordPress-Coding-Standards/wiki/Running-in-Travis)
+
 
 ## Fixing errors or ignoring them
 
 You can find information on how to deal with some of the more frequent issues in the [wiki](https://github.com/WordPress/WordPress-Coding-Standards/wiki).
 
-### Tools shipped with WPCS
+### Tools shipped with WordPressCS
 
-Since version 1.2.0, WPCS has a special sniff category `Utils`.
+Since version 1.2.0, WordPressCS has a special sniff category `Utils`.
 
 This sniff category contains some tools which, generally speaking, will only be needed to be run once over a codebase and for which the fixers can be considered _risky_, i.e. very careful review by a developer is needed before accepting the fixes made by these sniffs.
 
 The sniffs in this category are disabled by default and can only be activated by adding some properties for each sniff via a custom ruleset.
 
-At this moment, WPCS offer the following tools:
+At this moment, WordPressCS offer the following tools:
 * `WordPress.Utils.I18nTextDomainFixer` - This sniff can replace the text domain used in a code-base.
     The sniff will fix the text domains in both I18n function calls as well as in a plugin/theme header.
     Passing the following properties will activate the sniff:

--- a/Tests/RulesetCheck/class-ruleset-test.inc
+++ b/Tests/RulesetCheck/class-ruleset-test.inc
@@ -1,14 +1,14 @@
 <?php
 /**
- * Simple file which should not have any issues when testing against the WPCS rulesets.
+ * Simple file which should not have any issues when testing against the WordPressCS rulesets.
  *
  * Most - if not all - sniffs should be triggered by this file.
  *
  * Used to do a simple CI test on the rulesets.
  *
  * Currently covered - based on the rulesets as of July 24 2018:
- * - Every WPCS native sniff is triggered.
- * - Every WPCS + PHPCS sniff within the Core ruleset is triggered.
+ * - Every WordPressCS native sniff is triggered.
+ * - Every WordPressCS + PHPCS sniff within the Core ruleset is triggered.
  *
  * @package WPCS\WordPressCodingStandards
  */


### PR DESCRIPTION
### README: updates for WordPressCS 3.0.0

This commit updates the README guide to be in line with WordPressCS 3.0.0.

This commit:
* Removes the "Last commit to stable" and "Nr of contributors" badges.
* Updates the "Tested on PHP..." badges.
* Updates the table of contents to match the new content of the file.
* Removes the "Project history" section (has been moved to the wiki).
* Makes the pre-requisites for the package more explicit and puts them in a separate section.
* Updates the installation instructions and adds update instructions.
    - Removes the instructions related to stand-alone installs and using `composer create-project`.
    - The new installation instructions take the changes in Composer 2.2 (permission required for plugins to run) into account.
    - The new installation instructions include a link to the end user/ruleset maintainer upgrade guide for WPCS 3.0.0 as the initial upgrade may need extra work.
* Updates references to the Composer PHPCS plugin to make sure these reference the new name and link to the correct GH repo (as the repo has moved).
* Removes the reference to the VIP ruleset which was removed in WPCS 2.0.0 from the "Rulesets" section.
* Adds links to the "customizable properties" section for where to find customizable properties for PHPCS native sniffs and sniffs from PHPCSExtra.
* Adds the `VariableAnalysis` standard and the `VIP Coding Standards` to the list of optional additional rulesets to use.
* Updates the command and output for the example run.
* Removes the links to IDE related tutorials in favour of a link to the wiki (to save us having to maintain this list in multiple places).
* Ensures the text consistently uses `WordPressCS` instead of `WPCS`.

Closes #481
Closes #1821
Closes #1901

### CONTRIBUTING: updates for WordPressCS 3.0.0

This commit updates the CONTRIBUTING guide to be in line with WordPressCS 3.0.0.

This commit:
* Updates the information about usage of upstream sniffs and reporting upstream issues.
* Updates the information on creating a pull request.
* Removes the information about the use of a long running release PR (as we don't do this anymore in practice).
* Updates the information on running the unit tests, including the information on how to get set up with cloned dependencies.
* Updates the examples test run output and removes the outdated the asciinema image.
* Updates the code fragments and example output used in the tutorial part to be in line with the current code and run instructions.
* Ensures the text consistently uses `WordPressCS` instead of `WPCS`.
* Replaced some ablist language.

### Docs: miscellaneous changes

Change `WPCS` to `WordPressCS` in miscellaneous files.