### PR TITLE
GH Actions: add task to test example ruleset

### DIFF
--- a/.github/workflows/basic-qa.yml
+++ b/.github/workflows/basic-qa.yml
@@ -141,6 +141,12 @@ jobs:
       - name: Test the WordPress ruleset
         run: $(pwd)/vendor/bin/phpcs -ps ./Tests/RulesetCheck/class-ruleset-test.inc --standard=WordPress
 
+      - name: Rename the example ruleset to one which can be used for a ruleset
+        run:  cp phpcs.xml.dist.sample sample.xml
+
+      - name: Test the example ruleset
+        run: $(pwd)/vendor/bin/phpcs -ps ./Tests/RulesetCheck/example-ruleset-test.inc --standard=./sample.xml
+
       # Test for fixer conflicts by running the auto-fixers of the complete WPCS over the test case files.
       # This is not an exhaustive test, but should give an early indication for typical fixer conflicts.
       # If only fixable errors are found, the exit code will be 1, which can be interpreted as success.

--- a/Tests/RulesetCheck/example-ruleset-test.inc
+++ b/Tests/RulesetCheck/example-ruleset-test.inc
@@ -1,0 +1,8 @@
+<?php
+/**
+ * File which should not yield any errors when using the example ruleset.
+ *
+ * @package My\Prefix\Package
+ */
+
+$my_prefix_var = 'hello';


### PR DESCRIPTION
... to prevent typos like reported in #2375 from entering it.

Note: On the "Actions" tab you can see that I've also tested the "failure" case. It doesn't show the fatal error, but it does fail the build with an "ERROR: Referenced sniff "WordPress.Files.Filename" does not exist" error, so this should safeguard things sufficiently, I hope.