### PR TITLE
GH Actions: minor tweaks

### DIFF
--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Lint PHP files against parse errors
         if: ${{ matrix.dependencies == 'stable' }}
-        run: composer lint -- --checkstyle
+        run: composer lint
 
       - name: Run the unit tests without code coverage
         if: ${{ github.ref_name != 'develop' }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -119,7 +119,7 @@ jobs:
           custom-cache-suffix: $(date -u "+%Y-%m")
 
       - name: "Composer: downgrade PHPCS dependencies for tests (lowest)"
-        if: ${{ ! startsWith( matrix.php, '8' ) && matrix.dependencies == 'lowest' }}
+        if: ${{ matrix.dependencies == 'lowest' }}
         run: >
           composer update --prefer-lowest --no-scripts --no-interaction
           squizlabs/php_codesniffer

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -32,7 +32,7 @@ jobs:
         coverage: [false]
 
         include:
-          - php: '7.4'
+          - php: '7.2'
             dependencies: 'stable'
             extensions: ':mbstring' # = Disable Mbstring.
             coverage: true # Make sure coverage is recorded for this too.


### PR DESCRIPTION
### GH Actions: minor tweaks

* Remove `--checkstyle` for a lint job which doesn't display with `cs2pr`.
* Remove a stray condition.

### GH Actions: move code coverage build without MbString to PHP 7.2

PHP 7.2 should be using PHPUnit 8, which doesn't use PHP Parser, so _fingers crossed_, this should solve the build failure.