### PR TITLE
Docs: Use `FileName` rule instead of `Filename` in the sample phpcs ruleset

### DIFF
--- a/phpcs.xml.dist.sample
+++ b/phpcs.xml.dist.sample
@@ -146,7 +146,7 @@
 	<rule ref="WordPress.WP.GlobalVariablesOverride">
 		<exclude-pattern>/path/to/Tests/*Test\.php</exclude-pattern>
 	</rule>
-	<rule ref="WordPress.Files.Filename">
+	<rule ref="WordPress.Files.FileName">
 		<exclude-pattern>/path/to/Tests/*Test\.php</exclude-pattern>
 	</rule>
 


### PR DESCRIPTION
Currently file [phpcs.xml.dist.sample](https://github.com/WordPress/WordPress-Coding-Standards/blob/develop/phpcs.xml.dist.sample#L149) has a case sensitive typo.

It is:

```xml
	<rule ref="WordPress.Files.Filename">
		<exclude-pattern>/path/to/Tests/*Test\.php</exclude-pattern>
	</rule>
```

Should be:

```xml
	<rule ref="WordPress.Files.FileName">
		<exclude-pattern>/path/to/Tests/*Test\.php</exclude-pattern>
	</rule>
```

I stumble across this when having [this issue](https://github.com/WordPress/WordPress-Coding-Standards/issues/2375).