### PR TITLE
Funding: fix format

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,1 @@
-custom: ["https://opencollective.com/thewpcc/contribute/wp-php-63406", WP PHP]
+custom: "https://opencollective.com/thewpcc/contribute/wp-php-63406"


### PR DESCRIPTION
This should either be an array of links or a singular link. The `WP PHP` was regarded as an invalid link (not as a link description).

Ref: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository