### PR TITLE
Core: remove an exclusion

### DIFF
--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -218,10 +218,6 @@
 	<rule ref="Squiz.Functions.MultiLineFunctionDeclaration.BraceIndent">
 		<severity>0</severity>
 	</rule>
-	<!-- Prevent duplicate message. This is already checked by the Generic.WhiteSpace.LanguageConstructSpacing sniff. -->
-	<rule ref="Squiz.Functions.MultiLineFunctionDeclaration.SpaceAfterUse">
-		<severity>0</severity>
-	</rule>
 
 	<rule ref="Squiz.Functions.FunctionDeclarationArgumentSpacing">
 		<properties>


### PR DESCRIPTION
Turns out the exclusion is a little too aggresive. The `Generic.WhiteSpace.LanguageConstructSpacing` _will_ throw an error when there is too much whitespace, but not when there is no whitespace and the next thing is an open parenthesis.

By removing the exclusion, an error will now (correctly) be thrown when there is no whitespace between a closure `use` keyword and the open parenthesis.

It also means that where there is _too much_ whitespace between the keyword and the open parenthesis, two errors will be thrown, one from the `Generic.WhiteSpace.LanguageConstructSpacing` sniff and one from the `Squiz.Functions.MultiLineFunctionDeclaration` sniff.

Well, so be it. As both sniffs expect the same thing, this shouldn't lead to fixer conflicts anyhow.

See https://github.com/WordPress/WordPress-Coding-Standards/issues/764#issuecomment-1851046232