### PR TITLE
Add sanitize_locale_name() to escaping functions and unslashing sanitizing functions

### DIFF
--- a/WordPress/Helpers/EscapingFunctionsTrait.php
+++ b/WordPress/Helpers/EscapingFunctionsTrait.php
@@ -84,6 +84,7 @@ trait EscapingFunctionsTrait {
 		'sanitize_hex_color_no_hash' => true,
 		'sanitize_html_class'        => true,
 		'sanitize_key'               => true,
+		'sanitize_locale_name'       => true,
 		'sanitize_user_field'        => true,
 		'tag_escape'                 => true,
 		'urlencode_deep'             => true,

--- a/WordPress/Helpers/SanitizationHelperTrait.php
+++ b/WordPress/Helpers/SanitizationHelperTrait.php
@@ -137,14 +137,15 @@ trait SanitizationHelperTrait {
 	 * @var array<string, bool>
 	 */
 	private $unslashingSanitizingFunctions = array(
-		'absint'       => true,
-		'boolval'      => true,
-		'count'        => true,
-		'doubleval'    => true,
-		'floatval'     => true,
-		'intval'       => true,
-		'sanitize_key' => true,
-		'sizeof'       => true,
+		'absint'               => true,
+		'boolval'              => true,
+		'count'                => true,
+		'doubleval'            => true,
+		'floatval'             => true,
+		'intval'               => true,
+		'sanitize_key'         => true,
+		'sanitize_locale_name' => true,
+		'sizeof'               => true,
 	);
 
 	/**


### PR DESCRIPTION
WordPress 6.2.1 introduced the function [`sanitize_locale_name()`](https://developer.wordpress.org/reference/functions/sanitize_locale_name/). As it accepts only `[A-Za-z0-9_-]`, I propose to add it to escaping functions and unslashing sanitizing functions.