### PR TITLE
Release checklist: add link to monthly dev blog

### DIFF
--- a/.github/release-checklist.md
+++ b/.github/release-checklist.md
@@ -62,9 +62,10 @@ PR for tracking changes for the x.x.x release. Target release date: **DOW MONTH 
 - [ ] Tweet, toot, etc about the release.
 - [ ] Post about it in Slack.
 - [ ] Submit for ["Month in WordPress"][month-in-wp].
-
+- [ ] Submit for the ["Monthy Dev Roundup"][dev-roundup].
 
 [phpcs-releases]:      https://github.com/squizlabs/PHP_CodeSniffer/releases
 [phpcsutils-releases]: https://github.com/PHPCSStandards/PHPCSUtils/releases
 [phpcsextra-releases]: https://github.com/PHPCSStandards/PHPCSExtra/releases
 [month-in-wp]:         https://make.wordpress.org/community/month-in-wordpress-submissions/
+[dev-roundup]:         https://github.com/WordPress/developer-blog-content/issues?q=is%3Aissue+label%3A%22Monthly+Roundup%22


### PR DESCRIPTION
Apparently we have to pro-actively inform the team as they don't appear to watch Make.

Ref: https://developer.wordpress.org/news/2023/09/whats-new-for-developers-september-2023/#comment-1611