### PR TITLE
Update funding information

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,1 @@
-custom: "https://opencollective.com/thewpcc/contribute/wp-php-63406"
+custom: "https://opencollective.com/php_codesniffer"

--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ See [CONTRIBUTING](.github/CONTRIBUTING.md), including information about [unit t
 
 ## Funding
 
-If you want to sponsor the work on WordPressCS, you can do so by donating to the [WP PHP Open Collective](https://opencollective.com//thewpcc/contribute/wp-php-63406).
+If you want to sponsor the work on WordPressCS, you can do so by donating to the [PHP_CodeSniffer Open Collective](https://opencollective.com/php_codesniffer).
 
 ## License
 


### PR DESCRIPTION
The WP PHP Open Collective, aside from the name conveying the completely wrong message, has so far not been in touch with us about how funds can be released or anything else.

This seems like a dead-end.

Switching to the PHP_CodeSniffer Open Collective makes more sense (to me). Happy to have a discussion about this.