### PR TITLE
WhiteSpace/OperatorSpacing: add extra test

### DIFF
--- a/WordPress/Tests/WhiteSpace/OperatorSpacingUnitTest.inc
+++ b/WordPress/Tests/WhiteSpace/OperatorSpacingUnitTest.inc
@@ -75,3 +75,7 @@ function fooBar( TypeA&namespace\TypeB $param ) : \TypeC&Partially\Qualified {}
 class Foo {
 	public readonly int|string $prop;
 }
+
+// Safeguard that declare statements are ignored.
+// Ref: https://github.com/PHPCSStandards/PHP_CodeSniffer/pull/289
+declare(ticks=1);

--- a/WordPress/Tests/WhiteSpace/OperatorSpacingUnitTest.inc.fixed
+++ b/WordPress/Tests/WhiteSpace/OperatorSpacingUnitTest.inc.fixed
@@ -75,3 +75,7 @@ function fooBar( TypeA&namespace\TypeB $param ) : \TypeC&Partially\Qualified {}
 class Foo {
 	public readonly int|string $prop;
 }
+
+// Safeguard that declare statements are ignored.
+// Ref: https://github.com/PHPCSStandards/PHP_CodeSniffer/pull/289
+declare(ticks=1);


### PR DESCRIPTION
Upstream a PR is open - and will be merged soon - to change the protection against the `Squiz` sniff, which this sniff extends, handling operators found in `declare()` statements. In particular, the PR is about how the sniff handles parse errors/live coding for declare statements.

As the WPCS sniff calls the parent `register()` method and falls through to the parent `process()` method, the WPCS sniff should automatically get that extra protection too.

This commit just adds an extra test to the `WordPress.WhiteSpace.OperatorSpacing` to safeguard things.