### PR TITLE
Hotfix - Lowercase custom sniff properties

### DIFF
--- a/WordPress/Helpers/EscapingFunctionsTrait.php
+++ b/WordPress/Helpers/EscapingFunctionsTrait.php
@@ -218,15 +218,11 @@ trait EscapingFunctionsTrait {
 		if ( array() === $this->allEscapingFunctions
 			|| $this->customEscapingFunctions !== $this->addedCustomEscapingFunctions['escape']
 		) {
-			/*
-			 * Lowercase all names, both custom as well as "known", as PHP treats namespaced names case-insensitively.
-			 */
-			$custom_escaping_functions = array_map( 'strtolower', $this->customEscapingFunctions );
-			$escaping_functions        = array_change_key_case( $this->escapingFunctions, \CASE_LOWER );
-
 			$this->allEscapingFunctions = RulesetPropertyHelper::merge_custom_array(
-				$custom_escaping_functions,
-				$escaping_functions
+				$this->customEscapingFunctions,
+				$this->escapingFunctions,
+				true,
+				true
 			);
 
 			$this->addedCustomEscapingFunctions['escape'] = $this->customEscapingFunctions;
@@ -248,15 +244,11 @@ trait EscapingFunctionsTrait {
 		if ( array() === $this->allAutoEscapedFunctions
 			|| $this->customAutoEscapedFunctions !== $this->addedCustomEscapingFunctions['autoescape']
 		) {
-			/*
-			 * Lowercase all names, both custom as well as "known", as PHP treats namespaced names case-insensitively.
-			 */
-			$custom_auto_escaped_functions = array_map( 'strtolower', $this->customAutoEscapedFunctions );
-			$auto_escaped_functions        = array_change_key_case( $this->autoEscapedFunctions, \CASE_LOWER );
-
 			$this->allAutoEscapedFunctions = RulesetPropertyHelper::merge_custom_array(
-				$custom_auto_escaped_functions,
-				$auto_escaped_functions
+				$this->customAutoEscapedFunctions,
+				$this->autoEscapedFunctions,
+				true,
+				true
 			);
 
 			$this->addedCustomEscapingFunctions['autoescape'] = $this->customAutoEscapedFunctions;

--- a/WordPress/Helpers/EscapingFunctionsTrait.php
+++ b/WordPress/Helpers/EscapingFunctionsTrait.php
@@ -218,9 +218,15 @@ trait EscapingFunctionsTrait {
 		if ( array() === $this->allEscapingFunctions
 			|| $this->customEscapingFunctions !== $this->addedCustomEscapingFunctions['escape']
 		) {
+			/*
+			 * Lowercase all names, both custom as well as "known", as PHP treats namespaced names case-insensitively.
+			 */
+			$custom_escaping_functions = array_map( 'strtolower', $this->customEscapingFunctions );
+			$escaping_functions        = array_change_key_case( $this->escapingFunctions, \CASE_LOWER );
+
 			$this->allEscapingFunctions = RulesetPropertyHelper::merge_custom_array(
-				$this->customEscapingFunctions,
-				$this->escapingFunctions
+				$custom_escaping_functions,
+				$escaping_functions
 			);
 
 			$this->addedCustomEscapingFunctions['escape'] = $this->customEscapingFunctions;
@@ -242,9 +248,15 @@ trait EscapingFunctionsTrait {
 		if ( array() === $this->allAutoEscapedFunctions
 			|| $this->customAutoEscapedFunctions !== $this->addedCustomEscapingFunctions['autoescape']
 		) {
+			/*
+			 * Lowercase all names, both custom as well as "known", as PHP treats namespaced names case-insensitively.
+			 */
+			$custom_auto_escaped_functions = array_map( 'strtolower', $this->customAutoEscapedFunctions );
+			$auto_escaped_functions        = array_change_key_case( $this->autoEscapedFunctions, \CASE_LOWER );
+
 			$this->allAutoEscapedFunctions = RulesetPropertyHelper::merge_custom_array(
-				$this->customAutoEscapedFunctions,
-				$this->autoEscapedFunctions
+				$custom_auto_escaped_functions,
+				$auto_escaped_functions
 			);
 
 			$this->addedCustomEscapingFunctions['autoescape'] = $this->customAutoEscapedFunctions;

--- a/WordPress/Helpers/IsUnitTestTrait.php
+++ b/WordPress/Helpers/IsUnitTestTrait.php
@@ -142,15 +142,11 @@ trait IsUnitTestTrait {
 				}
 			}
 
-			/*
-			 * Lowercase all names, both custom as well as "known", as PHP treats namespaced names case-insensitively.
-			 */
-			$custom_test_classes = array_map( 'strtolower', $custom_test_classes );
-			$known_test_classes  = array_change_key_case( $this->known_test_classes, \CASE_LOWER );
-
 			$this->all_test_classes = RulesetPropertyHelper::merge_custom_array(
 				$custom_test_classes,
-				$known_test_classes
+				$this->known_test_classes,
+				true,
+				true
 			);
 
 			// Store the original value so the comparison can succeed.

--- a/WordPress/Helpers/PrintingFunctionsTrait.php
+++ b/WordPress/Helpers/PrintingFunctionsTrait.php
@@ -96,9 +96,15 @@ trait PrintingFunctionsTrait {
 		if ( array() === $this->allPrintingFunctions
 			|| $this->customPrintingFunctions !== $this->addedCustomPrintingFunctions
 		) {
+			/*
+			 * Lowercase all names, both custom as well as "known", as PHP treats namespaced names case-insensitively.
+			 */
+			$custom_printing_functions = array_map( 'strtolower', $this->customPrintingFunctions );
+			$printing_functions        = array_change_key_case( $this->printingFunctions, \CASE_LOWER );
+
 			$this->allPrintingFunctions = RulesetPropertyHelper::merge_custom_array(
-				$this->customPrintingFunctions,
-				$this->printingFunctions
+				$custom_printing_functions,
+				$printing_functions
 			);
 
 			$this->addedCustomPrintingFunctions = $this->customPrintingFunctions;

--- a/WordPress/Helpers/PrintingFunctionsTrait.php
+++ b/WordPress/Helpers/PrintingFunctionsTrait.php
@@ -96,15 +96,11 @@ trait PrintingFunctionsTrait {
 		if ( array() === $this->allPrintingFunctions
 			|| $this->customPrintingFunctions !== $this->addedCustomPrintingFunctions
 		) {
-			/*
-			 * Lowercase all names, both custom as well as "known", as PHP treats namespaced names case-insensitively.
-			 */
-			$custom_printing_functions = array_map( 'strtolower', $this->customPrintingFunctions );
-			$printing_functions        = array_change_key_case( $this->printingFunctions, \CASE_LOWER );
-
 			$this->allPrintingFunctions = RulesetPropertyHelper::merge_custom_array(
-				$custom_printing_functions,
-				$printing_functions
+				$this->customPrintingFunctions,
+				$this->printingFunctions,
+				true,
+				true
 			);
 
 			$this->addedCustomPrintingFunctions = $this->customPrintingFunctions;

--- a/WordPress/Helpers/RulesetPropertyHelper.php
+++ b/WordPress/Helpers/RulesetPropertyHelper.php
@@ -55,9 +55,9 @@ final class RulesetPropertyHelper {
 	 */
 	public static function merge_custom_array( $custom, array $base = array(), $flip = true, $lowercaseKeyValues = false ) {
 		if ( $lowercaseKeyValues ) {
-			$base = array_map( 'strtolower', $base );
+			$base   = array_map( 'strtolower', $base );
 			$custom = array_map( 'strtolower', $custom );
-			$base = array_change_key_case( $base );
+			$base   = array_change_key_case( $base );
 			$custom = array_change_key_case( $custom );
 		}
 

--- a/WordPress/Helpers/RulesetPropertyHelper.php
+++ b/WordPress/Helpers/RulesetPropertyHelper.php
@@ -54,6 +54,13 @@ final class RulesetPropertyHelper {
 	 * @return array
 	 */
 	public static function merge_custom_array( $custom, array $base = array(), $flip = true, $lowercaseKeyValues = false ) {
+		if ( $lowercaseKeyValues ) {
+			$base = array_map( 'strtolower', $base );
+			$custom = array_map( 'strtolower', $custom );
+			$base = array_change_key_case( $base );
+			$custom = array_change_key_case( $custom );
+		}
+
 		if ( true === $flip ) {
 			$base = array_filter( $base );
 		}
@@ -68,13 +75,6 @@ final class RulesetPropertyHelper {
 
 		if ( empty( $base ) ) {
 			return $custom;
-		}
-
-		if ( $lowercaseKeyValues ) {
-			$base = array_map( 'strtolower', $base );
-			$custom = array_map( 'strtolower', $custom );
-			$base = array_change_key_case( $base );
-			$custom = array_change_key_case( $custom );
 		}
 
 		return array_merge( $base, $custom );

--- a/WordPress/Helpers/RulesetPropertyHelper.php
+++ b/WordPress/Helpers/RulesetPropertyHelper.php
@@ -43,15 +43,17 @@ final class RulesetPropertyHelper {
 	 * @since 2.0.0  No longer supports custom array properties which were incorrectly
 	 *               passed as a string.
 	 * @since 3.0.0  Moved from the Sniff class to this class.
+	 * @since 3.1.0  Added a new parameter to lowercase array keys and values.
 	 *
-	 * @param array $custom Custom list as provided via a ruleset.
-	 * @param array $base   Optional. Base list. Defaults to an empty array.
-	 *                      Expects `value => true` format when `$flip` is true.
-	 * @param bool  $flip   Optional. Whether or not to flip the custom list.
-	 *                      Defaults to true.
+	 * @param array $custom             Custom list as provided via a ruleset.
+	 * @param array $base               Optional. Base list. Defaults to an empty array.
+	 *                                  Expects `value => true` format when `$flip` is true.
+	 * @param bool  $flip               Optional. Whether or not to flip the custom list.
+	 * @param bool  $lowercaseKeyValues Optional. Whether to lowercase keys and values in the resulting array.
+	 *                                  Defaults to false.
 	 * @return array
 	 */
-	public static function merge_custom_array( $custom, array $base = array(), $flip = true ) {
+	public static function merge_custom_array( $custom, array $base = array(), $flip = true, $lowercaseKeyValues = false ) {
 		if ( true === $flip ) {
 			$base = array_filter( $base );
 		}
@@ -66,6 +68,13 @@ final class RulesetPropertyHelper {
 
 		if ( empty( $base ) ) {
 			return $custom;
+		}
+
+		if ( $lowercaseKeyValues ) {
+			$base = array_map( 'strtolower', $base );
+			$custom = array_map( 'strtolower', $custom );
+			$base = array_change_key_case( $base );
+			$custom = array_change_key_case( $custom );
 		}
 
 		return array_merge( $base, $custom );

--- a/WordPress/Helpers/RulesetPropertyHelper.php
+++ b/WordPress/Helpers/RulesetPropertyHelper.php
@@ -49,7 +49,7 @@ final class RulesetPropertyHelper {
 	 * @param array $base          Optional. Base list. Defaults to an empty array.
 	 *                             Expects `value => true` format when `$flip` is true.
 	 * @param bool  $flip          Optional. Whether or not to flip the custom list.
-	 * @param bool  $lowercasekeys Optional. Whether to lowercase keys and values in the resulting array.
+	 * @param bool  $lowercasekeys Optional. Whether to lowercase keys in the resulting array.
 	 *                             Defaults to false.
 	 * @return array
 	 */

--- a/WordPress/Helpers/RulesetPropertyHelper.php
+++ b/WordPress/Helpers/RulesetPropertyHelper.php
@@ -43,22 +43,23 @@ final class RulesetPropertyHelper {
 	 * @since 2.0.0  No longer supports custom array properties which were incorrectly
 	 *               passed as a string.
 	 * @since 3.0.0  Moved from the Sniff class to this class.
-	 * @since 3.1.0  Added a new parameter to lowercase array keys and values.
+	 * @since 3.0.2  Added a new parameter to lowercase array keys and values.
 	 *
-	 * @param array $custom             Custom list as provided via a ruleset.
-	 * @param array $base               Optional. Base list. Defaults to an empty array.
-	 *                                  Expects `value => true` format when `$flip` is true.
-	 * @param bool  $flip               Optional. Whether or not to flip the custom list.
-	 * @param bool  $lowercaseKeyValues Optional. Whether to lowercase keys and values in the resulting array.
-	 *                                  Defaults to false.
+	 * @param array $custom        Custom list as provided via a ruleset.
+	 * @param array $base          Optional. Base list. Defaults to an empty array.
+	 *                             Expects `value => true` format when `$flip` is true.
+	 * @param bool  $flip          Optional. Whether or not to flip the custom list.
+	 * @param bool  $lowercasekeys Optional. Whether to lowercase keys and values in the resulting array.
+	 *                             Defaults to false.
 	 * @return array
 	 */
-	public static function merge_custom_array( $custom, array $base = array(), $flip = true, $lowercaseKeyValues = false ) {
-		if ( $lowercaseKeyValues ) {
-			$base   = array_map( 'strtolower', $base );
-			$custom = array_map( 'strtolower', $custom );
-			$base   = array_change_key_case( $base );
-			$custom = array_change_key_case( $custom );
+	public static function merge_custom_array( $custom, array $base = array(), $flip = true, $lowercasekeys = false ) {
+		if ( empty( $base ) && empty( $custom ) ) {
+			return array();
+		}
+
+		if ( $lowercasekeys ) {
+			$base = array_change_key_case( $base );
 		}
 
 		if ( true === $flip ) {
@@ -71,6 +72,10 @@ final class RulesetPropertyHelper {
 
 		if ( true === $flip ) {
 			$custom = array_fill_keys( $custom, false );
+		}
+
+		if ( $lowercasekeys ) {
+			$custom = array_change_key_case( $custom );
 		}
 
 		if ( empty( $base ) ) {

--- a/WordPress/Helpers/RulesetPropertyHelper.php
+++ b/WordPress/Helpers/RulesetPropertyHelper.php
@@ -43,7 +43,7 @@ final class RulesetPropertyHelper {
 	 * @since 2.0.0  No longer supports custom array properties which were incorrectly
 	 *               passed as a string.
 	 * @since 3.0.0  Moved from the Sniff class to this class.
-	 * @since 3.0.2  Added a new parameter to lowercase array keys and values.
+	 * @since 3.0.2  Added a new parameter to lowercase array keys for the resulting array.
 	 *
 	 * @param array $custom        Custom list as provided via a ruleset.
 	 * @param array $base          Optional. Base list. Defaults to an empty array.

--- a/WordPress/Helpers/SanitizationHelperTrait.php
+++ b/WordPress/Helpers/SanitizationHelperTrait.php
@@ -194,15 +194,11 @@ trait SanitizationHelperTrait {
 		if ( array() === $this->allSanitizingFunctions
 			|| $this->customSanitizingFunctions !== $this->addedCustomSanitizingFunctions['sanitize']
 		) {
-			/*
-			 * Lowercase all names, both custom as well as "known", as PHP treats namespaced names case-insensitively.
-			 */
-			$custom_sanitizing_functions = array_map( 'strtolower', $this->customSanitizingFunctions );
-			$sanitizing_functions        = array_change_key_case( $this->sanitizingFunctions, \CASE_LOWER );
-
 			$this->allSanitizingFunctions = RulesetPropertyHelper::merge_custom_array(
-				$custom_sanitizing_functions,
-				$sanitizing_functions
+				$this->customSanitizingFunctions,
+				$this->sanitizingFunctions,
+				true,
+				true
 			);
 
 			$this->addedCustomSanitizingFunctions['sanitize'] = $this->customSanitizingFunctions;
@@ -222,15 +218,11 @@ trait SanitizationHelperTrait {
 		if ( array() === $this->allUnslashingSanitizingFunctions
 			|| $this->customUnslashingSanitizingFunctions !== $this->addedCustomSanitizingFunctions['unslashsanitize']
 		) {
-			/*
-			 * Lowercase all names, both custom as well as "known", as PHP treats namespaced names case-insensitively.
-			 */
-			$custom_unslashing_sanitizing_functions = array_map( 'strtolower', $this->customUnslashingSanitizingFunctions );
-			$unslashing_sanitizing_functions        = array_change_key_case( $this->unslashingSanitizingFunctions, \CASE_LOWER );
-
 			$this->allUnslashingSanitizingFunctions = RulesetPropertyHelper::merge_custom_array(
-				$custom_unslashing_sanitizing_functions,
-				$unslashing_sanitizing_functions
+				$this->customUnslashingSanitizingFunctions,
+				$this->unslashingSanitizingFunctions,
+				true,
+				true
 			);
 
 			$this->addedCustomSanitizingFunctions['unslashsanitize'] = $this->customUnslashingSanitizingFunctions;

--- a/WordPress/Helpers/SanitizationHelperTrait.php
+++ b/WordPress/Helpers/SanitizationHelperTrait.php
@@ -194,9 +194,15 @@ trait SanitizationHelperTrait {
 		if ( array() === $this->allSanitizingFunctions
 			|| $this->customSanitizingFunctions !== $this->addedCustomSanitizingFunctions['sanitize']
 		) {
+			/*
+			 * Lowercase all names, both custom as well as "known", as PHP treats namespaced names case-insensitively.
+			 */
+			$custom_sanitizing_functions = array_map( 'strtolower', $this->customSanitizingFunctions );
+			$sanitizing_functions        = array_change_key_case( $this->sanitizingFunctions, \CASE_LOWER );
+
 			$this->allSanitizingFunctions = RulesetPropertyHelper::merge_custom_array(
-				$this->customSanitizingFunctions,
-				$this->sanitizingFunctions
+				$custom_sanitizing_functions,
+				$sanitizing_functions
 			);
 
 			$this->addedCustomSanitizingFunctions['sanitize'] = $this->customSanitizingFunctions;
@@ -216,9 +222,15 @@ trait SanitizationHelperTrait {
 		if ( array() === $this->allUnslashingSanitizingFunctions
 			|| $this->customUnslashingSanitizingFunctions !== $this->addedCustomSanitizingFunctions['unslashsanitize']
 		) {
+			/*
+			 * Lowercase all names, both custom as well as "known", as PHP treats namespaced names case-insensitively.
+			 */
+			$custom_unslashing_sanitizing_functions = array_map( 'strtolower', $this->customUnslashingSanitizingFunctions );
+			$unslashing_sanitizing_functions        = array_change_key_case( $this->unslashingSanitizingFunctions, \CASE_LOWER );
+
 			$this->allUnslashingSanitizingFunctions = RulesetPropertyHelper::merge_custom_array(
-				$this->customUnslashingSanitizingFunctions,
-				$this->unslashingSanitizingFunctions
+				$custom_unslashing_sanitizing_functions,
+				$unslashing_sanitizing_functions
 			);
 
 			$this->addedCustomSanitizingFunctions['unslashsanitize'] = $this->customUnslashingSanitizingFunctions;

--- a/WordPress/Sniffs/DB/DirectDatabaseQuerySniff.php
+++ b/WordPress/Sniffs/DB/DirectDatabaseQuerySniff.php
@@ -230,17 +230,17 @@ final class DirectDatabaseQuerySniff extends Sniff {
 			for ( $i = ( $scopeStart + 1 ); $i < $scopeEnd; $i++ ) {
 				if ( \T_STRING === $this->tokens[ $i ]['code'] ) {
 
-					if ( isset( $this->cacheDeleteFunctions[ $this->tokens[ $i ]['content'] ] ) ) {
+					if ( isset( $this->cacheDeleteFunctions[ strtolower( $this->tokens[ $i ]['content'] ) ] ) ) {
 
 						if ( \in_array( $method, array( 'query', 'update', 'replace', 'delete' ), true ) ) {
 							$cached = true;
 							break;
 						}
-					} elseif ( isset( $this->cacheGetFunctions[ $this->tokens[ $i ]['content'] ] ) ) {
+					} elseif ( isset( $this->cacheGetFunctions[ strtolower( $this->tokens[ $i ]['content'] ) ] ) ) {
 
 						$wp_cache_get = true;
 
-					} elseif ( isset( $this->cacheSetFunctions[ $this->tokens[ $i ]['content'] ] ) ) {
+					} elseif ( isset( $this->cacheSetFunctions[ strtolower( $this->tokens[ $i ]['content'] ) ] ) ) {
 
 						if ( $wp_cache_get ) {
 							$cached = true;
@@ -272,27 +272,45 @@ final class DirectDatabaseQuerySniff extends Sniff {
 		}
 
 		if ( $this->customCacheGetFunctions !== $this->addedCustomFunctions['cacheget'] ) {
+			/*
+			 * Lowercase all names, both custom as well as "known", as PHP treats namespaced names case-insensitively.
+			 */
+			$custom_cache_get_functions = array_map( 'strtolower', $this->customCacheGetFunctions );
+			$cache_get_functions        = array_change_key_case( $this->cacheGetFunctions, \CASE_LOWER );
+
 			$this->cacheGetFunctions = RulesetPropertyHelper::merge_custom_array(
-				$this->customCacheGetFunctions,
-				$this->cacheGetFunctions
+				$custom_cache_get_functions,
+				$cache_get_functions
 			);
 
 			$this->addedCustomFunctions['cacheget'] = $this->customCacheGetFunctions;
 		}
 
 		if ( $this->customCacheSetFunctions !== $this->addedCustomFunctions['cacheset'] ) {
+			/*
+			 * Lowercase all names, both custom as well as "known", as PHP treats namespaced names case-insensitively.
+			 */
+			$custom_cache_set_functions = array_map( 'strtolower', $this->customCacheSetFunctions );
+			$cache_set_functions        = array_change_key_case( $this->cacheSetFunctions, \CASE_LOWER );
+
 			$this->cacheSetFunctions = RulesetPropertyHelper::merge_custom_array(
-				$this->customCacheSetFunctions,
-				$this->cacheSetFunctions
+				$custom_cache_set_functions,
+				$cache_set_functions
 			);
 
 			$this->addedCustomFunctions['cacheset'] = $this->customCacheSetFunctions;
 		}
 
 		if ( $this->customCacheDeleteFunctions !== $this->addedCustomFunctions['cachedelete'] ) {
+			/*
+			 * Lowercase all names, both custom as well as "known", as PHP treats namespaced names case-insensitively.
+			 */
+			$custom_cache_delete_functions = array_map( 'strtolower', $this->customCacheDeleteFunctions );
+			$cache_delete_functions        = array_change_key_case( $this->cacheDeleteFunctions, \CASE_LOWER );
+
 			$this->cacheDeleteFunctions = RulesetPropertyHelper::merge_custom_array(
-				$this->customCacheDeleteFunctions,
-				$this->cacheDeleteFunctions
+				$custom_cache_delete_functions,
+				$cache_delete_functions
 			);
 
 			$this->addedCustomFunctions['cachedelete'] = $this->customCacheDeleteFunctions;

--- a/WordPress/Sniffs/DB/DirectDatabaseQuerySniff.php
+++ b/WordPress/Sniffs/DB/DirectDatabaseQuerySniff.php
@@ -229,18 +229,19 @@ final class DirectDatabaseQuerySniff extends Sniff {
 
 			for ( $i = ( $scopeStart + 1 ); $i < $scopeEnd; $i++ ) {
 				if ( \T_STRING === $this->tokens[ $i ]['code'] ) {
+					$content = strtolower( $this->tokens[ $i ]['content'] );
 
-					if ( isset( $this->cacheDeleteFunctions[ strtolower( $this->tokens[ $i ]['content'] ) ] ) ) {
+					if ( isset( $this->cacheDeleteFunctions[ $content ] ) ) {
 
 						if ( \in_array( $method, array( 'query', 'update', 'replace', 'delete' ), true ) ) {
 							$cached = true;
 							break;
 						}
-					} elseif ( isset( $this->cacheGetFunctions[ strtolower( $this->tokens[ $i ]['content'] ) ] ) ) {
+					} elseif ( isset( $this->cacheGetFunctions[ $content ] ) ) {
 
 						$wp_cache_get = true;
 
-					} elseif ( isset( $this->cacheSetFunctions[ strtolower( $this->tokens[ $i ]['content'] ) ] ) ) {
+					} elseif ( isset( $this->cacheSetFunctions[ $content ] ) ) {
 
 						if ( $wp_cache_get ) {
 							$cached = true;

--- a/WordPress/Sniffs/DB/DirectDatabaseQuerySniff.php
+++ b/WordPress/Sniffs/DB/DirectDatabaseQuerySniff.php
@@ -273,45 +273,33 @@ final class DirectDatabaseQuerySniff extends Sniff {
 		}
 
 		if ( $this->customCacheGetFunctions !== $this->addedCustomFunctions['cacheget'] ) {
-			/*
-			 * Lowercase all names, both custom as well as "known", as PHP treats namespaced names case-insensitively.
-			 */
-			$custom_cache_get_functions = array_map( 'strtolower', $this->customCacheGetFunctions );
-			$cache_get_functions        = array_change_key_case( $this->cacheGetFunctions, \CASE_LOWER );
-
 			$this->cacheGetFunctions = RulesetPropertyHelper::merge_custom_array(
-				$custom_cache_get_functions,
-				$cache_get_functions
+				$this->customCacheGetFunctions,
+				$this->cacheGetFunctions,
+				true,
+				true
 			);
 
 			$this->addedCustomFunctions['cacheget'] = $this->customCacheGetFunctions;
 		}
 
 		if ( $this->customCacheSetFunctions !== $this->addedCustomFunctions['cacheset'] ) {
-			/*
-			 * Lowercase all names, both custom as well as "known", as PHP treats namespaced names case-insensitively.
-			 */
-			$custom_cache_set_functions = array_map( 'strtolower', $this->customCacheSetFunctions );
-			$cache_set_functions        = array_change_key_case( $this->cacheSetFunctions, \CASE_LOWER );
-
 			$this->cacheSetFunctions = RulesetPropertyHelper::merge_custom_array(
-				$custom_cache_set_functions,
-				$cache_set_functions
+				$this->customCacheSetFunctions,
+				$this->cacheSetFunctions,
+				true,
+				true
 			);
 
 			$this->addedCustomFunctions['cacheset'] = $this->customCacheSetFunctions;
 		}
 
 		if ( $this->customCacheDeleteFunctions !== $this->addedCustomFunctions['cachedelete'] ) {
-			/*
-			 * Lowercase all names, both custom as well as "known", as PHP treats namespaced names case-insensitively.
-			 */
-			$custom_cache_delete_functions = array_map( 'strtolower', $this->customCacheDeleteFunctions );
-			$cache_delete_functions        = array_change_key_case( $this->cacheDeleteFunctions, \CASE_LOWER );
-
 			$this->cacheDeleteFunctions = RulesetPropertyHelper::merge_custom_array(
-				$custom_cache_delete_functions,
-				$cache_delete_functions
+				$this->customCacheDeleteFunctions,
+				$this->cacheDeleteFunctions,
+				true,
+				true
 			);
 
 			$this->addedCustomFunctions['cachedelete'] = $this->customCacheDeleteFunctions;

--- a/WordPress/Sniffs/PHP/NoSilencedErrorsSniff.php
+++ b/WordPress/Sniffs/PHP/NoSilencedErrorsSniff.php
@@ -184,7 +184,8 @@ final class NoSilencedErrorsSniff extends Sniff {
 	 */
 	public function process_token( $stackPtr ) {
 		// Handle the user-defined custom function list.
-		$this->customAllowedFunctionsList = RulesetPropertyHelper::merge_custom_array( $this->customAllowedFunctionsList, array(), false, true );
+		$this->customAllowedFunctionsList = RulesetPropertyHelper::merge_custom_array( $this->customAllowedFunctionsList, array(), false );
+		$this->customAllowedFunctionsList = array_map( 'strtolower', $this->customAllowedFunctionsList );
 
 		/*
 		 * Check if the error silencing is done for one of the allowed functions.

--- a/WordPress/Sniffs/PHP/NoSilencedErrorsSniff.php
+++ b/WordPress/Sniffs/PHP/NoSilencedErrorsSniff.php
@@ -184,8 +184,7 @@ final class NoSilencedErrorsSniff extends Sniff {
 	 */
 	public function process_token( $stackPtr ) {
 		// Handle the user-defined custom function list.
-		$this->customAllowedFunctionsList = RulesetPropertyHelper::merge_custom_array( $this->customAllowedFunctionsList, array(), false );
-		$this->customAllowedFunctionsList = array_map( 'strtolower', $this->customAllowedFunctionsList );
+		$this->customAllowedFunctionsList = RulesetPropertyHelper::merge_custom_array( $this->customAllowedFunctionsList, array(), false, true );
 
 		/*
 		 * Check if the error silencing is done for one of the allowed functions.

--- a/WordPress/Sniffs/Security/NonceVerificationSniff.php
+++ b/WordPress/Sniffs/Security/NonceVerificationSniff.php
@@ -310,7 +310,7 @@ class NonceVerificationSniff extends Sniff {
 			}
 
 			// If this is one of the nonce verification functions, we can bail out.
-			if ( isset( $this->nonceVerificationFunctions[ $this->tokens[ $i ]['content'] ] ) ) {
+			if ( isset( $this->nonceVerificationFunctions[ strtolower( $this->tokens[ $i ]['content'] ) ] ) ) {
 				/*
 				 * Now, make sure it is a call to a global function.
 				 */
@@ -411,9 +411,15 @@ class NonceVerificationSniff extends Sniff {
 	 */
 	protected function mergeFunctionLists() {
 		if ( $this->customNonceVerificationFunctions !== $this->addedCustomNonceFunctions ) {
+			/*
+			 * Lowercase all names, both custom as well as "known", as PHP treats namespaced names case-insensitively.
+			 */
+			$custom_nonce_verification_functions = array_map( 'strtolower', $this->customNonceVerificationFunctions );
+			$nonce_verification_functions        = array_change_key_case( $this->nonceVerificationFunctions, \CASE_LOWER );
+
 			$this->nonceVerificationFunctions = RulesetPropertyHelper::merge_custom_array(
-				$this->customNonceVerificationFunctions,
-				$this->nonceVerificationFunctions
+				$custom_nonce_verification_functions,
+				$nonce_verification_functions
 			);
 
 			$this->addedCustomNonceFunctions = $this->customNonceVerificationFunctions;

--- a/WordPress/Sniffs/Security/NonceVerificationSniff.php
+++ b/WordPress/Sniffs/Security/NonceVerificationSniff.php
@@ -411,15 +411,11 @@ class NonceVerificationSniff extends Sniff {
 	 */
 	protected function mergeFunctionLists() {
 		if ( $this->customNonceVerificationFunctions !== $this->addedCustomNonceFunctions ) {
-			/*
-			 * Lowercase all names, both custom as well as "known", as PHP treats namespaced names case-insensitively.
-			 */
-			$custom_nonce_verification_functions = array_map( 'strtolower', $this->customNonceVerificationFunctions );
-			$nonce_verification_functions        = array_change_key_case( $this->nonceVerificationFunctions, \CASE_LOWER );
-
 			$this->nonceVerificationFunctions = RulesetPropertyHelper::merge_custom_array(
-				$custom_nonce_verification_functions,
-				$nonce_verification_functions
+				$this->customNonceVerificationFunctions,
+				$this->nonceVerificationFunctions,
+				true,
+				true
 			);
 
 			$this->addedCustomNonceFunctions = $this->customNonceVerificationFunctions;

--- a/WordPress/Tests/DB/DirectDatabaseQueryUnitTest.inc
+++ b/WordPress/Tests/DB/DirectDatabaseQueryUnitTest.inc
@@ -336,9 +336,9 @@ function method_names_are_caseinsensitive() {
 /*
  * Test using custom properties, setting & unsetting (resetting).
  */
-// phpcs:set WordPress.DB.DirectDatabaseQuery customCacheGetFunctions[] my_cacheget
-// phpcs:set WordPress.DB.DirectDatabaseQuery customCacheSetFunctions[] my_cacheset,my_other_cacheset
-// phpcs:set WordPress.DB.DirectDatabaseQuery customCacheDeleteFunctions[] my_cachedel
+// phpcs:set WordPress.DB.DirectDatabaseQuery customCacheGetFunctions[] my_cacHeget
+// phpcs:set WordPress.DB.DirectDatabaseQuery customCacheSetFunctions[] my_cachEset,my_other_cacheSET
+// phpcs:set WordPress.DB.DirectDatabaseQuery customCacheDeleteFunctions[] MY_cachedeL
 function cache_customA() {
 	global $wpdb;
 	$quux = MY_cacheget( 'quux' );
@@ -363,7 +363,7 @@ function cache_customC() {
 	my_cacheDEL( 'key', 'group' );
 }
 
-// phpcs:set WordPress.DB.DirectDatabaseQuery customCacheSetFunctions[] my_cacheset
+// phpcs:set WordPress.DB.DirectDatabaseQuery customCacheSetFunctions[] my_cacheSet
 // phpcs:set WordPress.DB.DirectDatabaseQuery customCacheDeleteFunctions[]
 
 function cache_customD() {

--- a/WordPress/Tests/DB/DirectDatabaseQueryUnitTest.inc
+++ b/WordPress/Tests/DB/DirectDatabaseQueryUnitTest.inc
@@ -341,10 +341,10 @@ function method_names_are_caseinsensitive() {
 // phpcs:set WordPress.DB.DirectDatabaseQuery customCacheDeleteFunctions[] MY_cachedeL
 function cache_customA() {
 	global $wpdb;
-	$quux = MY_cacheget( 'quux' );
+	$quux = my_cacheget( 'quux' );
 	if ( false !== $quux ) {
 		$wpdb->get_results( 'SELECT X FROM Y' ); // Warning direct DB call.
-		my_cacheSet( 'key', 'group' );
+		my_cacheset( 'key', 'group' );
 	}
 }
 
@@ -353,14 +353,14 @@ function cache_customB() {
 	$quux = my_cacheget( 'quux' );
 	if ( false !== $quux ) {
 		$wpdb->get_results( 'SELECT X FROM Y' ); // Warning direct DB call.
-		my_other_CacheSet( 'key', 'group' );
+		my_other_cacheset( 'key', 'group' );
 	}
 }
 
 function cache_customC() {
 	global $wpdb;
 	$wpdb->query( 'SELECT X FROM Y' ); // Warning direct DB call.
-	my_cacheDEL( 'key', 'group' );
+	my_cachedel( 'key', 'group' );
 }
 
 // phpcs:set WordPress.DB.DirectDatabaseQuery customCacheSetFunctions[] my_cacheSet
@@ -371,7 +371,7 @@ function cache_customD() {
 	$quux = my_cacheget( 'quux' );
 	if ( false !== $quux ) {
 		$wpdb->get_results( 'SELECT X FROM Y' ); // Warning direct DB call.
-		my_cacHeset( 'key', 'group' );
+		my_cacheset( 'key', 'group' );
 	}
 }
 

--- a/WordPress/Tests/DB/DirectDatabaseQueryUnitTest.inc
+++ b/WordPress/Tests/DB/DirectDatabaseQueryUnitTest.inc
@@ -333,6 +333,66 @@ function method_names_are_caseinsensitive() {
 	$autoload = $wpdb->Get_Var( $wpdb->Prepare( "SELECT autoload FROM $wpdb->options WHERE option_name = %s", $option_name ) ); // Warning x 2.
 }
 
+/*
+ * Test using custom properties, setting & unsetting (resetting).
+ */
+// phpcs:set WordPress.DB.DirectDatabaseQuery customCacheGetFunctions[] my_cacheget
+// phpcs:set WordPress.DB.DirectDatabaseQuery customCacheSetFunctions[] my_cacheset,my_other_cacheset
+// phpcs:set WordPress.DB.DirectDatabaseQuery customCacheDeleteFunctions[] my_cachedel
+function cache_customA() {
+	global $wpdb;
+	$quux = MY_cacheget( 'quux' );
+	if ( false !== $quux ) {
+		$wpdb->get_results( 'SELECT X FROM Y' ); // Warning direct DB call.
+		my_cacheSet( 'key', 'group' );
+	}
+}
+
+function cache_customB() {
+	global $wpdb;
+	$quux = my_cacheget( 'quux' );
+	if ( false !== $quux ) {
+		$wpdb->get_results( 'SELECT X FROM Y' ); // Warning direct DB call.
+		my_other_CacheSet( 'key', 'group' );
+	}
+}
+
+function cache_customC() {
+	global $wpdb;
+	$wpdb->query( 'SELECT X FROM Y' ); // Warning direct DB call.
+	my_cacheDEL( 'key', 'group' );
+}
+
+// phpcs:set WordPress.DB.DirectDatabaseQuery customCacheSetFunctions[] my_cacheset
+// phpcs:set WordPress.DB.DirectDatabaseQuery customCacheDeleteFunctions[]
+
+function cache_customD() {
+	global $wpdb;
+	$quux = my_cacheget( 'quux' );
+	if ( false !== $quux ) {
+		$wpdb->get_results( 'SELECT X FROM Y' ); // Warning direct DB call.
+		my_cacHeset( 'key', 'group' );
+	}
+}
+
+function cache_customE() {
+	global $wpdb;
+	$quux = my_cacheget( 'quux' );
+	if ( false !== $quux ) {
+		$wpdb->get_results( 'SELECT X FROM Y' ); // Warning x 2.
+		my_other_cacheset( 'key', 'group' );
+	}
+}
+
+function cache_customF() {
+	global $wpdb;
+	$wpdb->query( 'SELECT X FROM Y' ); // Warning x 2.
+	my_cachedel( 'key', 'group' );
+}
+
+// phpcs:set WordPress.DB.DirectDatabaseQuery customCacheGetFunctions[]
+// phpcs:set WordPress.DB.DirectDatabaseQuery customCacheSetFunctions[]
+
 // Live coding/parse error test.
 // This must be the last test in the file.
 $wpdb->get_col( '

--- a/WordPress/Tests/DB/DirectDatabaseQueryUnitTest.php
+++ b/WordPress/Tests/DB/DirectDatabaseQueryUnitTest.php
@@ -91,6 +91,12 @@ final class DirectDatabaseQueryUnitTest extends AbstractSniffUnitTest {
 			300 => 1,
 			306 => 2,
 			333 => 2,
+			346 => 1,
+			355 => 1,
+			362 => 1,
+			373 => 1,
+			382 => 2,
+			389 => 2,
 		);
 	}
 }

--- a/WordPress/Tests/PHP/NoSilencedErrorsUnitTest.inc
+++ b/WordPress/Tests/PHP/NoSilencedErrorsUnitTest.inc
@@ -73,7 +73,7 @@ $files1 = @ & scandir($dir); // Bad.
 /*
  * The custom allowed functions list will be respected even when `usePHPFunctionsList` is set to false.
  */
-// phpcs:set WordPress.PHP.NoSilencedErrors customAllowedFunctionsList[] fgetcsv,hex2bin
+// phpcs:set WordPress.PHP.NoSilencedErrors customAllowedFunctionsList[] fgetCsv,hEx2bin
 while ( ( $csvdata = @fgetcsv( $handle, 2000, $separator ) ) !== false ) {}
 echo @some_userland_function( $param ); // Bad.
 $decoded = @hex2bin( $data );

--- a/WordPress/Tests/Security/EscapeOutputUnitTest.1.inc
+++ b/WordPress/Tests/Security/EscapeOutputUnitTest.1.inc
@@ -655,3 +655,9 @@ echo '<input type="search" value="' . get_search_query( false ) . '">'; // Bad.
 echo '<input type="search" value="' . get_search_query( 0 ) . '">'; // Bad.
 echo '<input type="search" value="' . get_search_query( escape: false ) . '">'; // OK, well not really, typo in param name, but that's not our concern.
 echo '<input type="search" value="' . get_search_query( escaped: false ) . '">'; // Bad.
+
+// phpcs:set WordPress.Security.EscapeOutput customPrintingFunctions[] to_screen,my_print
+to_scReen( $var1, esc_attr( $var2 ) ); // Bad x 1.
+my_prinT( $var1, $var2 ); // Bad x 2.
+
+// phpcs:set WordPress.Security.EscapeOutput customEscapingFunctions[]

--- a/WordPress/Tests/Security/EscapeOutputUnitTest.1.inc
+++ b/WordPress/Tests/Security/EscapeOutputUnitTest.1.inc
@@ -657,7 +657,7 @@ echo '<input type="search" value="' . get_search_query( escape: false ) . '">'; 
 echo '<input type="search" value="' . get_search_query( escaped: false ) . '">'; // Bad.
 
 // phpcs:set WordPress.Security.EscapeOutput customPrintingFunctions[] TO_SCREEN,my_print
-to_scReen( $var1, esc_attr( $var2 ) ); // Bad x 1.
-my_prinT( $var1, $var2 ); // Bad x 2.
+to_screen( $var1, esc_attr( $var2 ) ); // Bad x 1.
+my_print( $var1, $var2 ); // Bad x 2.
 
 // phpcs:set WordPress.Security.EscapeOutput customEscapingFunctions[]

--- a/WordPress/Tests/Security/EscapeOutputUnitTest.1.inc
+++ b/WordPress/Tests/Security/EscapeOutputUnitTest.1.inc
@@ -656,7 +656,7 @@ echo '<input type="search" value="' . get_search_query( 0 ) . '">'; // Bad.
 echo '<input type="search" value="' . get_search_query( escape: false ) . '">'; // OK, well not really, typo in param name, but that's not our concern.
 echo '<input type="search" value="' . get_search_query( escaped: false ) . '">'; // Bad.
 
-// phpcs:set WordPress.Security.EscapeOutput customPrintingFunctions[] to_screen,my_print
+// phpcs:set WordPress.Security.EscapeOutput customPrintingFunctions[] TO_SCREEN,my_print
 to_scReen( $var1, esc_attr( $var2 ) ); // Bad x 1.
 my_prinT( $var1, $var2 ); // Bad x 2.
 

--- a/WordPress/Tests/Security/EscapeOutputUnitTest.php
+++ b/WordPress/Tests/Security/EscapeOutputUnitTest.php
@@ -159,6 +159,8 @@ final class EscapeOutputUnitTest extends AbstractSniffUnitTest {
 					654 => 1,
 					655 => 1,
 					657 => 1,
+					660 => 1,
+					661 => 2,
 				);
 
 			case 'EscapeOutputUnitTest.6.inc':

--- a/WordPress/Tests/Security/NonceVerificationUnitTest.1.inc
+++ b/WordPress/Tests/Security/NonceVerificationUnitTest.1.inc
@@ -489,7 +489,7 @@ enum MyEnum {
 // phpcs:set WordPress.Security.NonceVerification customNonceVerificationFunctions[] MY_nonce_check
 // phpcs:set WordPress.Security.NonceVerification customUnslashingSanitizingFunctions[] do_sometHING
 function foo_6() {
-	my_noncE_cheCk( do_soMeThinG( $_POST['tweet'] ) ); // OK.
+	my_nonce_check( do_something( $_POST['tweet'] ) ); // OK.
 }
 // phpcs:set WordPress.Security.NonceVerification customUnslashingSanitizingFunctions[]
 // phpcs:set WordPress.Security.NonceVerification customNonceVerificationFunctions[]

--- a/WordPress/Tests/Security/NonceVerificationUnitTest.1.inc
+++ b/WordPress/Tests/Security/NonceVerificationUnitTest.1.inc
@@ -486,8 +486,8 @@ enum MyEnum {
 		echo $_POST['foo']; // OK.
 	}
 }
-// phpcs:set WordPress.Security.NonceVerification customNonceVerificationFunctions[] my_nonce_check
-// phpcs:set WordPress.Security.NonceVerification customUnslashingSanitizingFunctions[] do_something
+// phpcs:set WordPress.Security.NonceVerification customNonceVerificationFunctions[] MY_nonce_check
+// phpcs:set WordPress.Security.NonceVerification customUnslashingSanitizingFunctions[] do_sometHING
 function foo_6() {
 	my_noncE_cheCk( do_soMeThinG( $_POST['tweet'] ) ); // OK.
 }

--- a/WordPress/Tests/Security/NonceVerificationUnitTest.1.inc
+++ b/WordPress/Tests/Security/NonceVerificationUnitTest.1.inc
@@ -466,7 +466,7 @@ function function_containing_nested_enum_with_nonce_check() {
 			wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['my_nonce'] ) ), 'the_nonce' );
 		}
 	}
-	
+
 	echo $_POST['foo']; // Bad.
 }
 
@@ -486,3 +486,10 @@ enum MyEnum {
 		echo $_POST['foo']; // OK.
 	}
 }
+// phpcs:set WordPress.Security.NonceVerification customNonceVerificationFunctions[] my_nonce_check
+// phpcs:set WordPress.Security.NonceVerification customUnslashingSanitizingFunctions[] do_something
+function foo_6() {
+	my_noncE_cheCk( do_soMeThinG( $_POST['tweet'] ) ); // OK.
+}
+// phpcs:set WordPress.Security.NonceVerification customUnslashingSanitizingFunctions[]
+// phpcs:set WordPress.Security.NonceVerification customNonceVerificationFunctions[]

--- a/WordPress/Tests/Security/ValidatedSanitizedInputUnitTest.1.inc
+++ b/WordPress/Tests/Security/ValidatedSanitizedInputUnitTest.1.inc
@@ -500,3 +500,32 @@ function test_in_match_condition_is_regarded_as_comparison() {
 		};
 	}
 }
+
+/*
+ * Test using custom properties, setting & unsetting (resetting).
+ */
+function test_this() {
+	if ( ! isset( $_POST['abc_field'] ) ) {
+		return;
+	}
+
+	$abc = sanitize_color( wp_unslash( $_POST['abc_field'] ) ); // Bad x1 - sanitize.
+
+	// phpcs:set WordPress.Security.ValidatedSanitizedInput customSanitizingFunctions[] sanitize_color,sanitize_twitter_handle
+
+	$abc = sanitize_cOlor( wp_unslash( $_POST['abc_field'] ) ); // OK.
+	$abc = sanitize_facebook_ID( wp_unslash( $_POST['abc_field'] ) ); // Bad x1 - sanitize.
+	$abc = sanitize_twitteR_handle( $_POST['abc_field'] ); // Bad x1 - unslash.
+
+	// phpcs:set WordPress.Security.ValidatedSanitizedInput customSanitizingFunctions[] sanitize_color,sanitize_facebook_id
+	// phpcs:set WordPress.Security.ValidatedSanitizedInput customUnslashingSanitizingFunctions[] sanitize_twitter_handle
+
+	$abc = sanitizE_coLor( wp_unslash( $_POST['abc_field'] ) ); // OK.
+	$abc = sanitize_facebook_ID( wp_unslash( $_POST['abc_field'] ) ); // OK.
+	$abc = sanitize_TWITTER_haNdle( $_POST['abc_field'] ); // OK.
+
+	// phpcs:set WordPress.Security.ValidatedSanitizedInput customSanitizingFunctions[]
+	// phpcs:set WordPress.Security.ValidatedSanitizedInput customUnslashingSanitizingFunctions[]
+
+	$abc = sanitize_twitter_handle( $_POST['abc_field'] ); // Bad x2, sanitize + unslash.
+}

--- a/WordPress/Tests/Security/ValidatedSanitizedInputUnitTest.1.inc
+++ b/WordPress/Tests/Security/ValidatedSanitizedInputUnitTest.1.inc
@@ -511,14 +511,14 @@ function test_this() {
 
 	$abc = sanitize_color( wp_unslash( $_POST['abc_field'] ) ); // Bad x1 - sanitize.
 
-	// phpcs:set WordPress.Security.ValidatedSanitizedInput customSanitizingFunctions[] sanitize_color,sanitize_twitter_handle
+	// phpcs:set WordPress.Security.ValidatedSanitizedInput customSanitizingFunctions[] sanitize_color,sanitize_TWITTER_handle
 
 	$abc = sanitize_cOlor( wp_unslash( $_POST['abc_field'] ) ); // OK.
 	$abc = sanitize_facebook_ID( wp_unslash( $_POST['abc_field'] ) ); // Bad x1 - sanitize.
 	$abc = sanitize_twitteR_handle( $_POST['abc_field'] ); // Bad x1 - unslash.
 
-	// phpcs:set WordPress.Security.ValidatedSanitizedInput customSanitizingFunctions[] sanitize_color,sanitize_facebook_id
-	// phpcs:set WordPress.Security.ValidatedSanitizedInput customUnslashingSanitizingFunctions[] sanitize_twitter_handle
+	// phpcs:set WordPress.Security.ValidatedSanitizedInput customSanitizingFunctions[] sanitize_color,sanitize_facebook_ID
+	// phpcs:set WordPress.Security.ValidatedSanitizedInput customUnslashingSanitizingFunctions[] sanITize_twitter_handle
 
 	$abc = sanitizE_coLor( wp_unslash( $_POST['abc_field'] ) ); // OK.
 	$abc = sanitize_facebook_ID( wp_unslash( $_POST['abc_field'] ) ); // OK.

--- a/WordPress/Tests/Security/ValidatedSanitizedInputUnitTest.1.inc
+++ b/WordPress/Tests/Security/ValidatedSanitizedInputUnitTest.1.inc
@@ -513,16 +513,16 @@ function test_this() {
 
 	// phpcs:set WordPress.Security.ValidatedSanitizedInput customSanitizingFunctions[] sanitize_color,sanitize_TWITTER_handle
 
-	$abc = sanitize_cOlor( wp_unslash( $_POST['abc_field'] ) ); // OK.
-	$abc = sanitize_facebook_ID( wp_unslash( $_POST['abc_field'] ) ); // Bad x1 - sanitize.
-	$abc = sanitize_twitteR_handle( $_POST['abc_field'] ); // Bad x1 - unslash.
+	$abc = sanitize_color( wp_unslash( $_POST['abc_field'] ) ); // OK.
+	$abc = sanitize_facebook_id( wp_unslash( $_POST['abc_field'] ) ); // Bad x1 - sanitize.
+	$abc = sanitize_twitter_handle( $_POST['abc_field'] ); // Bad x1 - unslash.
 
 	// phpcs:set WordPress.Security.ValidatedSanitizedInput customSanitizingFunctions[] sanitize_color,sanitize_facebook_ID
 	// phpcs:set WordPress.Security.ValidatedSanitizedInput customUnslashingSanitizingFunctions[] sanITize_twitter_handle
 
-	$abc = sanitizE_coLor( wp_unslash( $_POST['abc_field'] ) ); // OK.
-	$abc = sanitize_facebook_ID( wp_unslash( $_POST['abc_field'] ) ); // OK.
-	$abc = sanitize_TWITTER_haNdle( $_POST['abc_field'] ); // OK.
+	$abc = sanitize_color( wp_unslash( $_POST['abc_field'] ) ); // OK.
+	$abc = sanitize_facebook_id( wp_unslash( $_POST['abc_field'] ) ); // OK.
+	$abc = sanitize_twitter_handle( $_POST['abc_field'] ); // OK.
 
 	// phpcs:set WordPress.Security.ValidatedSanitizedInput customSanitizingFunctions[]
 	// phpcs:set WordPress.Security.ValidatedSanitizedInput customUnslashingSanitizingFunctions[]

--- a/WordPress/Tests/Security/ValidatedSanitizedInputUnitTest.php
+++ b/WordPress/Tests/Security/ValidatedSanitizedInputUnitTest.php
@@ -114,6 +114,10 @@ final class ValidatedSanitizedInputUnitTest extends AbstractSniffUnitTest {
 					497 => 1,
 					498 => 1,
 					499 => 3,
+					512 => 1,
+					517 => 1,
+					518 => 1,
+					530 => 2,
 				);
 
 			case 'ValidatedSanitizedInputUnitTest.2.inc':


### PR DESCRIPTION
This PR will address the issue of handling mixed case function/method/class names when those are passed as custom-allowed properties in certain sniffs.

For instance, if we pass a custom sanitization function as a property `my_custom_sanitization` then it doesn't matter if we are calling `My_custom_Sanitization` or `MY_CUSTOM_SANITIZATION` (or any combination of cases for that matter), PHP is case insensitive in that regard and the same function will be called.

So the sniff shouldn't trigger on those variations (in some cases it will do that, as shown in PR #2370 which holds the fix for the custom escaping functions).

I've added tests to ensure that these changes will be caught.

I'm not 100% sure if I've covered all the cases, so any help in pointing out if I've missed something helps.