### PR TITLE
Extra: do not allow ambiguous conditions (needs PHPCS 3.9.0)

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -39,7 +39,7 @@ When you introduce new `public` sniff properties, or your sniff extends a class 
 
 ## Pre-requisites
 * WordPress-Coding-Standards
-* PHP_CodeSniffer 3.8.0 or higher
+* PHP_CodeSniffer 3.9.0 or higher
 * PHPCSUtils 1.0.9 or higher
 * PHPCSExtra 1.2.1 or higher
 * PHPUnit 4.x - 9.x

--- a/Tests/RulesetCheck/class-ruleset-test.inc
+++ b/Tests/RulesetCheck/class-ruleset-test.inc
@@ -64,7 +64,7 @@ class Ruleset_Test {
 			if ( preg_match( '`' . preg_quote( $param_a, '`' ) . '`i', $param_b ) === 1 ) {
 				echo esc_html( "doublequoted $string" );
 			} elseif ( $this->a ) {
-				$ab = $a % $b + $c / $d && $param_a || $param_b >> $bitshift;
+				$ab = $a % $b + $c / $d && ( $param_a || $param_b >> $bitshift );
 			}
 		};
 

--- a/WordPress-Extra/ruleset.xml
+++ b/WordPress-Extra/ruleset.xml
@@ -41,6 +41,10 @@
 		 https://github.com/WordPress/WordPress-Coding-Standards/pull/809 -->
 	<rule ref="Squiz.PHP.DisallowSizeFunctionsInLoops"/>
 
+	<!-- Do not allow ambiguous conditions.
+		 https://github.com/WordPress/WordPress-Coding-Standards/issues/2429 -->
+	<rule ref="Generic.CodeAnalysis.RequireExplicitBooleanOperatorPrecedence"/>
+
 	<!-- Check that functions use all parameters passed.
 		 https://github.com/WordPress/WordPress-Coding-Standards/issues/1510 -->
 	<rule ref="Generic.CodeAnalysis.UnusedFunctionParameter">

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
 		"ext-libxml": "*",
 		"ext-tokenizer": "*",
 		"ext-xmlreader": "*",
-		"squizlabs/php_codesniffer": "^3.8.0",
+		"squizlabs/php_codesniffer": "^3.9.0",
 		"phpcsstandards/phpcsutils": "^1.0.9",
 		"phpcsstandards/phpcsextra": "^1.2.1"
 	},


### PR DESCRIPTION
### Composer: raise the minimum supported PHPCS version to 3.9.0

### Extra: do not allow ambiguous conditions

This new PHPCS 3.9.0 sniff will flag code which contains a `||` and a `&&` operator in the same condition and their precedence is not clarified via parenthesis.

This should allow for users of WPCS to find/prevent some bugs in code.

I'd personally would **_highly_** recommend for WP Core to also use this sniff, but I suspect that will need due discussion/Make post/handbook change.

Note: running this sniff on WP Core as-is, would (to my surprise) not actually trigger any new errors.

Includes updating a code snippet in the Ruleset test to comply.