### PR TITLE
Update list based sniffs for WP 6.5

### DIFF
--- a/WordPress/Helpers/MinimumWPVersionTrait.php
+++ b/WordPress/Helpers/MinimumWPVersionTrait.php
@@ -79,7 +79,7 @@ trait MinimumWPVersionTrait {
 	 *
 	 * @var string WordPress version.
 	 */
-	private $default_minimum_wp_version = '6.0';
+	private $default_minimum_wp_version = '6.2';
 
 	/**
 	 * Overrule the minimum supported WordPress version with a command-line/config value.

--- a/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
+++ b/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
@@ -147,7 +147,7 @@ final class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 	 * Only overrulable constants are listed, i.e. those defined within core within
 	 * a `if ( ! defined() ) {}` wrapper.
 	 *
-	 * Last update: July 2023 for WP 6.3 at https://github.com/WordPress/wordpress-develop/commit/6281ce432c50345a57768bf53854d9b65b6cdd52
+	 * {@internal To be updated after every major release. Last updated for WordPress 6.5-RC3.}
 	 *
 	 * @since 1.0.0
 	 * @since 3.0.0 Renamed from `$whitelisted_core_constants` to `$allowed_core_constants`.
@@ -201,6 +201,8 @@ final class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 	 *
 	 * Note: deprecated functions should still be included in this list as plugins may support older WP versions.
 	 *
+	 * {@internal To be updated after every major release. Last updated for WordPress 6.5-RC3.}
+	 *
 	 * @since 3.0.0.
 	 *
 	 * @var array<string, true> Key is function name, value irrelevant.
@@ -236,6 +238,7 @@ final class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 		'twentyeleven_comment'                           => true,
 		'twentyeleven_content_nav'                       => true,
 		'twentyeleven_continue_reading_link'             => true,
+		'twentyeleven_header_image'                      => true,
 		'twentyeleven_header_style'                      => true,
 		'twentyeleven_posted_on'                         => true,
 		'twentyeleven_setup'                             => true,
@@ -255,6 +258,7 @@ final class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 		'twentyfourteen_admin_header_style'              => true,
 		'twentyfourteen_excerpt_more'                    => true,
 		'twentyfourteen_font_url'                        => true,
+		'twentyfourteen_header_image'                    => true,
 		'twentyfourteen_header_style'                    => true,
 		'twentyfourteen_list_authors'                    => true,
 		'twentyfourteen_paging_nav'                      => true,
@@ -296,6 +300,7 @@ final class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 		'twentyten_admin_header_style'                   => true,
 		'twentyten_comment'                              => true,
 		'twentyten_continue_reading_link'                => true,
+		'twentyten_header_image'                         => true,
 		'twentyten_posted_in'                            => true,
 		'twentyten_posted_on'                            => true,
 		'twentyten_setup'                                => true,
@@ -317,6 +322,9 @@ final class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 		'twentytwenty_get_customizer_css'                => true,
 		'twentytwenty_get_theme_svg'                     => true,
 		'twentytwenty_the_theme_svg'                     => true,
+		'twentytwentyfour_block_styles'                  => true,
+		'twentytwentyfour_block_stylesheets'             => true,
+		'twentytwentyfour_pattern_categories'            => true,
 		'twentytwentytwo_styles'                         => true,
 		'twentytwentytwo_support'                        => true,
 		'wp_authenticate'                                => true,
@@ -373,6 +381,8 @@ final class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 	 * and {@link https://core.trac.wordpress.org/browser/trunk/src/wp-includes/pluggable-deprecated.php}
 	 *
 	 * Note: deprecated classes should still be included in this list as plugins may support older WP versions.
+	 *
+	 * {@internal To be updated after every major release. Last updated for WordPress 6.5-RC3.}
 	 *
 	 * @since 3.0.0.
 	 *

--- a/WordPress/Sniffs/NamingConventions/ValidPostTypeSlugSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidPostTypeSlugSniff.php
@@ -63,7 +63,7 @@ final class ValidPostTypeSlugSniff extends AbstractFunctionParameterSniff {
 	 *
 	 * Source: {@link https://developer.wordpress.org/reference/functions/register_post_type/#reserved-post-types}
 	 *
-	 * Last update: July 2023 for WP 6.3 at https://github.com/WordPress/wordpress-develop/commit/6281ce432c50345a57768bf53854d9b65b6cdd52
+	 * {@internal To be updated after every major release. Last updated for WordPress 6.5-RC3.}
 	 *
 	 * @since 2.2.0
 	 *
@@ -84,6 +84,8 @@ final class ValidPostTypeSlugSniff extends AbstractFunctionParameterSniff {
 		'theme'               => true, // Not a WP post type, but prevents other problems.
 		'user_request'        => true,
 		'wp_block'            => true,
+		'wp_font_face'        => true,
+		'wp_font_family'      => true,
 		'wp_global_styles'    => true,
 		'wp_navigation'       => true,
 		'wp_template'         => true,

--- a/WordPress/Sniffs/WP/ClassNameCaseSniff.php
+++ b/WordPress/Sniffs/WP/ClassNameCaseSniff.php
@@ -25,7 +25,7 @@ final class ClassNameCaseSniff extends AbstractClassRestrictionsSniff {
 	 *
 	 * Note: this list will be enhanced in the class constructor.
 	 *
-	 * {@internal To be updated after every major release. Last updated for WordPress 6.3-RC1.}
+	 * {@internal To be updated after every major release. Last updated for WordPress 6.5-RC3.}
 	 *
 	 * @since 3.0.0
 	 *
@@ -121,6 +121,8 @@ final class ClassNameCaseSniff extends AbstractClassRestrictionsSniff {
 		'WP_Application_Passwords_List_Table',
 		'WP_Automatic_Updater',
 		'WP_Block',
+		'WP_Block_Bindings_Registry',
+		'WP_Block_Bindings_Source',
 		'WP_Block_Editor_Context',
 		'WP_Block_List',
 		'WP_Block_Parser',
@@ -192,10 +194,21 @@ final class ClassNameCaseSniff extends AbstractClassRestrictionsSniff {
 		'WP_Filesystem_FTPext',
 		'WP_Filesystem_SSH2',
 		'WP_Filesystem_ftpsockets',
+		'WP_Font_Collection',
+		'WP_Font_Face',
+		'WP_Font_Face_Resolver',
+		'WP_Font_Library',
+		'WP_Font_Utils',
+		'WP_HTML_Active_Formatting_Elements',
 		'WP_HTML_Attribute_Token',
+		'WP_HTML_Open_Elements',
+		'WP_HTML_Processor',
+		'WP_HTML_Processor_State',
 		'WP_HTML_Span',
 		'WP_HTML_Tag_Processor',
 		'WP_HTML_Text_Replacement',
+		'WP_HTML_Token',
+		'WP_HTML_Unsupported_Exception',
 		'WP_HTTP_Fsockopen',
 		'WP_HTTP_IXR_Client',
 		'WP_HTTP_Proxy',
@@ -212,6 +225,8 @@ final class ClassNameCaseSniff extends AbstractClassRestrictionsSniff {
 		'WP_Image_Editor_GD',
 		'WP_Image_Editor_Imagick',
 		'WP_Importer',
+		'WP_Interactivity_API',
+		'WP_Interactivity_API_Directives_Processor',
 		'WP_Internal_Pointers',
 		'WP_Links_List_Table',
 		'WP_List_Table',
@@ -226,11 +241,13 @@ final class ClassNameCaseSniff extends AbstractClassRestrictionsSniff {
 		'WP_Meta_Query',
 		'WP_Metadata_Lazyloader',
 		'WP_Nav_Menu_Widget',
+		'WP_Navigation_Block_Renderer',
 		'WP_Navigation_Fallback',
 		'WP_Network',
 		'WP_Network_Query',
 		'WP_Object_Cache',
 		'WP_Paused_Extensions_Storage',
+		'WP_Plugin_Dependencies',
 		'WP_Plugin_Install_List_Table',
 		'WP_Plugins_List_Table',
 		'WP_Post',
@@ -257,6 +274,9 @@ final class ClassNameCaseSniff extends AbstractClassRestrictionsSniff {
 		'WP_REST_Comments_Controller',
 		'WP_REST_Controller',
 		'WP_REST_Edit_Site_Export_Controller',
+		'WP_REST_Font_Collections_Controller',
+		'WP_REST_Font_Faces_Controller',
+		'WP_REST_Font_Families_Controller',
 		'WP_REST_Global_Styles_Controller',
 		'WP_REST_Global_Styles_Revisions_Controller',
 		'WP_REST_Menu_Items_Controller',
@@ -282,6 +302,8 @@ final class ClassNameCaseSniff extends AbstractClassRestrictionsSniff {
 		'WP_REST_Sidebars_Controller',
 		'WP_REST_Site_Health_Controller',
 		'WP_REST_Taxonomies_Controller',
+		'WP_REST_Template_Autosaves_Controller',
+		'WP_REST_Template_Revisions_Controller',
 		'WP_REST_Templates_Controller',
 		'WP_REST_Term_Meta_Fields',
 		'WP_REST_Term_Search_Handler',
@@ -301,6 +323,7 @@ final class ClassNameCaseSniff extends AbstractClassRestrictionsSniff {
 		'WP_Role',
 		'WP_Roles',
 		'WP_Screen',
+		'WP_Script_Modules',
 		'WP_Scripts',
 		'WP_Session_Tokens',
 		'WP_Sidebar_Block_Editor_Control',
@@ -341,6 +364,11 @@ final class ClassNameCaseSniff extends AbstractClassRestrictionsSniff {
 		'WP_Theme_JSON_Resolver',
 		'WP_Theme_JSON_Schema',
 		'WP_Themes_List_Table',
+		'WP_Translation_Controller',
+		'WP_Translation_File',
+		'WP_Translation_File_MO',
+		'WP_Translation_File_PHP',
+		'WP_Translations',
 		'WP_Upgrader',
 		'WP_Upgrader_Skin',
 		'WP_User',
@@ -384,7 +412,7 @@ final class ClassNameCaseSniff extends AbstractClassRestrictionsSniff {
 	 *
 	 * Note: this list will be enhanced in the class constructor.
 	 *
-	 * {@internal To be updated after every major release. Last updated for WordPress 6.3-RC1.}
+	 * {@internal To be updated after every major release. Last updated for WordPress 6.5-RC3.}
 	 *
 	 * @since 3.0.0
 	 *
@@ -412,11 +440,33 @@ final class ClassNameCaseSniff extends AbstractClassRestrictionsSniff {
 	);
 
 	/**
-	 * List of all GetID3 classes include in WP Core.
+	 * List of all AVIF classes included in WP Core.
 	 *
 	 * Note: this list will be enhanced in the class constructor.
 	 *
-	 * {@internal To be updated after every major release. Last updated for WordPress 6.3-RC1.}
+	 * {@internal To be updated after every major release. Last updated for WordPress 6.5-RC3.}
+	 *
+	 * @since 3.1.0
+	 *
+	 * @var string[] The class names in their "proper" case.
+	 *               The constructor will add the lowercased class name as a key to each entry.
+	 */
+	private $avif_classes = array(
+		'Avifinfo\\Box',
+		'Avifinfo\\Chan_Prop',
+		'Avifinfo\\Dim_Prop',
+		'Avifinfo\\Features',
+		'Avifinfo\\Parser',
+		'Avifinfo\\Prop',
+		'Avifinfo\\Tile',
+	);
+
+	/**
+	 * List of all GetID3 classes included in WP Core.
+	 *
+	 * Note: this list will be enhanced in the class constructor.
+	 *
+	 * {@internal To be updated after every major release. Last updated for WordPress 6.5-RC3.}
 	 *
 	 * @since 3.0.0
 	 *
@@ -452,7 +502,7 @@ final class ClassNameCaseSniff extends AbstractClassRestrictionsSniff {
 	 *
 	 * Note: this list will be enhanced in the class constructor.
 	 *
-	 * {@internal To be updated after every major release. Last updated for WordPress 6.3-RC1.}
+	 * {@internal To be updated after every major release. Last updated for WordPress 6.5-RC3.}
 	 *
 	 * @since 3.0.0
 	 *
@@ -470,7 +520,7 @@ final class ClassNameCaseSniff extends AbstractClassRestrictionsSniff {
 	 *
 	 * Note: this list will be enhanced in the class constructor.
 	 *
-	 * {@internal To be updated after every major release. Last updated for WordPress 6.3-RC1.}
+	 * {@internal To be updated after every major release. Last updated for WordPress 6.5-RC3.}
 	 *
 	 * @since 3.0.0
 	 *
@@ -614,7 +664,7 @@ final class ClassNameCaseSniff extends AbstractClassRestrictionsSniff {
 	 *
 	 * Note: this list will be enhanced in the class constructor.
 	 *
-	 * {@internal To be updated after every major release. Last updated for WordPress 6.3-RC1.}
+	 * {@internal To be updated after every major release. Last updated for WordPress 6.5-RC3.}
 	 *
 	 * @since 3.0.0
 	 *
@@ -685,6 +735,17 @@ final class ClassNameCaseSniff extends AbstractClassRestrictionsSniff {
 	private $wp_themes_classes_lc = array();
 
 	/**
+	 * List of all AVIF classes in lowercase.
+	 *
+	 * This array is automatically generated in the class constructor based on the $avif_classes property.
+	 *
+	 * @since 3.1.0
+	 *
+	 * @var string[] The class names in lowercase.
+	 */
+	private $avif_classes_lc = array();
+
+	/**
 	 * List of all GetID3 classes in lowercase.
 	 *
 	 * This array is automatically generated in the class constructor based on the $phpmailer_classes property.
@@ -740,6 +801,7 @@ final class ClassNameCaseSniff extends AbstractClassRestrictionsSniff {
 	private $class_groups = array(
 		'wp_classes',
 		'wp_themes_classes',
+		'avif_classes',
 		'getid3_classes',
 		'phpmailer_classes',
 		'requests_classes',

--- a/WordPress/Sniffs/WP/DeprecatedClassesSniff.php
+++ b/WordPress/Sniffs/WP/DeprecatedClassesSniff.php
@@ -41,7 +41,7 @@ final class DeprecatedClassesSniff extends AbstractClassRestrictionsSniff {
 	 *
 	 * Version numbers should be fully qualified.
 	 *
-	 * Last update: July 2023 for WP 6.3 at https://github.com/WordPress/wordpress-develop/commit/6281ce432c50345a57768bf53854d9b65b6cdd52
+	 * {@internal To be updated after every major release. Last updated for WordPress 6.5-RC3.}
 	 *
 	 * @var array
 	 */
@@ -83,6 +83,16 @@ final class DeprecatedClassesSniff extends AbstractClassRestrictionsSniff {
 		'Services_JSON_Error' => array(
 			'alt'     => 'The PHP native JSON extension',
 			'version' => '5.3.0',
+		),
+
+		// WP 6.4.0.
+		'WP_Http_Curl' => array(
+			'alt'     => 'WP_Http',
+			'version' => '6.4.0',
+		),
+		'WP_Http_Streams' => array(
+			'alt'     => 'WP_Http',
+			'version' => '6.4.0',
 		),
 	);
 

--- a/WordPress/Sniffs/WP/DeprecatedFunctionsSniff.php
+++ b/WordPress/Sniffs/WP/DeprecatedFunctionsSniff.php
@@ -37,14 +37,13 @@ final class DeprecatedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 	/**
 	 * List of deprecated functions with alternative when available.
 	 *
-	 * To be updated after every major release.
-	 * Last updated for WordPress 6.3.
-	 *
 	 * Version numbers should be fully qualified.
 	 * Replacement functions should have parentheses.
 	 *
 	 * To retrieve a function list for comparison, the following tool is available:
 	 * https://github.com/JDGrimes/wp-deprecated-code-scanner
+	 *
+	 * {@internal To be updated after every major release. Last updated for WordPress 6.5-RC3.}
 	 *
 	 * @var array
 	 */
@@ -1596,6 +1595,62 @@ final class DeprecatedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 		'wp_tinycolor_string_to_rgb' => array(
 			'alt'     => '',
 			'version' => '6.3.0',
+		),
+
+		// WP 6.4.0.
+		'_admin_bar_bump_cb' => array(
+			'alt'     => 'wp_enqueue_admin_bar_bump_styles()',
+			'version' => '6.4.0',
+		),
+		'_inject_theme_attribute_in_block_template_content' => array(
+			'alt'     => 'traverse_and_serialize_blocks( parse_blocks( $template_content ), \'_inject_theme_attribute_in_template_part_block\' )',
+			'version' => '6.4.0',
+		),
+		'_remove_theme_attribute_in_block_template_content' => array(
+			'alt'     => 'traverse_and_serialize_blocks( parse_blocks( $template_content ), \'_remove_theme_attribute_from_template_part_block\' )',
+			'version' => '6.4.0',
+		),
+		'_wp_theme_json_webfonts_handler' => array(
+			'alt'     => 'wp_print_font_faces()',
+			'version' => '6.4.0',
+		),
+		'print_embed_styles' => array(
+			'alt'     => 'wp_enqueue_embed_styles()',
+			'version' => '6.4.0',
+		),
+		'print_emoji_styles' => array(
+			'alt'     => 'wp_enqueue_emoji_styles()',
+			'version' => '6.4.0',
+		),
+		'the_block_template_skip_link' => array(
+			'alt'     => 'wp_enqueue_block_template_skip_link()',
+			'version' => '6.4.0',
+		),
+		'wp_admin_bar_header' => array(
+			'alt'     => 'wp_enqueue_admin_bar_header_styles()',
+			'version' => '6.4.0',
+		),
+		'wp_img_tag_add_decoding_attr' => array(
+			'alt'     => 'wp_img_tag_add_loading_optimization_attrs()',
+			'version' => '6.4.0',
+		),
+		'wp_update_https_detection_errors' => array(
+			'alt'     => 'wp_get_https_detection_errors()',
+			'version' => '6.4.0',
+		),
+
+		// WP 6.5.0.
+		'block_core_file_ensure_interactivity_dependency' => array(
+			'alt'     => 'wp_register_script_module()',
+			'version' => '6.5.0',
+		),
+		'block_core_image_ensure_interactivity_dependency' => array(
+			'alt'     => 'wp_register_script_module()',
+			'version' => '6.5.0',
+		),
+		'block_core_query_ensure_interactivity_dependency' => array(
+			'alt'     => 'wp_register_script_module()',
+			'version' => '6.5.0',
 		),
 	);
 

