### PR TITLE
Composer: raise the minimum supported PHPCSUtils version to 1.0.10

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -40,7 +40,7 @@ When you introduce new `public` sniff properties, or your sniff extends a class 
 ## Pre-requisites
 * WordPress-Coding-Standards
 * PHP_CodeSniffer 3.9.0 or higher
-* PHPCSUtils 1.0.9 or higher
+* PHPCSUtils 1.0.10 or higher
 * PHPCSExtra 1.2.1 or higher
 * PHPUnit 4.x - 9.x
 

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
 		"ext-tokenizer": "*",
 		"ext-xmlreader": "*",
 		"squizlabs/php_codesniffer": "^3.9.0",
-		"phpcsstandards/phpcsutils": "^1.0.9",
+		"phpcsstandards/phpcsutils": "^1.0.10",
 		"phpcsstandards/phpcsextra": "^1.2.1"
 	},
 	"require-dev": {


### PR DESCRIPTION
Nothing major in the 1.0.10 release, but updating the requirement prevents us having to deal with invalid bug reports when people would already be running WPCS against PHP 8.4, as two issues related to a PHP 8.4 deprecation have been fixed.

Ref: https://github.com/PHPCSStandards/PHPCSUtils/releases/tag/1.0.10