### PR TITLE
Use two new sniffs from PHPCSExtra 1.2.0

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -41,7 +41,7 @@ When you introduce new `public` sniff properties, or your sniff extends a class 
 * WordPress-Coding-Standards
 * PHP_CodeSniffer 3.7.2 or higher
 * PHPCSUtils 1.0.8 or higher
-* PHPCSExtra 1.1.0 or higher
+* PHPCSExtra 1.2.0 or higher
 * PHPUnit 4.x, 5.x, 6.x or 7.x
 
 The WordPress Coding Standards use the `PHP_CodeSniffer` native unit test framework for unit testing the sniffs.

--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -869,6 +869,9 @@
 	<!-- Important to prevent issues with content being sent before headers. -->
 	<rule ref="Generic.Files.ByteOrderMark"/>
 
+	<!-- Always have a lowertag PHP open tag. -->
+	<rule ref="Universal.PHP.LowercasePHPTag"/>
+
 	<!-- All line endings should be \n. -->
 	<rule ref="Generic.Files.LineEndings">
 		<properties>

--- a/WordPress-Extra/ruleset.xml
+++ b/WordPress-Extra/ruleset.xml
@@ -180,6 +180,9 @@
 	<!-- Detect useless "echo sprintf(...)". -->
 	<rule ref="Universal.CodeAnalysis.NoEchoSprintf"/>
 
+	<!-- Detect use of double negative `!!`. -->
+	<rule ref="Universal.CodeAnalysis.NoDoubleNegative"/>
+
 	<!--
 	#############################################################################
 	Code style sniffs for more recent PHP features and syntaxes.

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
 		"ext-xmlreader": "*",
 		"squizlabs/php_codesniffer": "^3.7.2",
 		"phpcsstandards/phpcsutils": "^1.0.8",
-		"phpcsstandards/phpcsextra": "^1.1.0"
+		"phpcsstandards/phpcsextra": "^1.2.0"
 	},
 	"require-dev": {
 		"phpcompatibility/php-compatibility": "^9.0",


### PR DESCRIPTION
PHPCSExtra 1.2.0 was released yesterday and contains two new sniffs which IMO would be suitable for adding to WordPressCS.

Includes raising the minimum supported PHPCSExtra version. (will conflict with PR #2408 and will need rebase depending on which is merged first)

Ref:
* https://github.com/PHPCSStandards/PHPCSExtra/releases/tag/1.2.0

--

_Note: adding these sniffs means this PR will need to go into a new minor, while #2408 can go into a patch release._