--- a/WordPress/Tests/DB/PreparedSQLPlaceholdersUnitTest.inc
+++ b/WordPress/Tests/DB/PreparedSQLPlaceholdersUnitTest.inc
@@ -343,10 +343,10 @@ $where = $wpdb->prepare(
 ); // OK.
 
 // Disregard comments in the array_fill() $value param.
-$wpdb->prepare( '
-	xxx IN ( ' . implode( ',', array_fill( 0, count( $post_types ), '%i' /*comment*/ ) ) . ' )',
-	$fields
-); // IdentifierWithinIN.
+// Also test handling of %i when minimum supported WP version is not high enough yet.
+// phpcs:set WordPress.DB.PreparedSQLPlaceholders minimum_wp_version 6.0
+$wpdb->prepare( 'xxx IN ( ' . implode( ',', array_fill( 0, count( $post_types ), '%i' /*comment*/ ) ) . ' )', $fields ); // IdentifierWithinIN.
+// phpcs:set WordPress.DB.PreparedSQLPlaceholders minimum_wp_version
 
 $where = $wpdb->prepare(
 	"{$wpdb->posts}.post_type IN ("

--- a/WordPress/Tests/DB/PreparedSQLPlaceholdersUnitTest.php
+++ b/WordPress/Tests/DB/PreparedSQLPlaceholdersUnitTest.php
@@ -101,7 +101,7 @@ final class PreparedSQLPlaceholdersUnitTest extends AbstractSniffUnitTest {
 			315 => 1,
 			322 => 1,
 
-			347 => 2, // UnsupportedIdentifierPlaceholder + IdentifierWithinIN.
+			348 => 2, // UnsupportedIdentifierPlaceholder + IdentifierWithinIN.
 			353 => 1,
 
 			// Named parameter support.

--- a/WordPress/Tests/WP/DeprecatedClassesUnitTest.inc
+++ b/WordPress/Tests/WP/DeprecatedClassesUnitTest.inc
@@ -23,3 +23,10 @@ $json = new Services_JSON;
 $json = new Services_JSON_Error;
 class Prefix_Menu_section extends WP_Privacy_Data_Export_Requests_Table {}
 WP_Privacy_Data_Removal_Requests_Table::foo();
+
+/*
+ * Warning
+ */
+/* ============ WP 6.4 ============ */
+WP_Http_Curl::do_something();
+$streams = new WP_Http_Streams();

--- a/WordPress/Tests/WP/DeprecatedClassesUnitTest.php
+++ b/WordPress/Tests/WP/DeprecatedClassesUnitTest.php
@@ -43,6 +43,9 @@ final class DeprecatedClassesUnitTest extends AbstractSniffUnitTest {
 	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList() {
-		return array();
+		return array(
+			31 => 1,
+			32 => 1,
+		);
 	}
 }

--- a/WordPress/Tests/WP/DeprecatedFunctionsUnitTest.inc
+++ b/WordPress/Tests/WP/DeprecatedFunctionsUnitTest.inc
@@ -360,10 +360,6 @@ _excerpt_render_inner_columns_blocks();
 readonly();
 /* ============ WP 5.9.1 ============ */
 wp_render_duotone_filter_preset();
-
-/*
- * Warning.
- */
 /* ============ WP 6.0 ============ */
 image_attachment_fields_to_save();
 wp_add_iframed_editor_assets_html();
@@ -384,6 +380,10 @@ install_global_terms();
 sync_category_tag_slugs();
 wp_get_attachment_thumb_file();
 wp_typography_get_css_variable_inline_style();
+
+/*
+ * Warning.
+ */
 /* ============ WP 6.2 ============ */
 _resolve_home_block_template();
 get_page_by_title();

--- a/WordPress/Tests/WP/DeprecatedFunctionsUnitTest.inc
+++ b/WordPress/Tests/WP/DeprecatedFunctionsUnitTest.inc
@@ -411,3 +411,18 @@ wp_tinycolor_hsl_to_rgb();
 wp_tinycolor_hue_to_rgb();
 wp_tinycolor_rgb_to_rgb();
 wp_tinycolor_string_to_rgb();
+/* ============ WP 6.4 ============ */
+_admin_bar_bump_cb();
+_inject_theme_attribute_in_block_template_content();
+_remove_theme_attribute_in_block_template_content();
+_wp_theme_json_webfonts_handler();
+print_embed_styles();
+print_emoji_styles();
+the_block_template_skip_link();
+wp_admin_bar_header();
+wp_img_tag_add_decoding_attr();
+wp_update_https_detection_errors();
+/* ============ WP 6.5 ============ */
+block_core_file_ensure_interactivity_dependency();
+block_core_image_ensure_interactivity_dependency();
+block_core_query_ensure_interactivity_dependency();

--- a/WordPress/Tests/WP/DeprecatedFunctionsUnitTest.php
+++ b/WordPress/Tests/WP/DeprecatedFunctionsUnitTest.php
@@ -28,7 +28,7 @@ final class DeprecatedFunctionsUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getErrorList() {
 		$start_line = 8;
-		$end_line   = 362;
+		$end_line   = 382;
 		$errors     = array_fill( $start_line, ( ( $end_line - $start_line ) + 1 ), 1 );
 
 		// Unset the lines related to version comments.
@@ -73,7 +73,11 @@ final class DeprecatedFunctionsUnitTest extends AbstractSniffUnitTest {
 			$errors[353],
 			$errors[357],
 			$errors[359],
-			$errors[361]
+			$errors[361],
+			$errors[363],
+			$errors[369],
+			$errors[371],
+			$errors[373]
 		);
 
 		return $errors;
@@ -85,16 +89,12 @@ final class DeprecatedFunctionsUnitTest extends AbstractSniffUnitTest {
 	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList() {
-		$start_line = 368;
+		$start_line = 388;
 		$end_line   = 428;
 		$warnings   = array_fill( $start_line, ( ( $end_line - $start_line ) + 1 ), 1 );
 
 		// Unset the lines related to version comments.
 		unset(
-			$warnings[373],
-			$warnings[375],
-			$warnings[377],
-			$warnings[387],
 			$warnings[390],
 			$warnings[414],
 			$warnings[425]

--- a/WordPress/Tests/WP/DeprecatedFunctionsUnitTest.php
+++ b/WordPress/Tests/WP/DeprecatedFunctionsUnitTest.php
@@ -86,7 +86,7 @@ final class DeprecatedFunctionsUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getWarningList() {
 		$start_line = 368;
-		$end_line   = 413;
+		$end_line   = 428;
 		$warnings   = array_fill( $start_line, ( ( $end_line - $start_line ) + 1 ), 1 );
 
 		// Unset the lines related to version comments.
@@ -95,7 +95,9 @@ final class DeprecatedFunctionsUnitTest extends AbstractSniffUnitTest {
 			$warnings[375],
 			$warnings[377],
 			$warnings[387],
-			$warnings[390]
+			$warnings[390],
+			$warnings[414],
+			$warnings[425]
 		);
 
 		return $warnings;

--- a/WordPress/Tests/WP/DeprecatedParametersUnitTest.inc
+++ b/WordPress/Tests/WP/DeprecatedParametersUnitTest.inc
@@ -94,6 +94,6 @@ wp_notify_postauthor( '', 'null' ); // Null as a string not null.
 wp_title_rss( 'deprecated' );
 wp_upload_bits( '', 'deprecated' );
 xfn_check( '', '', 'deprecated' );
+global_terms( $foo, 'deprecated' );
 
 // All will give an WARNING as they have been deprecated after WP 5.8.
-global_terms( $foo, 'deprecated' );

--- a/WordPress/Tests/WP/DeprecatedParametersUnitTest.php
+++ b/WordPress/Tests/WP/DeprecatedParametersUnitTest.php
@@ -28,7 +28,7 @@ final class DeprecatedParametersUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getErrorList() {
 		$start_line = 42;
-		$end_line   = 96;
+		$end_line   = 97;
 		$errors     = array_fill( $start_line, ( ( $end_line - $start_line ) + 1 ), 1 );
 
 		$errors[22] = 1;
@@ -51,10 +51,6 @@ final class DeprecatedParametersUnitTest extends AbstractSniffUnitTest {
 	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList() {
-		$start_line = 99;
-		$end_line   = 99;
-		$errors     = array_fill( $start_line, ( ( $end_line - $start_line ) + 1 ), 1 );
-
-		return $errors;
+		return array();
 	}
 }


### PR DESCRIPTION
### NamingConventions/PrefixAllGlobals: update the functions list based on WP 6.5-RC3

Based on a scan of WP Core at commit WordPress/wordpress-develop@3595704 using a preliminary sniff created for issue #1803.

### NamingConventions/ValidPostTypeSlug: update the reserved post types list based on WP 6.5-RC3

Based on a scan of WP Core at commit WordPress/wordpress-develop@3595704 using a preliminary sniff created for issue #1803.

### WP/ClassNameCase: update the class lists based on WP 6.5-RC3

Based on a scan of WP Core at commit WordPress/wordpress-develop@3595704 using a preliminary sniff created for issue #1803.

### WP/DeprecatedClasses: update the class list based on WP 6.5-RC3

Based on a scan of WP Core at commit WordPress/wordpress-develop@3595704 using a preliminary sniff created for issue #1803.

Includes tests.

### WP/DeprecatedFunctions: update the functions list based on WP 6.5-RC3

Based on a scan of WP Core at commit WordPress/wordpress-develop@3595704 using a preliminary sniff created for issue #1803.

Includes tests.

### Update the minimum_wp_version to WP 6.2

The minimum version should be three versions behind the latest WP release, so what with 6.5 being in RC, to be released on next week, it should now become 6.2.

Includes updating the tests to match.

Previous: #2121, #2321