### PR TITLE
Tests: allow for PHPUnit 8/9

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -42,7 +42,7 @@ When you introduce new `public` sniff properties, or your sniff extends a class 
 * PHP_CodeSniffer 3.8.0 or higher
 * PHPCSUtils 1.0.9 or higher
 * PHPCSExtra 1.2.1 or higher
-* PHPUnit 4.x, 5.x, 6.x or 7.x
+* PHPUnit 4.x - 9.x
 
 The WordPress Coding Standards use the `PHP_CodeSniffer` native unit test framework for unit testing the sniffs.
 
@@ -85,9 +85,9 @@ phpunit --filter WordPress /path/to/PHP_CodeSniffer/tests/AllTests.php
 
 Expected output:
 ```
-PHPUnit 7.5.20 by Sebastian Bergmann and contributors.
+PHPUnit 9.6.15 by Sebastian Bergmann and contributors.
 
-Runtime:       PHP 7.4.33
+Runtime:       PHP 8.3.0
 Configuration: /WordPressCS/phpunit.xml.dist
 
 .........................................................         57 / 57 (100%)

--- a/.github/workflows/basic-qa.yml
+++ b/.github/workflows/basic-qa.yml
@@ -127,8 +127,7 @@ jobs:
           custom-cache-suffix: $(date -u "+%Y-%m")
 
       - name: "Set PHPCS version (lowest)"
-        if: ${{ matrix.phpcs_version == 'lowest' }}
-        run: composer update squizlabs/php_codesniffer --prefer-lowest --ignore-platform-req=php+ --no-scripts --no-interaction
+        run: composer update squizlabs/php_codesniffer --prefer-lowest --no-scripts --no-interaction
 
       - name: Test the WordPress-Core ruleset
         run: $(pwd)/vendor/bin/phpcs -ps ./Tests/RulesetCheck/class-ruleset-test.inc --standard=WordPress-Core
@@ -178,7 +177,7 @@ jobs:
       - name: Install PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.4'
+          php-version: 'latest'
           coverage: none
           tools: phpstan
 

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [ '5.4', '7.4', 'latest' ]
+        php: [ '5.4', 'latest' ]
         phpcs_version: [ 'lowest', 'dev-master' ]
 
     name: QTest - PHP ${{ matrix.php }} on PHPCS ${{ matrix.phpcs_version }}
@@ -54,18 +54,10 @@ jobs:
         if: ${{ matrix.phpcs_version != 'lowest' }}
         run: composer require squizlabs/php_codesniffer:"${{ matrix.phpcs_version }}" --no-update --no-scripts --no-interaction
 
-      - name: Install Composer dependencies (PHP < 8.0 )
-        if: ${{ matrix.php < 8.0 && matrix.php != 'latest' }}
+      - name: Install Composer dependencies
         uses: ramsey/composer-install@v2
         with:
           # Bust the cache at least once a month - output format: YYYY-MM.
-          custom-cache-suffix: $(date -u "+%Y-%m")
-
-      - name: Install Composer dependencies (PHP >= 8.0)
-        if: ${{ matrix.php >= 8.0 || matrix.php == 'latest' }}
-        uses: ramsey/composer-install@v2
-        with:
-          composer-options: --ignore-platform-req=php+
           custom-cache-suffix: $(date -u "+%Y-%m")
 
       - name: "Set PHPCS version (lowest)"
@@ -76,21 +68,16 @@ jobs:
         if: ${{ matrix.phpcs_version == 'dev-master' }}
         run: composer lint -- --checkstyle
 
-      - name: Run the unit tests without code coverage - PHP 5.4 - 8.0
-        if: ${{ matrix.php == '5.4' && github.ref_name != 'develop' }}
+      - name: Run the unit tests without code coverage
+        if: ${{ github.ref_name != 'develop' }}
         run: composer run-tests
 
-      # Until PHPCS supports PHPUnit 9, we cannot run code coverage on PHP 8.0+, so run it on PHP 5.4 and 7.4.
-      - name: Run the unit tests with code coverage - PHP 5.4 - 8.0
-        if: ${{ matrix.php != 'latest' && github.ref_name == 'develop' }}
+      - name: Run the unit tests with code coverage
+        if: ${{ github.ref_name == 'develop' }}
         run: composer coverage
 
-      - name: Run the unit tests without code coverage - PHP >= 8.1
-        if: ${{ matrix.php == 'latest' }}
-        run: composer run-tests -- --no-configuration --bootstrap=./Tests/bootstrap.php --dont-report-useless-tests
-
       - name: Send coverage report to Codecov
-        if: ${{ success() && github.ref_name == 'develop' && matrix.php != 'latest' }}
+        if: ${{ success() && github.ref_name == 'develop' }}
         uses: codecov/codecov-action@v3
         with:
           files: ./build/logs/clover.xml

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [ '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '8.0', '8.1', '8.2', '8.3', '8.4' ]
+        php: [ '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.4' ]
         phpcs_version: [ 'lowest', 'dev-master' ]
         extensions: [ '' ]
         coverage: [false]
@@ -33,7 +33,6 @@ jobs:
             coverage: true # Make sure coverage is recorded for this too.
 
           # Run code coverage builds against high/low PHP and high/low PHPCS.
-          # Note: Until PHPCS supports PHPUnit 9, we cannot run code coverage on PHP 8.0+.
           - php: '5.4'
             phpcs_version: 'dev-master'
             extensions: ''
@@ -42,11 +41,11 @@ jobs:
             phpcs_version: 'lowest'
             extensions: ''
             coverage: true
-          - php: '7.4'
+          - php: '8.3'
             phpcs_version: 'dev-master'
             extensions: ''
             coverage: true
-          - php: '7.4'
+          - php: '8.3'
             phpcs_version: 'lowest'
             extensions: ''
             coverage: true
@@ -86,18 +85,10 @@ jobs:
         if: ${{ matrix.phpcs_version != 'lowest' }}
         run: composer require squizlabs/php_codesniffer:"${{ matrix.phpcs_version }}" --no-update --no-scripts --no-interaction
 
-      - name: Install Composer dependencies (PHP < 8.0 )
-        if: ${{ matrix.php < 8.0 }}
+      - name: Install Composer dependencies
         uses: ramsey/composer-install@v2
         with:
           # Bust the cache at least once a month - output format: YYYY-MM.
-          custom-cache-suffix: $(date -u "+%Y-%m")
-
-      - name: Install Composer dependencies (PHP >= 8.0)
-        if: ${{ matrix.php >= 8.0 }}
-        uses: ramsey/composer-install@v2
-        with:
-          composer-options: --ignore-platform-req=php+
           custom-cache-suffix: $(date -u "+%Y-%m")
 
       - name: "Set PHPCS version (lowest)"
@@ -108,18 +99,13 @@ jobs:
         if: ${{ matrix.phpcs_version == 'dev-master' }}
         run: composer lint -- --checkstyle | cs2pr
 
-      - name: Run the unit tests without code coverage - PHP 5.4 - 8.0
-        if: ${{ matrix.php < '8.1' && matrix.coverage == false }}
+      - name: Run the unit tests without code coverage
+        if: ${{ matrix.coverage == false }}
         run: composer run-tests
 
-      - name: Run the unit tests with code coverage - PHP 5.4 - 8.0
-        if: ${{ matrix.php < '8.1' && matrix.coverage == true  }}
+      - name: Run the unit tests with code coverage
+        if: ${{ matrix.coverage == true  }}
         run: composer coverage
-
-      # Until PHPCS supports PHPUnit 9, we cannot run code coverage on PHP 8.0+.
-      - name: Run the unit tests without code coverage - PHP >= 8.1
-        if: ${{ matrix.php >= '8.1' && matrix.coverage == false  }}
-        run: composer run-tests -- --no-configuration --bootstrap=./Tests/bootstrap.php --dont-report-useless-tests
 
       - name: Send coverage report to Codecov
         if: ${{ success() && matrix.coverage == true }}

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ phpunit.xml
 phpcs.xml
 .phpcs.xml
 phpstan.neon
+.phpunit.result.cache

--- a/WordPress/Tests/DB/RestrictedClassesUnitTest.php
+++ b/WordPress/Tests/DB/RestrictedClassesUnitTest.php
@@ -37,7 +37,7 @@ final class RestrictedClassesUnitTest extends AbstractSniffUnitTest {
 	 * @return void
 	 */
 	protected function enhanceGroups() {
-		parent::setUp();
+		parent::setUpPrerequisites();
 
 		AbstractFunctionRestrictionsSniff::$unittest_groups = array(
 			'test' => array(

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
 	},
 	"require-dev": {
 		"phpcompatibility/php-compatibility": "^9.0",
-		"phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0",
+		"phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0",
 		"phpcsstandards/phpcsdevtools": "^1.2.0",
 		"php-parallel-lint/php-parallel-lint": "^1.3.2",
 		"php-parallel-lint/php-console-highlighter": "^1.0.0"

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,5 @@
 parameters:
-    #phpVersion: 50400 # Needs to be 70100 or higher... sigh...
+    phpVersion: 70100 # Needs to be 70100 or higher... sigh...
     level: 5
     paths:
         - WordPress

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -4,6 +4,10 @@
 	xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/6.3/phpunit.xsd"
 	backupGlobals="true"
 	bootstrap="./Tests/bootstrap.php"
+	convertErrorsToExceptions="true"
+	convertWarningsToExceptions="true"
+	convertNoticesToExceptions="true"
+	convertDeprecationsToExceptions="true"
 	beStrictAboutTestsThatDoNotTestAnything="false"
 	colors="true"
 	forceCoversAnnotation="true">


### PR DESCRIPTION
PHP_CodeSniffer 3.8.0 now allows for running the tests, which are based on the PHPCS native test suite, with PHPUnit 8 and 9.

This commit updates the package to take advantage of that.

Includes:
* Widening the PHPUnit version requirements.
* Adding the PHPUnit 8+ cache file to `.gitignore`.
* Updating the PHPUnit configuration to make sure that deprecations will always show, even when on a high PHPUnit 9.6 version.
* Updating the info in `CONTRIBUTING`.
* Simplifications to the `quicktest` and `test` workflows. Also, the code coverage "high" run can now be run against PHP 8.3.
* Running PHPStan against PHP `latest` (couldn't previously be done due to the old PHPUnit version).
* Minor tweak to the PHPStan config to make sure PHP 8.x specific issues don't get flagged for this codebase.
* Removing a no longer needed `--ignore-platform*` argument.
* Updating the "setUp" method in one test to call the parent "setUp" method via the new method name.

Ref:
* PHPCSStandards/PHP_CodeSniffer#59