### PR TITLE
Fix the test case file path used in a CONTRIBUTING.md example

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -138,7 +138,7 @@ Also note the class name convention. The method `getErrorList()` MUST return an 
 If you run the following from the root directory of your WordPressCS clone:
 
 ```sh
-$ "vendor/bin/phpcs" --standard=Wordpress -s ./Tests/PHP/POSIXFunctionsUnitTest.inc --sniffs=WordPress.PHP.POSIXFunctions
+$ "vendor/bin/phpcs" --standard=Wordpress -s ./WordPress/Tests/PHP/POSIXFunctionsUnitTest.inc --sniffs=WordPress.PHP.POSIXFunctions
 ...
 --------------------------------------------------------------------------------
 FOUND 7 ERRORS AFFECTING 7 LINES


### PR DESCRIPTION
I believe the path of the test case file used in the example of how to generate the list of expected lines with errors is wrong. This PR fixes it.

Here is the commit that introduced the current version of the line that is changed in this PR: https://github.com/WordPress/WordPress-Coding-Standards/pull/2367/commits/4a33d468821f805a1cd222990c46ad9d632b0bd7#diff-98e64bc1cd2db9333c6effe87bbe0d6dfe8714aba4c6bde45aa037fe0796e44cR141.

If we want to keep the current path for some reason, we might want to change the part that says "from the root directory of your WordPressCS clone".