### PR TITLE
GH Actions/fixer conflict check: remove temporary exclusion

### DIFF
--- a/.github/workflows/basic-qa.yml
+++ b/.github/workflows/basic-qa.yml
@@ -151,15 +151,13 @@ jobs:
       # Test for fixer conflicts by running the auto-fixers of the complete WPCS over the test case files.
       # This is not an exhaustive test, but should give an early indication for typical fixer conflicts.
       # If only fixable errors are found, the exit code will be 1, which can be interpreted as success.
-      #
-      # Note: the ValidVariableNameUnitTest.inc file is temporarily ignored until upstream PHPCS PR 3833 has been merged.
       - name: Test for fixer conflicts (fixes expected)
         if: ${{ matrix.phpcs_version == 'dev-master' }}
         id: phpcbf
         continue-on-error: true
         run: |
           set +e
-          $(pwd)/vendor/bin/phpcbf -pq ./WordPress/Tests/ --standard=WordPress --extensions=inc --exclude=Generic.PHP.Syntax --report=summary --ignore=/WordPress/Tests/NamingConventions/ValidVariableNameUnitTest.inc,/WordPress/Tests/WP/GlobalVariablesOverrideUnitTest.7.inc
+          $(pwd)/vendor/bin/phpcbf -pq ./WordPress/Tests/ --standard=WordPress --extensions=inc --exclude=Generic.PHP.Syntax --report=summary --ignore=/WordPress/Tests/WP/GlobalVariablesOverrideUnitTest.7.inc
           exitcode="$?"
           echo "EXITCODE=$exitcode" >> $GITHUB_OUTPUT
           exit "$exitcode"


### PR DESCRIPTION
Upstream PR squizlabs/PHP_CodeSniffer#3833 / PHPCSStandards/PHP_CodeSniffer#62 has now been merged, so the exclusion introduced in #2243 can be removed and the fixer conflict check passes again without issues.

Fixes #2274