### PR TITLE
Add defensive coding in posts per page sniff

### DIFF
--- a/WordPress/Sniffs/WP/PostsPerPageSniff.php
+++ b/WordPress/Sniffs/WP/PostsPerPageSniff.php
@@ -67,6 +67,10 @@ final class PostsPerPageSniff extends AbstractArrayAssignmentRestrictionsSniff {
 	public function callback( $key, $val, $line, $group ) {
 		$stripped_val = TextStrings::stripQuotes( $val );
 
+		if ( '' === $stripped_val ) {
+			return false;
+		}
+
 		if ( $val !== $stripped_val ) {
 			// The value was a text string. For text strings, we only accept purely numeric values.
 			if ( preg_match( '`^[0-9]+$`', $stripped_val ) !== 1 ) {

--- a/WordPress/Tests/DB/SlowDBQueryUnitTest.inc
+++ b/WordPress/Tests/DB/SlowDBQueryUnitTest.inc
@@ -21,3 +21,7 @@ $query = 'foo=bar&meta_key=foo&meta_value=bar';
 if ( ! isset( $widget['params'][0] ) ) {
 	$widget['params'][0] = array();
 }
+
+$query = 'foo=bar&meta_key=&meta_value=bar';
+$query = 'foo=bar&meta_key=foo&meta_value=';
+$query = 'foo=bar&meta_key=&meta_value=';

--- a/WordPress/Tests/DB/SlowDBQueryUnitTest.php
+++ b/WordPress/Tests/DB/SlowDBQueryUnitTest.php
@@ -44,6 +44,9 @@ final class SlowDBQueryUnitTest extends AbstractSniffUnitTest {
 			15 => 1,
 			16 => 1,
 			19 => 2,
+			25 => 2,
+			26 => 2,
+			27 => 2,
 		);
 	}
 }

--- a/WordPress/Tests/WP/PostsPerPageUnitTest.inc
+++ b/WordPress/Tests/WP/PostsPerPageUnitTest.inc
@@ -124,3 +124,17 @@ $args = array(
 	'posts_per_page' => 75.0, // OK (75).
 	'posts_per_page' => 150.000, // Bad (150).
 );
+
+$query = 'posts_per_page=' . (int) $_POST['limit']; // OK.
+
+$args = array(
+	'posts_per_page' => '', // OK.
+);
+
+_query_posts( 'nopaging=true&posts_per_page=' ); // OK.
+
+$query_args['posts_per_page'] = ''; // OK.
+
+$query_args[
+	'posts_per_page'
+] = ''; // OK.


### PR DESCRIPTION
This will prevent the undefined offset internal error.

Closes #2390 