### PR TITLE
Fix PHPStan (again)

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -17,6 +17,16 @@ parameters:
             message: "#^Cannot unset offset 'query' on non-empty-array<int, array<string, int\\|string>>.$#"
             path: WordPress/Sniffs/DB/PreparedSQLPlaceholdersSniff.php
 
+        # Level 3
+        # Consistency preferred - these are methods which return whatever a parent/child method returns.
+        # They shouldn't need to keep track of whether the child method returns int or void.
+        - '#^Method [^ ]+Sniff::process_token\(\) should return int\|void but returns null\.$#'
+        -
+            # False positive. Will be fixed via next version of PHPCSUtils.
+            count: 1
+            message: '#^Method [^ ]+Sniff::process\(\) should return int\|void but returns null\.$#'
+            path: WordPress/Sniffs/WhiteSpace/ObjectOperatorSpacingSniff.php
+
         # Level 4
         - '#^Property \S+::\$\S+ \([^)]+\) in isset\(\) is not nullable\.$#'
         -


### PR DESCRIPTION
PHPStan released version 1.10.49 today and managed to break things again... maybe someone should explain semver to them....

Either way, this fixes it.

I've favoured ignoring these issues instead of "fixing" them as we were already ignoring a "Result of method * (void) is used" for level 0, which is about the same thing.

These methods all `return` the return value of a parent/child method, which can either be `int` or `void`. For code consistency and stability, it is a lot clearer to have these `return` statements in place and it will prevent potential future breakage if the parent/child would start returning a stack pointer.

Ref: https://github.com/phpstan/phpstan/releases/tag/1.10.49