### PR TITLE
Release WordPressCS 3.1.0

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -41,7 +41,7 @@ When you introduce new `public` sniff properties, or your sniff extends a class 
 * WordPress-Coding-Standards
 * PHP_CodeSniffer 3.7.2 or higher
 * PHPCSUtils 1.0.8 or higher
-* PHPCSExtra 1.1.0 or higher
+* PHPCSExtra 1.2.0 or higher
 * PHPUnit 4.x, 5.x, 6.x or 7.x
 
 The WordPress Coding Standards use the `PHP_CodeSniffer` native unit test framework for unit testing the sniffs.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -138,7 +138,7 @@ Also note the class name convention. The method `getErrorList()` MUST return an 
 If you run the following from the root directory of your WordPressCS clone:
 
 ```sh
-$ "vendor/bin/phpcs" --standard=Wordpress -s ./Tests/PHP/POSIXFunctionsUnitTest.inc --sniffs=WordPress.PHP.POSIXFunctions
+$ "vendor/bin/phpcs" --standard=Wordpress -s ./WordPress/Tests/PHP/POSIXFunctionsUnitTest.inc --sniffs=WordPress.PHP.POSIXFunctions
 ...
 --------------------------------------------------------------------------------
 FOUND 7 ERRORS AFFECTING 7 LINES

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Bug reports containing a minimal code sample which can be used to reproduce the 
 Since WordPressCS employs many sniffs that are part of PHP_CodeSniffer itself or PHPCSExtra, sometimes an issue will be caused by a bug in PHPCS or PHPCSExtra and not in WordPressCS itself.
 If the error message in question doesn't come from a sniff whose name starts with `WordPress`, the issue is probably a bug in PHPCS or PHPCSExtra.
 
-* Bugs for sniffs starting with `Generic`, `PEAR`, `PSR1`, `PSR2`, `PSR12`, `Squiz` or `Zend` should be [reported to PHPCS](https://github.com/squizlabs/PHP_CodeSniffer/issues).
+* Bugs for sniffs starting with `Generic`, `PEAR`, `PSR1`, `PSR2`, `PSR12`, `Squiz` or `Zend` should be [reported to PHPCS](https://github.com/PHPCSStandards/PHP_CodeSniffer/issues).
 * Bugs for sniffs starting with `Modernize`, `NormalizedArrays` or `Universal` should be [reported to PHPCSExtra](https://github.com/PHPCSStandards/PHPCSExtra/issues).
 
 # Contributing patches and new features
@@ -39,9 +39,9 @@ When you introduce new `public` sniff properties, or your sniff extends a class 
 
 ## Pre-requisites
 * WordPress-Coding-Standards
-* PHP_CodeSniffer 3.7.2 or higher
-* PHPCSUtils 1.0.8 or higher
-* PHPCSExtra 1.2.0 or higher
+* PHP_CodeSniffer 3.8.0 or higher
+* PHPCSUtils 1.0.9 or higher
+* PHPCSExtra 1.2.1 or higher
 * PHPUnit 4.x, 5.x, 6.x or 7.x
 
 The WordPress Coding Standards use the `PHP_CodeSniffer` native unit test framework for unit testing the sniffs.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -39,7 +39,7 @@ When you introduce new `public` sniff properties, or your sniff extends a class 
 
 ## Pre-requisites
 * WordPress-Coding-Standards
-* PHP_CodeSniffer 3.8.0 or higher
+* PHP_CodeSniffer 3.9.0 or higher
 * PHPCSUtils 1.0.9 or higher
 * PHPCSExtra 1.2.1 or higher
 * PHPUnit 4.x - 9.x

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -42,7 +42,7 @@ When you introduce new `public` sniff properties, or your sniff extends a class 
 * PHP_CodeSniffer 3.8.0 or higher
 * PHPCSUtils 1.0.9 or higher
 * PHPCSExtra 1.2.1 or higher
-* PHPUnit 4.x, 5.x, 6.x or 7.x
+* PHPUnit 4.x - 9.x
 
 The WordPress Coding Standards use the `PHP_CodeSniffer` native unit test framework for unit testing the sniffs.
 
@@ -85,9 +85,9 @@ phpunit --filter WordPress /path/to/PHP_CodeSniffer/tests/AllTests.php
 
 Expected output:
 ```
-PHPUnit 7.5.20 by Sebastian Bergmann and contributors.
+PHPUnit 9.6.15 by Sebastian Bergmann and contributors.
 
-Runtime:       PHP 7.4.33
+Runtime:       PHP 8.3.0
 Configuration: /WordPressCS/phpunit.xml.dist
 
 .........................................................         57 / 57 (100%)

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -40,7 +40,7 @@ When you introduce new `public` sniff properties, or your sniff extends a class 
 ## Pre-requisites
 * WordPress-Coding-Standards
 * PHP_CodeSniffer 3.9.0 or higher
-* PHPCSUtils 1.0.9 or higher
+* PHPCSUtils 1.0.10 or higher
 * PHPCSExtra 1.2.1 or higher
 * PHPUnit 4.x - 9.x
 

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,1 @@
-custom: "https://opencollective.com/thewpcc/contribute/wp-php-63406"
+custom: "https://opencollective.com/php_codesniffer"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+# Dependabot configuration.
+#
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      time: "09:00"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "GH Actions:"
+    labels:
+      - "Type: Chores/Cleanup"

--- a/.github/release-checklist.md
+++ b/.github/release-checklist.md
@@ -64,7 +64,7 @@ PR for tracking changes for the x.x.x release. Target release date: **DOW MONTH 
 - [ ] Submit for ["Month in WordPress"][month-in-wp].
 - [ ] Submit for the ["Monthy Dev Roundup"][dev-roundup].
 
-[phpcs-releases]:      https://github.com/squizlabs/PHP_CodeSniffer/releases
+[phpcs-releases]:      https://github.com/PHPCSStandards/PHP_CodeSniffer/releases
 [phpcsutils-releases]: https://github.com/PHPCSStandards/PHPCSUtils/releases
 [phpcsextra-releases]: https://github.com/PHPCSStandards/PHPCSExtra/releases
 [month-in-wp]:         https://make.wordpress.org/community/month-in-wordpress-submissions/

--- a/.github/workflows/basic-qa.yml
+++ b/.github/workflows/basic-qa.yml
@@ -12,6 +12,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  PHPCS_DEV: 'dev-master'
+  UTILS_DEV: 'dev-develop'
+  EXTRA_DEV: 'dev-develop'
+
 jobs:
   # Check code style of sniffs, rulesets and XML documentation.
   # Check that all sniffs are feature complete.
@@ -37,9 +42,13 @@ jobs:
       - name: Validate the composer.json file
         run: composer validate --no-check-all --strict
 
-      # Using PHPCS `master` as an early detection system for bugs upstream.
-      - name: Set PHPCS version
-        run: composer require squizlabs/php_codesniffer:"dev-master" --no-update --no-scripts --no-interaction
+      # Using dev versions of the dependencies as an early detection system for bugs upstream.
+      - name: "Composer: set PHPCS dependencies (dev)"
+        run: >
+          composer require --no-update --no-scripts --no-interaction
+          squizlabs/php_codesniffer:"${{ env.PHPCS_DEV }}"
+          phpcsstandards/phpcsutils:"${{ env.UTILS_DEV }}"
+          phpcsstandards/phpcsextra:"${{ env.EXTRA_DEV }}"
 
       - name: Install Composer dependencies
         uses: ramsey/composer-install@v2
@@ -93,15 +102,15 @@ jobs:
 
   # Makes sure the rulesets don't throw unexpected errors or warnings.
   # This workflow needs to be run against a high PHP version to prevent triggering the syntax error check.
-  # It also needs to be run against all PHPCS versions WPCS is tested against.
+  # It also needs to be run against all dependency versions WPCS is tested against.
   ruleset-tests:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         php: [ 'latest' ]
-        phpcs_version: [ 'lowest', 'dev-master' ]
+        dependencies: [ 'lowest', 'stable', 'dev' ]
 
-    name: "Ruleset test: PHP ${{ matrix.php }} on PHPCS ${{ matrix.phpcs_version }}"
+    name: "Ruleset test: PHP ${{ matrix.php }} on PHPCS ${{ matrix.dependencies }}"
 
     steps:
       - name: Checkout repository
@@ -115,9 +124,13 @@ jobs:
           ini-values: error_reporting = E_ALL & ~E_DEPRECATED
           coverage: none
 
-      - name: "Set PHPCS version (master)"
-        if: ${{ matrix.phpcs_version != 'lowest' }}
-        run: composer require squizlabs/php_codesniffer:"${{ matrix.phpcs_version }}" --no-update --no-scripts --no-interaction
+      - name: "Composer: set PHPCS dependencies for tests (dev)"
+        if: ${{ matrix.dependencies == 'dev' }}
+        run: >
+          composer require --no-update --no-scripts --no-interaction
+          squizlabs/php_codesniffer:"${{ env.PHPCS_DEV }}"
+          phpcsstandards/phpcsutils:"${{ env.UTILS_DEV }}"
+          phpcsstandards/phpcsextra:"${{ env.EXTRA_DEV }}"
 
       - name: Install Composer dependencies
         uses: ramsey/composer-install@v2
@@ -126,8 +139,13 @@ jobs:
           # Bust the cache at least once a month - output format: YYYY-MM.
           custom-cache-suffix: $(date -u "+%Y-%m")
 
-      - name: "Set PHPCS version (lowest)"
-        run: composer update squizlabs/php_codesniffer --prefer-lowest --no-scripts --no-interaction
+      - name: "Composer: downgrade PHPCS dependencies for tests (lowest)"
+        if: ${{ matrix.dependencies == 'lowest' }}
+        run: >
+          composer update --prefer-lowest --no-scripts --no-interaction
+          squizlabs/php_codesniffer
+          phpcsstandards/phpcsutils
+          phpcsstandards/phpcsextra
 
       - name: Test the WordPress-Core ruleset
         run: $(pwd)/vendor/bin/phpcs -ps ./Tests/RulesetCheck/class-ruleset-test.inc --standard=WordPress-Core
@@ -150,8 +168,9 @@ jobs:
       # Test for fixer conflicts by running the auto-fixers of the complete WPCS over the test case files.
       # This is not an exhaustive test, but should give an early indication for typical fixer conflicts.
       # If only fixable errors are found, the exit code will be 1, which can be interpreted as success.
+      # This check is only run against "dev" as conflicts can not be fixed for already released versions.
       - name: Test for fixer conflicts (fixes expected)
-        if: ${{ matrix.phpcs_version == 'dev-master' }}
+        if: ${{ matrix.dependencies == 'dev' }}
         id: phpcbf
         continue-on-error: true
         run: |

--- a/.github/workflows/basic-qa.yml
+++ b/.github/workflows/basic-qa.yml
@@ -127,8 +127,7 @@ jobs:
           custom-cache-suffix: $(date -u "+%Y-%m")
 
       - name: "Set PHPCS version (lowest)"
-        if: ${{ matrix.phpcs_version == 'lowest' }}
-        run: composer update squizlabs/php_codesniffer --prefer-lowest --ignore-platform-req=php+ --no-scripts --no-interaction
+        run: composer update squizlabs/php_codesniffer --prefer-lowest --no-scripts --no-interaction
 
       - name: Test the WordPress-Core ruleset
         run: $(pwd)/vendor/bin/phpcs -ps ./Tests/RulesetCheck/class-ruleset-test.inc --standard=WordPress-Core
@@ -178,7 +177,7 @@ jobs:
       - name: Install PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.4'
+          php-version: 'latest'
           coverage: none
           tools: phpstan
 

--- a/.github/workflows/basic-qa.yml
+++ b/.github/workflows/basic-qa.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -104,7 +104,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
@@ -174,7 +174,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/basic-qa.yml
+++ b/.github/workflows/basic-qa.yml
@@ -51,7 +51,7 @@ jobs:
           phpcsstandards/phpcsextra:"${{ env.EXTRA_DEV }}"
 
       - name: Install Composer dependencies
-        uses: ramsey/composer-install@v2
+        uses: ramsey/composer-install@v3
         with:
           # Bust the cache at least once a month - output format: YYYY-MM.
           custom-cache-suffix: $(date -u "+%Y-%m")
@@ -133,7 +133,7 @@ jobs:
           phpcsstandards/phpcsextra:"${{ env.EXTRA_DEV }}"
 
       - name: Install Composer dependencies
-        uses: ramsey/composer-install@v2
+        uses: ramsey/composer-install@v3
         with:
           composer-options: --no-dev
           # Bust the cache at least once a month - output format: YYYY-MM.
@@ -204,7 +204,7 @@ jobs:
       # Dependencies need to be installed to make sure the PHPCS and PHPUnit classes are recognized.
       # @link https://github.com/marketplace/actions/install-php-dependencies-with-composer
       - name: Install Composer dependencies
-        uses: "ramsey/composer-install@v2"
+        uses: "ramsey/composer-install@v3"
         with:
           # Bust the cache at least once a month - output format: YYYY-MM.
           custom-cache-suffix: $(date -u "+%Y-%m")

--- a/.github/workflows/basic-qa.yml
+++ b/.github/workflows/basic-qa.yml
@@ -54,7 +54,8 @@ jobs:
 
       # Show XML violations inline in the file diff.
       # @link https://github.com/marketplace/actions/xmllint-problem-matcher
-      - uses: korelstar/xmllint-problem-matcher@v1
+      - name: Enable showing XML issues inline
+        uses: korelstar/xmllint-problem-matcher@v1
 
       - name: Check the code style of the PHP files
         id: phpcs
@@ -185,7 +186,7 @@ jobs:
 
       # Install dependencies and handle caching in one go.
       # Dependencies need to be installed to make sure the PHPCS and PHPUnit classes are recognized.
-      # @link https://github.com/marketplace/actions/install-composer-dependencies
+      # @link https://github.com/marketplace/actions/install-php-dependencies-with-composer
       - name: Install Composer dependencies
         uses: "ramsey/composer-install@v2"
         with:

--- a/.github/workflows/basic-qa.yml
+++ b/.github/workflows/basic-qa.yml
@@ -151,15 +151,13 @@ jobs:
       # Test for fixer conflicts by running the auto-fixers of the complete WPCS over the test case files.
       # This is not an exhaustive test, but should give an early indication for typical fixer conflicts.
       # If only fixable errors are found, the exit code will be 1, which can be interpreted as success.
-      #
-      # Note: the ValidVariableNameUnitTest.inc file is temporarily ignored until upstream PHPCS PR 3833 has been merged.
       - name: Test for fixer conflicts (fixes expected)
         if: ${{ matrix.phpcs_version == 'dev-master' }}
         id: phpcbf
         continue-on-error: true
         run: |
           set +e
-          $(pwd)/vendor/bin/phpcbf -pq ./WordPress/Tests/ --standard=WordPress --extensions=inc --exclude=Generic.PHP.Syntax --report=summary --ignore=/WordPress/Tests/NamingConventions/ValidVariableNameUnitTest.inc,/WordPress/Tests/WP/GlobalVariablesOverrideUnitTest.7.inc
+          $(pwd)/vendor/bin/phpcbf -pq ./WordPress/Tests/ --standard=WordPress --extensions=inc --exclude=Generic.PHP.Syntax --report=summary --ignore=/WordPress/Tests/WP/GlobalVariablesOverrideUnitTest.7.inc
           exitcode="$?"
           echo "EXITCODE=$exitcode" >> $GITHUB_OUTPUT
           exit "$exitcode"

--- a/.github/workflows/manage-labels.yml
+++ b/.github/workflows/manage-labels.yml
@@ -17,7 +17,7 @@ jobs:
     name: Clean up labels on PR merge
 
     steps:
-      - uses: mondeja/remove-labels-gh-action@v1
+      - uses: mondeja/remove-labels-gh-action@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           labels: |
@@ -31,7 +31,7 @@ jobs:
     name: Clean up labels on PR close
 
     steps:
-      - uses: mondeja/remove-labels-gh-action@v1
+      - uses: mondeja/remove-labels-gh-action@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           labels: |
@@ -46,7 +46,7 @@ jobs:
     name: Clean up labels on issue close
 
     steps:
-      - uses: mondeja/remove-labels-gh-action@v1
+      - uses: mondeja/remove-labels-gh-action@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           labels: |

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -42,7 +42,7 @@ jobs:
           coverage:  ${{ github.ref_name == 'develop' && 'xdebug' || 'none' }}
 
       - name: Install Composer dependencies
-        uses: ramsey/composer-install@v2
+        uses: ramsey/composer-install@v3
         with:
           # Bust the cache at least once a month - output format: YYYY-MM.
           custom-cache-suffix: $(date -u "+%Y-%m")

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # On stable PHPCS versions, allow for PHP deprecation notices.
       # Unit tests don't need to fail on those for stable releases where those issues won't get fixed anymore.

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -24,35 +24,22 @@ jobs:
     strategy:
       matrix:
         php: [ '5.4', 'latest' ]
-        phpcs_version: [ 'lowest', 'dev-master' ]
+        dependencies: [ 'lowest', 'stable' ]
 
-    name: QTest - PHP ${{ matrix.php }} on PHPCS ${{ matrix.phpcs_version }}
+    name: QTest - PHP ${{ matrix.php }} on PHPCS ${{ matrix.dependencies }}
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      # On stable PHPCS versions, allow for PHP deprecation notices.
-      # Unit tests don't need to fail on those for stable releases where those issues won't get fixed anymore.
-      - name: Setup ini config
-        id: set_ini
-        run: |
-          if [ "${{ matrix.phpcs_version }}" != "dev-master" ]; then
-            echo 'PHP_INI=error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On' >> $GITHUB_OUTPUT
-          else
-            echo 'PHP_INI=error_reporting=-1, display_errors=On' >> $GITHUB_OUTPUT
-          fi
-
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          ini-values: ${{ steps.set_ini.outputs.PHP_INI }}
+          # With stable PHPCS dependencies, allow for PHP deprecation notices.
+          # Unit tests don't need to fail on those for stable releases where those issues won't get fixed anymore.
+          ini-values: error_reporting=-1, display_errors=On
           coverage:  ${{ github.ref_name == 'develop' && 'xdebug' || 'none' }}
-
-      - name: "Set PHPCS version (master)"
-        if: ${{ matrix.phpcs_version != 'lowest' }}
-        run: composer require squizlabs/php_codesniffer:"${{ matrix.phpcs_version }}" --no-update --no-scripts --no-interaction
 
       - name: Install Composer dependencies
         uses: ramsey/composer-install@v2
@@ -60,12 +47,16 @@ jobs:
           # Bust the cache at least once a month - output format: YYYY-MM.
           custom-cache-suffix: $(date -u "+%Y-%m")
 
-      - name: "Set PHPCS version (lowest)"
-        if: ${{ matrix.phpcs_version == 'lowest' }}
-        run: composer update squizlabs/php_codesniffer --prefer-lowest --ignore-platform-req=php+ --no-scripts --no-interaction
+      - name: "Composer: downgrade PHPCS dependencies for tests (lowest)"
+        if: ${{ matrix.dependencies == 'lowest' }}
+        run: >
+          composer update --prefer-lowest --no-scripts --no-interaction
+          squizlabs/php_codesniffer
+          phpcsstandards/phpcsutils
+          phpcsstandards/phpcsextra
 
       - name: Lint PHP files against parse errors
-        if: ${{ matrix.phpcs_version == 'dev-master' }}
+        if: ${{ matrix.dependencies == 'stable' }}
         run: composer lint -- --checkstyle
 
       - name: Run the unit tests without code coverage

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [ '5.4', '7.4', 'latest' ]
+        php: [ '5.4', 'latest' ]
         phpcs_version: [ 'lowest', 'dev-master' ]
 
     name: QTest - PHP ${{ matrix.php }} on PHPCS ${{ matrix.phpcs_version }}
@@ -54,18 +54,10 @@ jobs:
         if: ${{ matrix.phpcs_version != 'lowest' }}
         run: composer require squizlabs/php_codesniffer:"${{ matrix.phpcs_version }}" --no-update --no-scripts --no-interaction
 
-      - name: Install Composer dependencies (PHP < 8.0 )
-        if: ${{ matrix.php < 8.0 && matrix.php != 'latest' }}
+      - name: Install Composer dependencies
         uses: ramsey/composer-install@v2
         with:
           # Bust the cache at least once a month - output format: YYYY-MM.
-          custom-cache-suffix: $(date -u "+%Y-%m")
-
-      - name: Install Composer dependencies (PHP >= 8.0)
-        if: ${{ matrix.php >= 8.0 || matrix.php == 'latest' }}
-        uses: ramsey/composer-install@v2
-        with:
-          composer-options: --ignore-platform-req=php+
           custom-cache-suffix: $(date -u "+%Y-%m")
 
       - name: "Set PHPCS version (lowest)"
@@ -76,21 +68,16 @@ jobs:
         if: ${{ matrix.phpcs_version == 'dev-master' }}
         run: composer lint -- --checkstyle
 
-      - name: Run the unit tests without code coverage - PHP 5.4 - 8.0
-        if: ${{ matrix.php == '5.4' && github.ref_name != 'develop' }}
+      - name: Run the unit tests without code coverage
+        if: ${{ github.ref_name != 'develop' }}
         run: composer run-tests
 
-      # Until PHPCS supports PHPUnit 9, we cannot run code coverage on PHP 8.0+, so run it on PHP 5.4 and 7.4.
-      - name: Run the unit tests with code coverage - PHP 5.4 - 8.0
-        if: ${{ matrix.php != 'latest' && github.ref_name == 'develop' }}
+      - name: Run the unit tests with code coverage
+        if: ${{ github.ref_name == 'develop' }}
         run: composer coverage
 
-      - name: Run the unit tests without code coverage - PHP >= 8.1
-        if: ${{ matrix.php == 'latest' }}
-        run: composer run-tests -- --no-configuration --bootstrap=./Tests/bootstrap.php --dont-report-useless-tests
-
       - name: Send coverage report to Codecov
-        if: ${{ success() && github.ref_name == 'develop' && matrix.php != 'latest' }}
+        if: ${{ success() && github.ref_name == 'develop' }}
         uses: codecov/codecov-action@v3
         with:
           files: ./build/logs/clover.xml

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Lint PHP files against parse errors
         if: ${{ matrix.dependencies == 'stable' }}
-        run: composer lint -- --checkstyle
+        run: composer lint
 
       - name: Run the unit tests without code coverage
         if: ${{ github.ref_name != 'develop' }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -32,7 +32,7 @@ jobs:
         coverage: [false]
 
         include:
-          - php: '7.4'
+          - php: '7.2'
             dependencies: 'stable'
             extensions: ':mbstring' # = Disable Mbstring.
             coverage: true # Make sure coverage is recorded for this too.
@@ -119,7 +119,7 @@ jobs:
           custom-cache-suffix: $(date -u "+%Y-%m")
 
       - name: "Composer: downgrade PHPCS dependencies for tests (lowest)"
-        if: ${{ ! startsWith( matrix.php, '8' ) && matrix.dependencies == 'lowest' }}
+        if: ${{ matrix.dependencies == 'lowest' }}
         run: >
           composer update --prefer-lowest --no-scripts --no-interaction
           squizlabs/php_codesniffer

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [ '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '8.0', '8.1', '8.2', '8.3', '8.4' ]
+        php: [ '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.4' ]
         phpcs_version: [ 'lowest', 'dev-master' ]
         extensions: [ '' ]
         coverage: [false]
@@ -33,7 +33,6 @@ jobs:
             coverage: true # Make sure coverage is recorded for this too.
 
           # Run code coverage builds against high/low PHP and high/low PHPCS.
-          # Note: Until PHPCS supports PHPUnit 9, we cannot run code coverage on PHP 8.0+.
           - php: '5.4'
             phpcs_version: 'dev-master'
             extensions: ''
@@ -42,11 +41,11 @@ jobs:
             phpcs_version: 'lowest'
             extensions: ''
             coverage: true
-          - php: '7.4'
+          - php: '8.3'
             phpcs_version: 'dev-master'
             extensions: ''
             coverage: true
-          - php: '7.4'
+          - php: '8.3'
             phpcs_version: 'lowest'
             extensions: ''
             coverage: true
@@ -86,18 +85,10 @@ jobs:
         if: ${{ matrix.phpcs_version != 'lowest' }}
         run: composer require squizlabs/php_codesniffer:"${{ matrix.phpcs_version }}" --no-update --no-scripts --no-interaction
 
-      - name: Install Composer dependencies (PHP < 8.0 )
-        if: ${{ matrix.php < 8.0 }}
+      - name: Install Composer dependencies
         uses: ramsey/composer-install@v2
         with:
           # Bust the cache at least once a month - output format: YYYY-MM.
-          custom-cache-suffix: $(date -u "+%Y-%m")
-
-      - name: Install Composer dependencies (PHP >= 8.0)
-        if: ${{ matrix.php >= 8.0 }}
-        uses: ramsey/composer-install@v2
-        with:
-          composer-options: --ignore-platform-req=php+
           custom-cache-suffix: $(date -u "+%Y-%m")
 
       - name: "Set PHPCS version (lowest)"
@@ -108,18 +99,13 @@ jobs:
         if: ${{ matrix.phpcs_version == 'dev-master' }}
         run: composer lint -- --checkstyle | cs2pr
 
-      - name: Run the unit tests without code coverage - PHP 5.4 - 8.0
-        if: ${{ matrix.php < '8.1' && matrix.coverage == false }}
+      - name: Run the unit tests without code coverage
+        if: ${{ matrix.coverage == false }}
         run: composer run-tests
 
-      - name: Run the unit tests with code coverage - PHP 5.4 - 8.0
-        if: ${{ matrix.php < '8.1' && matrix.coverage == true  }}
+      - name: Run the unit tests with code coverage
+        if: ${{ matrix.coverage == true  }}
         run: composer coverage
-
-      # Until PHPCS supports PHPUnit 9, we cannot run code coverage on PHP 8.0+.
-      - name: Run the unit tests without code coverage - PHP >= 8.1
-        if: ${{ matrix.php >= '8.1' && matrix.coverage == false  }}
-        run: composer run-tests -- --no-configuration --bootstrap=./Tests/bootstrap.php --dont-report-useless-tests
 
       - name: Send coverage report to Codecov
         if: ${{ success() && matrix.coverage == true }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -14,47 +14,70 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  PHPCS_DEV: 'dev-master'
+  UTILS_DEV: 'dev-develop'
+  EXTRA_DEV: 'dev-develop'
+
 jobs:
   # Runs the test suite against all supported branches and combinations.
-  # Linting is performed on all jobs run against PHPCS `dev-master`.
+  # Linting is performed on all jobs run with dependencies `stable`.
   test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         php: [ '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.4' ]
-        phpcs_version: [ 'lowest', 'dev-master' ]
+        dependencies: [ 'lowest', 'stable' ]
         extensions: [ '' ]
         coverage: [false]
 
         include:
           - php: '7.4'
-            phpcs_version: 'dev-master'
+            dependencies: 'stable'
             extensions: ':mbstring' # = Disable Mbstring.
             coverage: true # Make sure coverage is recorded for this too.
 
           # Run code coverage builds against high/low PHP and high/low PHPCS.
           - php: '5.4'
-            phpcs_version: 'dev-master'
+            dependencies: 'stable'
             extensions: ''
             coverage: true
           - php: '5.4'
-            phpcs_version: 'lowest'
+            dependencies: 'lowest'
             extensions: ''
             coverage: true
           - php: '8.3'
-            phpcs_version: 'dev-master'
+            dependencies: 'stable'
             extensions: ''
             coverage: true
           - php: '8.3'
-            phpcs_version: 'lowest'
+            dependencies: 'lowest'
             extensions: ''
             coverage: true
+
+          # Test against dev versions of all dependencies with select PHP versions for early detection of issues.
+          - php: '5.4'
+            dependencies: 'dev'
+            extensions: ''
+            coverage: false
+          - php: '7.0'
+            dependencies: 'dev'
+            extensions: ''
+            coverage: false
+          - php: '7.4'
+            dependencies: 'dev'
+            extensions: ''
+            coverage: false
+          - php: '8.3'
+            dependencies: 'dev'
+            extensions: ''
+            coverage: false
 
           # Add extra build to test against PHPCS 4.
           #- php: '7.4'
-          #  phpcs_version: '4.0.x-dev as 3.9.99'
+          #  dependencies: '4.0.x-dev as 3.9.99'
 
-    name: PHP ${{ matrix.php }} on PHPCS ${{ matrix.phpcs_version }}
+    name: PHP ${{ matrix.php }} on PHPCS ${{ matrix.dependencies }}
 
     continue-on-error: ${{ matrix.php == '8.4' }}
 
@@ -62,12 +85,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      # On stable PHPCS versions, allow for PHP deprecation notices.
+      # With stable PHPCS dependencies, allow for PHP deprecation notices.
       # Unit tests don't need to fail on those for stable releases where those issues won't get fixed anymore.
       - name: Setup ini config
         id: set_ini
         run: |
-          if [ "${{ matrix.phpcs_version }}" != "dev-master" ]; then
+          if [ "${{ matrix.dependencies }}" != "dev" ]; then
             echo 'PHP_INI=error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On' >> $GITHUB_OUTPUT
           else
             echo 'PHP_INI=error_reporting=-1, display_errors=On' >> $GITHUB_OUTPUT
@@ -81,9 +104,13 @@ jobs:
           coverage: ${{ matrix.coverage && 'xdebug' || 'none' }}
           tools: cs2pr
 
-      - name: "Set PHPCS version (master)"
-        if: ${{ matrix.phpcs_version != 'lowest' }}
-        run: composer require squizlabs/php_codesniffer:"${{ matrix.phpcs_version }}" --no-update --no-scripts --no-interaction
+      - name: "Composer: set PHPCS dependencies for tests (dev)"
+        if: ${{ matrix.dependencies == 'dev' }}
+        run: >
+          composer require --no-update --no-scripts --no-interaction
+          squizlabs/php_codesniffer:"${{ env.PHPCS_DEV }}"
+          phpcsstandards/phpcsutils:"${{ env.UTILS_DEV }}"
+          phpcsstandards/phpcsextra:"${{ env.EXTRA_DEV }}"
 
       - name: Install Composer dependencies
         uses: ramsey/composer-install@v2
@@ -91,12 +118,16 @@ jobs:
           # Bust the cache at least once a month - output format: YYYY-MM.
           custom-cache-suffix: $(date -u "+%Y-%m")
 
-      - name: "Set PHPCS version (lowest)"
-        if: ${{ matrix.phpcs_version == 'lowest' }}
-        run: composer update squizlabs/php_codesniffer --prefer-lowest --ignore-platform-req=php+ --no-scripts --no-interaction
+      - name: "Composer: downgrade PHPCS dependencies for tests (lowest)"
+        if: ${{ ! startsWith( matrix.php, '8' ) && matrix.dependencies == 'lowest' }}
+        run: >
+          composer update --prefer-lowest --no-scripts --no-interaction
+          squizlabs/php_codesniffer
+          phpcsstandards/phpcsutils
+          phpcsstandards/phpcsextra
 
       - name: Lint PHP files against parse errors
-        if: ${{ matrix.phpcs_version == 'dev-master' }}
+        if: ${{ matrix.dependencies == 'stable' }}
         run: composer lint -- --checkstyle | cs2pr
 
       - name: Run the unit tests without code coverage

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [ '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '8.0', '8.1', '8.2', '8.3' ]
+        php: [ '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '8.0', '8.1', '8.2', '8.3', '8.4' ]
         phpcs_version: [ 'lowest', 'dev-master' ]
         extensions: [ '' ]
         coverage: [false]
@@ -57,7 +57,7 @@ jobs:
 
     name: PHP ${{ matrix.php }} on PHPCS ${{ matrix.phpcs_version }}
 
-    continue-on-error: ${{ matrix.php == '8.3' }}
+    continue-on-error: ${{ matrix.php == '8.4' }}
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -61,7 +61,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # On stable PHPCS versions, allow for PHP deprecation notices.
       # Unit tests don't need to fail on those for stable releases where those issues won't get fixed anymore.

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -113,7 +113,7 @@ jobs:
           phpcsstandards/phpcsextra:"${{ env.EXTRA_DEV }}"
 
       - name: Install Composer dependencies
-        uses: ramsey/composer-install@v2
+        uses: ramsey/composer-install@v3
         with:
           # Bust the cache at least once a month - output format: YYYY-MM.
           custom-cache-suffix: $(date -u "+%Y-%m")

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ phpunit.xml
 phpcs.xml
 .phpcs.xml
 phpstan.neon
+.phpunit.result.cache

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -1,12 +1,12 @@
 <?xml version="1.0"?>
-<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="WordPress Coding Standards" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/squizlabs/PHP_CodeSniffer/master/phpcs.xsd">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="WordPress Coding Standards" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
 
 	<description>The Coding standard for the WordPress Coding Standards itself.</description>
 
 	<!--
 	#############################################################################
 	COMMAND LINE ARGUMENTS
-	https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-Ruleset
+	https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Annotated-Ruleset
 	#############################################################################
 	-->
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,7 +97,7 @@ In all cases, please read the complete changelog carefully before you upgrade.
 - The `sanitize_url()` and `wp_kses_one_attr()` functions to the list of known "sanitizing" functions.
 - Metrics for blank lines at the start/end of a control structure body to the `WordPress.WhiteSpace.ControlStructureSpacing` sniff. These can be displayed using `--report=info` when the `blank_line_check` property has been set to `true`.
 - End-user documentation to the following new and pre-existing sniffs: `WordPress.DateTime.RestrictedFunctions`, `WordPress.NamingConventions.PrefixAllGlobals` (props [@Ipstenu]), `WordPress.PHP.StrictInArray` (props [@marconmartins]), `WordPress.PHP.YodaConditions` (props [@Ipstenu]), `WordPress.WhiteSpace.ControlStructureSpacing` (props [@ckanitz]), `WordPress.WhiteSpace.ObjectOperatorSpacing`, `WordPress.WhiteSpace.OperatorSpacing` (props [@ckanitz]), `WordPress.WP.CapitalPDangit` (props [@NielsdeBlaauw]), `WordPress.WP.Capabilities`, `WordPress.WP.ClassNameCase`, `WordPress.WP.EnqueueResourceParameters` (props [@NielsdeBlaauw]).
-    This documentation can be exposed via the [`PHP_CodeSniffer` `--generator=...` command-line argument](https://github.com/squizlabs/PHP_CodeSniffer/wiki/Usage).
+    This documentation can be exposed via the [`PHP_CodeSniffer` `--generator=...` command-line argument](https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Usage).
     Note: all sniffs which have been added from PHPCSExtra (Universal, Modernize, NormalizedArrays sniffs) are also fully documented.
 
 #### Added (internal/dev-only)
@@ -454,7 +454,7 @@ The move does not affect the package name for Packagist. This remains the same: 
 - `Sniff::get_list_variables()` utility method which will retrieve an array with the token pointers to the variables which are being assigned to in a `list()` construct. Includes support for short lists.
 - `Sniff::is_function_deprecated()` static utility method to determine whether a declared function has been marked as deprecated in the function DocBlock.
 - End-user documentation to the following existing sniffs: `WordPress.Arrays.ArrayIndentation`, `WordPress.Arrays.ArrayKeySpacingRestrictions`, `WordPress.Arrays.MultipleStatementAlignment`, `WordPress.Classes.ClassInstantiation`, `WordPress.NamingConventions.ValidHookName`, `WordPress.PHP.IniSet`, `WordPress.Security.SafeRedirect`, `WordPress.WhiteSpace.CastStructureSpacing`, `WordPress.WhiteSpace.DisallowInlineTabs`, `WordPress.WhiteSpace.PrecisionAlignment`, `WordPress.WP.CronInterval`, `WordPress.WP.DeprecatedClasses`, `WordPress.WP.DeprecatedFunctions`, `WordPress.WP.DeprecatedParameters`, `WordPress.WP.DeprecatedParameterValues`, `WordPress.WP.EnqueuedResources`, `WordPress.WP.PostsPerPage`.
-    This documentation can be exposed via the [`PHP_CodeSniffer` `--generator=...` command-line argument](https://github.com/squizlabs/PHP_CodeSniffer/wiki/Usage).
+    This documentation can be exposed via the [`PHP_CodeSniffer` `--generator=...` command-line argument](https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Usage).
 
 ### Changed
 - The default value for `minimum_supported_wp_version`, as used by a [number of sniffs detecting usage of deprecated WP features](https://github.com/WordPress/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#minimum-wp-version-to-check-for-usage-of-deprecated-functions-classes-and-function-parameters), has been updated to `5.0`.
@@ -661,7 +661,7 @@ If you are a maintainer of an external standard based on WordPressCS and any of 
 - `WordPress.NamingConventions.ValidVariableName`: Added unit tests confirming support for multi-variable/property declarations.
 - The `get_name_suggestion()` method has been moved from the `WordPress.NamingConventions.ValidFunctionName` sniff to the base `Sniff` class, renamed to `get_snake_case_name_suggestion()` and made static.
 - The rulesets are now validated against the `PHP_CodeSniffer` XSD schema.
-- Updated the [custom ruleset example](https://github.com/WordPress/WordPress-Coding-Standards/blob/develop/phpcs.xml.dist.sample) to use the recommended ruleset syntax for `PHP_CodeSniffer` 3.3.1+, including using the new [array property format](https://github.com/squizlabs/PHP_CodeSniffer/releases/tag/3.3.0) which is now supported.
+- Updated the [custom ruleset example](https://github.com/WordPress/WordPress-Coding-Standards/blob/develop/phpcs.xml.dist.sample) to use the recommended ruleset syntax for `PHP_CodeSniffer` 3.3.1+, including using the new [array property format](https://github.com/PHPCSStandards/PHP_CodeSniffer/releases/tag/3.3.0) which is now supported.
 - Dev: The command to run the unit tests has changed. Please see the updated instructions in the [CONTRIBUTING.md](https://github.com/WordPress/WordPress-Coding-Standards/blob/develop/.github/CONTRIBUTING.md) file.
     The `bin/pre-commit` example git hook has been updated to match. Additionally a `run-tests` script has been added to the `composer.json` file for your convenience.
 	To facilitate this, PHPUnit has been added to `require-dev`, even though it is strictly speaking a dependency of PHPCS, not of WPCS.
@@ -672,7 +672,7 @@ If you are a maintainer of an external standard based on WordPressCS and any of 
 ### Deprecated
 - The use of the [WordPressCS native whitelist comments](https://github.com/WordPress/WordPress-Coding-Standards/wiki/Whitelisting-code-which-flags-errors), which were introduced in WPCS 0.4.0, have been deprecated and support will be removed in WPCS 3.0.0.
     The WordPressCS native whitelist comments will continue to work for now, but a deprecation warning will be thrown when they are encountered.
-    You are encouraged to upgrade our whitelist comment to use the [PHPCS native selective ignore annotations](https://github.com/squizlabs/PHP_CodeSniffer/releases/tag/3.2.0) as introduced in `PHP_CodeSniffer` 3.2.0, as soon as possible.
+    You are encouraged to upgrade our whitelist comment to use the [PHPCS native selective ignore annotations](https://github.com/PHPCSStandards/PHP_CodeSniffer/releases/tag/3.2.0) as introduced in `PHP_CodeSniffer` 3.2.0, as soon as possible.
 
 ### Removed
 - Support for PHP 5.3. PHP 5.4 is the minimum requirement for `PHP_CodeSniffer` 3.x.
@@ -684,7 +684,7 @@ If you are a maintainer of an external standard based on WordPressCS and any of 
 - Support for array properties set in a custom ruleset without the `type="array"` attribute.
     Support for this was deprecated in WPCS 1.0.0.
     If in doubt about how properties should be set in your custom ruleset, please refer to the [Customizable sniff properties](https://github.com/WordPress/WordPress-Coding-Standards/wiki/Customizable-sniff-properties) wiki page which contains XML code examples for setting each and every WPCS native sniff property.
-    As the minimum `PHP_CodeSniffer` version is now 3.3.1, you can now also use the [new format for setting array properties](https://github.com/squizlabs/PHP_CodeSniffer/releases/tag/3.3.0), so this would be a great moment to review and update your custom ruleset.
+    As the minimum `PHP_CodeSniffer` version is now 3.3.1, you can now also use the [new format for setting array properties](https://github.com/PHPCSStandards/PHP_CodeSniffer/releases/tag/3.3.0), so this would be a great moment to review and update your custom ruleset.
     Note: the ability to set select properties from the command-line as comma-delimited strings is _not_ affected by this change.
 - The following sniffs have been removed outright without deprecation.
     If you are referencing these sniffs in a ruleset XML file or in inline annotations, please update these to reference the replacement sniffs instead.
@@ -985,10 +985,10 @@ If you are a maintainer of an external standard based on WPCS and any of your cu
 
 ### Fixed
 - Compatibility with PHP 7.3. A change in PHP 7.3 was causing the `WordPress.DB.RestrictedClasses`, `WordPress.DB.RestrictedFunctions` and the `WordPress.WP.AlternativeFunctions` sniffs to fail to correctly detect issues.
-- Compatibility with the latest releases from [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer).
+- Compatibility with the latest releases from [PHP_CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer).
     PHPCS 3.2.0 introduced new annotations which can be used inline to selectively disable/ignore certain sniffs.
     **Note**: The initial implementation of the new annotations was buggy. If you intend to start using these new style annotations, you are strongly advised to use PHPCS 3.3.0 or higher.
-    For more information about these annotations, please refer to the [PHPCS Wiki](https://github.com/squizlabs/PHP_CodeSniffer/wiki/Advanced-Usage#ignoring-parts-of-a-file).
+    For more information about these annotations, please refer to the [PHPCS Wiki](https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Advanced-Usage#ignoring-parts-of-a-file).
     - The [WPCS native whitelist comments](https://github.com/WordPress/WordPress-Coding-Standards/wiki/Whitelisting-code-which-flags-errors) can now be combined with the new style PHPCS whitelist annotations in the `-- for reasons` part of the annotation.
     - `WordPress.Arrays.ArrayDeclarationSpacing`: the fixer will now handle the new style annotations correctly.
     - `WordPress.Arrays.CommaAfterArrayItem`: prevent a fixer loop when new style annotations are encountered.
@@ -1221,7 +1221,7 @@ If you exclude some sniffs or error codes, you may have to update your custom ru
 
 Additionally, to make it easier for you to customize your ruleset, two new wiki pages have been published with information on the properties you can adjust from your ruleset:
 * [WPCS customizable sniff properties](https://github.com/WordPress/WordPress-Coding-Standards/wiki/Customizable-sniff-properties)
-* [PHPCS customizable sniff properties](https://github.com/squizlabs/PHP_CodeSniffer/wiki/Customisable-Sniff-Properties)
+* [PHPCS customizable sniff properties](https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Customisable-Sniff-Properties)
 
 For more detailed information about the changed sniff names and error codes, please refer to PR [#633](https://github.com/WordPress/WordPress-Coding-Standards/pull/633) and PR [#814](https://github.com/WordPress/WordPress-Coding-Standards/pull/814).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,36 @@ This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a 
 
 _No documentation available about unreleased changes as of yet._
 
+## [3.1.0] - 2024-03-25
+
+### Added
+- WordPress-Core ruleset: now includes the `Universal.PHP.LowercasePHPTag` sniff.
+- WordPress-Extra ruleset: now includes the `Generic.CodeAnalysis.RequireExplicitBooleanOperatorPrecedence` and the `Universal.CodeAnalysis.NoDoubleNegative` sniffs.
+- The `sanitize_locale_name()` function to the list of known "escaping" functions. Props [@Chouby]
+- The `sanitize_locale_name()` function to the list of known "sanitize & unslash" functions. Props [@Chouby]
+
+### Changed
+
+- The minimum required `PHP_CodeSniffer` version to 3.9.0 (was 3.7.2).
+- The minimum required `PHPCSUtils` version to 1.0.10 (was 1.0.8).
+- The minimum required `PHPCSExtra` version to 1.2.1 (was 1.1.0).
+    Please ensure you run `composer update wp-coding-standards/wpcs --with-dependencies` to benefit from these updates.
+- Core ruleset: the spacing after the `use` keyword for closure `use` statements will now consistently be checked. Props [@westonruter] for reporting.
+- The default value for `minimum_wp_version`, as used by a [number of sniffs detecting usage of deprecated WP features](https://github.com/WordPress/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#various-sniffs-set-the-minimum-supported-wp-version), has been updated to `6.2`.
+- `WordPress.NamingConventions.PrefixAllGlobals` has been updated to recognize pluggable functions introduced in WP 6.4 and 6.5.
+- `WordPress.NamingConventions.ValidPostTypeSlug` has been updated to recognize reserved post types introduced in WP 6.4 and 6.5.
+- `WordPress.WP.ClassNameCase` has been updated to recognize classes introduced in WP 6.4 and 6.5.
+- `WordPress.WP.DeprecatedClasses` now detects classes deprecated in WordPress up to WP 6.5.
+- `WordPress.WP.DeprecatedFunctions` now detects functions deprecated in WordPress up to WP 6.5.
+- The `IsUnitTestTrait` will now recognize classes which extend the new WP Core `WP_Font_Face_UnitTestCase` class as test classes.
+- The test suite can now run on PHPUnit 4.x - 9.x (was 4.x - 7.x), which should make contributing more straight forward.
+- Various housekeeping, includes a contribution from [@rodrigoprimo].
+
+### Fixed
+
+- `WordPress.WP.PostsPerPage` could potentially result in an `Internal.Exception` when encountering a query string which doesn't include the value for `posts_per_page` in the query string. Props [@anomiex] for reporting.
+
+
 ## [3.0.1] - 2023-09-14
 
 ### Added
@@ -1571,8 +1601,10 @@ See the comparison for full list.
 Initial tagged release.
 
 [Composer PHPCS plugin]: https://github.com/PHPCSStandards/composer-installer
+[PHP_CodeSniffer]:       https://github.com/PHPCSStandards/PHP_CodeSniffer
 
 [Unreleased]: https://github.com/WordPress/WordPress-Coding-Standards/compare/main...HEAD
+[3.1.0]: https://github.com/WordPress/WordPress-Coding-Standards/compare/3.0.1...3.1.0
 [3.0.1]: https://github.com/WordPress/WordPress-Coding-Standards/compare/3.0.0...3.0.1
 [3.0.0]: https://github.com/WordPress/WordPress-Coding-Standards/compare/2.3.0...3.0.0
 [2.3.0]: https://github.com/WordPress/WordPress-Coding-Standards/compare/2.2.1...2.3.0
@@ -1604,6 +1636,7 @@ Initial tagged release.
 [2013-10-06]: https://github.com/WordPress/WordPress-Coding-Standards/compare/2013-06-11...2013-10-06
 
 [@anomiex]:       https://github.com/anomiex
+[@Chouby]:        https://github.com/Chouby
 [@ckanitz]:       https://github.com/ckanitz
 [@craigfrancis]:  https://github.com/craigfrancis
 [@dawidurbanski]: https://github.com/dawidurbanski
@@ -1615,5 +1648,7 @@ Initial tagged release.
 [@Luc45]:         https://github.com/Luc45
 [@marconmartins]: https://github.com/marconmartins
 [@NielsdeBlaauw]: https://github.com/NielsdeBlaauw
+[@rodrigoprimo]:  https://github.com/rodrigoprimo
 [@slaFFik]:       https://github.com/slaFFik
 [@sandeshjangam]: https://github.com/sandeshjangam
+[@westonruter]:   https://github.com/westonruter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a 
 
 _No documentation available about unreleased changes as of yet._
 
-## [3.0.1] - 2023-09-13
+## [3.0.1] - 2023-09-14
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@
 
 ## Introduction
 
-This project is a collection of [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) rules (sniffs) to validate code developed for WordPress. It ensures code quality and adherence to coding conventions, especially the official [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
+This project is a collection of [PHP_CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer) rules (sniffs) to validate code developed for WordPress. It ensures code quality and adherence to coding conventions, especially the official [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
 
 This project needs funding. [Find out how you can help](#funding).
 
@@ -133,7 +133,7 @@ If you need to further customize the selection of sniffs for your project - you 
 
 When you name this file either `.phpcs.xml`, `phpcs.xml`, `.phpcs.xml.dist` or `phpcs.xml.dist`, PHP_CodeSniffer will automatically locate it as long as it is placed in the directory from which you run the CodeSniffer or in a directory above it. If you follow these naming conventions you don't have to supply a `--standard` CLI argument.
 
-For more info, read about [using a default configuration file](https://github.com/squizlabs/PHP_CodeSniffer/wiki/Advanced-Usage#using-a-default-configuration-file). See also the provided WordPressCS [`phpcs.xml.dist.sample`](phpcs.xml.dist.sample) file and the [fully annotated example ruleset](https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml) in the PHP_CodeSniffer documentation.
+For more info, read about [using a default configuration file](https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Advanced-Usage#using-a-default-configuration-file). See also the provided WordPressCS [`phpcs.xml.dist.sample`](phpcs.xml.dist.sample) file and the [fully annotated example ruleset](https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Annotated-ruleset.xml) in the PHP_CodeSniffer documentation.
 
 ### Customizing sniff behaviour
 
@@ -143,7 +143,7 @@ You can find a complete list of all the properties you can change for the WordPr
 
 WordPressCS also uses sniffs from PHPCSExtra and from PHP_CodeSniffer itself.
 The [README for PHPCSExtra](https://github.com/PHPCSStandards/PHPCSExtra) contains information on the properties which can be set for the sniff from PHPCSExtra.
-Information on custom properties which can be set for sniffs from PHP_CodeSniffer can be found in the [PHP_CodeSniffer wiki](https://github.com/squizlabs/PHP_CodeSniffer/wiki/Customisable-Sniff-Properties).
+Information on custom properties which can be set for sniffs from PHP_CodeSniffer can be found in the [PHP_CodeSniffer wiki](https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Customisable-Sniff-Properties).
 
 
 ### Recommended additional rulesets

--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ See [CONTRIBUTING](.github/CONTRIBUTING.md), including information about [unit t
 
 ## Funding
 
-If you want to sponsor the work on WordPressCS, you can do so by donating to the [WP PHP Open Collective](https://opencollective.com//thewpcc/contribute/wp-php-63406).
+If you want to sponsor the work on WordPressCS, you can do so by donating to the [PHP_CodeSniffer Open Collective](https://opencollective.com/php_codesniffer).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ The WordPress Coding Standards package requires:
 * [Composer](https://getcomposer.org/)
 
 For the best results, it is recommended to also ensure the following additional PHP extensions are enabled:
-    - [iconv](https://www.php.net/book.iconv)
-    - [Multibyte String](https://www.php.net/book.mbstring)
+- [iconv](https://www.php.net/book.iconv)
+- [Multibyte String](https://www.php.net/book.mbstring)
 
 ## Installation
 

--- a/Tests/RulesetCheck/class-ruleset-test.inc
+++ b/Tests/RulesetCheck/class-ruleset-test.inc
@@ -64,7 +64,7 @@ class Ruleset_Test {
 			if ( preg_match( '`' . preg_quote( $param_a, '`' ) . '`i', $param_b ) === 1 ) {
 				echo esc_html( "doublequoted $string" );
 			} elseif ( $this->a ) {
-				$ab = $a % $b + $c / $d && $param_a || $param_b >> $bitshift;
+				$ab = $a % $b + $c / $d && ( $param_a || $param_b >> $bitshift );
 			}
 		};
 

--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -218,10 +218,6 @@
 	<rule ref="Squiz.Functions.MultiLineFunctionDeclaration.BraceIndent">
 		<severity>0</severity>
 	</rule>
-	<!-- Prevent duplicate message. This is already checked by the Generic.WhiteSpace.LanguageConstructSpacing sniff. -->
-	<rule ref="Squiz.Functions.MultiLineFunctionDeclaration.SpaceAfterUse">
-		<severity>0</severity>
-	</rule>
 
 	<rule ref="Squiz.Functions.FunctionDeclarationArgumentSpacing">
 		<properties>

--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -869,6 +869,9 @@
 	<!-- Important to prevent issues with content being sent before headers. -->
 	<rule ref="Generic.Files.ByteOrderMark"/>
 
+	<!-- Always have a lowertag PHP open tag. -->
+	<rule ref="Universal.PHP.LowercasePHPTag"/>
+
 	<!-- All line endings should be \n. -->
 	<rule ref="Generic.Files.LineEndings">
 		<properties>

--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="WordPress Core" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/squizlabs/PHP_CodeSniffer/master/phpcs.xsd">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="WordPress Core" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
 
 	<description>Non-controversial generally-agreed upon WordPress Coding Standards</description>
 

--- a/WordPress-Docs/ruleset.xml
+++ b/WordPress-Docs/ruleset.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="WordPress Docs" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/squizlabs/PHP_CodeSniffer/master/phpcs.xsd">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="WordPress Docs" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
 
 	<description>WordPress Coding Standards for Inline Documentation and Comments</description>
 

--- a/WordPress-Extra/ruleset.xml
+++ b/WordPress-Extra/ruleset.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="WordPress Extra" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/squizlabs/PHP_CodeSniffer/master/phpcs.xsd">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="WordPress Extra" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
 
 	<description>Best practices beyond core WordPress Coding Standards</description>
 

--- a/WordPress-Extra/ruleset.xml
+++ b/WordPress-Extra/ruleset.xml
@@ -42,7 +42,7 @@
 	<rule ref="Squiz.PHP.DisallowSizeFunctionsInLoops"/>
 
 	<!-- Check that functions use all parameters passed.
-		 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/pull/xxx -->
+		 https://github.com/WordPress/WordPress-Coding-Standards/issues/1510 -->
 	<rule ref="Generic.CodeAnalysis.UnusedFunctionParameter">
 		<!-- Allow for callback functions which may not need all parameters passed. -->
 		<exclude name="Generic.CodeAnalysis.UnusedFunctionParameter.FoundBeforeLastUsed"/>

--- a/WordPress-Extra/ruleset.xml
+++ b/WordPress-Extra/ruleset.xml
@@ -41,6 +41,10 @@
 		 https://github.com/WordPress/WordPress-Coding-Standards/pull/809 -->
 	<rule ref="Squiz.PHP.DisallowSizeFunctionsInLoops"/>
 
+	<!-- Do not allow ambiguous conditions.
+		 https://github.com/WordPress/WordPress-Coding-Standards/issues/2429 -->
+	<rule ref="Generic.CodeAnalysis.RequireExplicitBooleanOperatorPrecedence"/>
+
 	<!-- Check that functions use all parameters passed.
 		 https://github.com/WordPress/WordPress-Coding-Standards/issues/1510 -->
 	<rule ref="Generic.CodeAnalysis.UnusedFunctionParameter">

--- a/WordPress-Extra/ruleset.xml
+++ b/WordPress-Extra/ruleset.xml
@@ -180,6 +180,9 @@
 	<!-- Detect useless "echo sprintf(...)". -->
 	<rule ref="Universal.CodeAnalysis.NoEchoSprintf"/>
 
+	<!-- Detect use of double negative `!!`. -->
+	<rule ref="Universal.CodeAnalysis.NoDoubleNegative"/>
+
 	<!--
 	#############################################################################
 	Code style sniffs for more recent PHP features and syntaxes.

--- a/WordPress/Helpers/EscapingFunctionsTrait.php
+++ b/WordPress/Helpers/EscapingFunctionsTrait.php
@@ -84,6 +84,7 @@ trait EscapingFunctionsTrait {
 		'sanitize_hex_color_no_hash' => true,
 		'sanitize_html_class'        => true,
 		'sanitize_key'               => true,
+		'sanitize_locale_name'       => true,
 		'sanitize_user_field'        => true,
 		'tag_escape'                 => true,
 		'urlencode_deep'             => true,

--- a/WordPress/Helpers/IsUnitTestTrait.php
+++ b/WordPress/Helpers/IsUnitTestTrait.php
@@ -87,6 +87,7 @@ trait IsUnitTestTrait {
 		// Domain specific base test cases.
 		'WP_Ajax_UnitTestCase'                       => true,
 		'WP_Canonical_UnitTestCase'                  => true,
+		'WP_Font_Face_UnitTestCase'                  => true,
 		'WP_Test_REST_Controller_Testcase'           => true,
 		'WP_Test_REST_Post_Type_Controller_Testcase' => true,
 		'WP_Test_REST_TestCase'                      => true,

--- a/WordPress/Helpers/MinimumWPVersionTrait.php
+++ b/WordPress/Helpers/MinimumWPVersionTrait.php
@@ -79,7 +79,7 @@ trait MinimumWPVersionTrait {
 	 *
 	 * @var string WordPress version.
 	 */
-	private $default_minimum_wp_version = '6.0';
+	private $default_minimum_wp_version = '6.2';
 
 	/**
 	 * Overrule the minimum supported WordPress version with a command-line/config value.

--- a/WordPress/Helpers/SanitizationHelperTrait.php
+++ b/WordPress/Helpers/SanitizationHelperTrait.php
@@ -137,14 +137,15 @@ trait SanitizationHelperTrait {
 	 * @var array<string, bool>
 	 */
 	private $unslashingSanitizingFunctions = array(
-		'absint'       => true,
-		'boolval'      => true,
-		'count'        => true,
-		'doubleval'    => true,
-		'floatval'     => true,
-		'intval'       => true,
-		'sanitize_key' => true,
-		'sizeof'       => true,
+		'absint'               => true,
+		'boolval'              => true,
+		'count'                => true,
+		'doubleval'            => true,
+		'floatval'             => true,
+		'intval'               => true,
+		'sanitize_key'         => true,
+		'sanitize_locale_name' => true,
+		'sizeof'               => true,
 	);
 
 	/**

--- a/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
+++ b/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
@@ -147,7 +147,7 @@ final class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 	 * Only overrulable constants are listed, i.e. those defined within core within
 	 * a `if ( ! defined() ) {}` wrapper.
 	 *
-	 * Last update: July 2023 for WP 6.3 at https://github.com/WordPress/wordpress-develop/commit/6281ce432c50345a57768bf53854d9b65b6cdd52
+	 * {@internal To be updated after every major release. Last updated for WordPress 6.5-RC3.}
 	 *
 	 * @since 1.0.0
 	 * @since 3.0.0 Renamed from `$whitelisted_core_constants` to `$allowed_core_constants`.
@@ -201,6 +201,8 @@ final class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 	 *
 	 * Note: deprecated functions should still be included in this list as plugins may support older WP versions.
 	 *
+	 * {@internal To be updated after every major release. Last updated for WordPress 6.5-RC3.}
+	 *
 	 * @since 3.0.0.
 	 *
 	 * @var array<string, true> Key is function name, value irrelevant.
@@ -236,6 +238,7 @@ final class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 		'twentyeleven_comment'                           => true,
 		'twentyeleven_content_nav'                       => true,
 		'twentyeleven_continue_reading_link'             => true,
+		'twentyeleven_header_image'                      => true,
 		'twentyeleven_header_style'                      => true,
 		'twentyeleven_posted_on'                         => true,
 		'twentyeleven_setup'                             => true,
@@ -255,6 +258,7 @@ final class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 		'twentyfourteen_admin_header_style'              => true,
 		'twentyfourteen_excerpt_more'                    => true,
 		'twentyfourteen_font_url'                        => true,
+		'twentyfourteen_header_image'                    => true,
 		'twentyfourteen_header_style'                    => true,
 		'twentyfourteen_list_authors'                    => true,
 		'twentyfourteen_paging_nav'                      => true,
@@ -296,6 +300,7 @@ final class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 		'twentyten_admin_header_style'                   => true,
 		'twentyten_comment'                              => true,
 		'twentyten_continue_reading_link'                => true,
+		'twentyten_header_image'                         => true,
 		'twentyten_posted_in'                            => true,
 		'twentyten_posted_on'                            => true,
 		'twentyten_setup'                                => true,
@@ -317,6 +322,9 @@ final class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 		'twentytwenty_get_customizer_css'                => true,
 		'twentytwenty_get_theme_svg'                     => true,
 		'twentytwenty_the_theme_svg'                     => true,
+		'twentytwentyfour_block_styles'                  => true,
+		'twentytwentyfour_block_stylesheets'             => true,
+		'twentytwentyfour_pattern_categories'            => true,
 		'twentytwentytwo_styles'                         => true,
 		'twentytwentytwo_support'                        => true,
 		'wp_authenticate'                                => true,
@@ -373,6 +381,8 @@ final class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 	 * and {@link https://core.trac.wordpress.org/browser/trunk/src/wp-includes/pluggable-deprecated.php}
 	 *
 	 * Note: deprecated classes should still be included in this list as plugins may support older WP versions.
+	 *
+	 * {@internal To be updated after every major release. Last updated for WordPress 6.5-RC3.}
 	 *
 	 * @since 3.0.0.
 	 *

--- a/WordPress/Sniffs/NamingConventions/ValidPostTypeSlugSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidPostTypeSlugSniff.php
@@ -63,7 +63,7 @@ final class ValidPostTypeSlugSniff extends AbstractFunctionParameterSniff {
 	 *
 	 * Source: {@link https://developer.wordpress.org/reference/functions/register_post_type/#reserved-post-types}
 	 *
-	 * Last update: July 2023 for WP 6.3 at https://github.com/WordPress/wordpress-develop/commit/6281ce432c50345a57768bf53854d9b65b6cdd52
+	 * {@internal To be updated after every major release. Last updated for WordPress 6.5-RC3.}
 	 *
 	 * @since 2.2.0
 	 *
@@ -84,6 +84,8 @@ final class ValidPostTypeSlugSniff extends AbstractFunctionParameterSniff {
 		'theme'               => true, // Not a WP post type, but prevents other problems.
 		'user_request'        => true,
 		'wp_block'            => true,
+		'wp_font_face'        => true,
+		'wp_font_family'      => true,
 		'wp_global_styles'    => true,
 		'wp_navigation'       => true,
 		'wp_template'         => true,

--- a/WordPress/Sniffs/NamingConventions/ValidVariableNameSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidVariableNameSniff.php
@@ -29,7 +29,7 @@ use WordPressCS\WordPress\Helpers\SnakeCaseHelper;
  * @since 2.0.0  Now offers name suggestions for variables in violation.
  *
  * Last synced with base class January 2022 at commit 4b49a952bf0e2c3863d0a113256bae0d7fe63d52.
- * @link https://github.com/squizlabs/PHP_CodeSniffer/blob/master/src/Standards/Squiz/Sniffs/NamingConventions/ValidVariableNameSniff.php
+ * @link https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/src/Standards/Squiz/Sniffs/NamingConventions/ValidVariableNameSniff.php
  */
 final class ValidVariableNameSniff extends PHPCS_AbstractVariableSniff {
 

--- a/WordPress/Sniffs/Security/EscapeOutputSniff.php
+++ b/WordPress/Sniffs/Security/EscapeOutputSniff.php
@@ -141,7 +141,7 @@ class EscapeOutputSniff extends AbstractFunctionRestrictionsSniff {
 		$this->safe_components += Tokens::$booleanOperators;
 		$this->safe_components += Collections::incrementDecrementOperators();
 
-		// Set up the tokens the sniff should listen too.
+		// Set up the tokens the sniff should listen to.
 		$targets   = array_merge( parent::register(), $this->target_keywords );
 		$targets[] = \T_ECHO;
 		$targets[] = \T_OPEN_TAG_WITH_ECHO;
@@ -157,7 +157,7 @@ class EscapeOutputSniff extends AbstractFunctionRestrictionsSniff {
 	 * @return array
 	 */
 	public function getGroups() {
-		// Make sure all array keys are lowercase (could contain user provided function names).
+		// Make sure all array keys are lowercase (could contain user-provided function names).
 		$printing_functions = array_change_key_case( $this->get_printing_functions(), \CASE_LOWER );
 
 		// Remove the unsafe printing functions to prevent duplicate notices.
@@ -237,7 +237,7 @@ class EscapeOutputSniff extends AbstractFunctionRestrictionsSniff {
 				if ( \T_OPEN_PARENTHESIS !== $this->tokens[ $next_relevant ]['code']
 					|| isset( $this->tokens[ $next_relevant ]['parenthesis_closer'] ) === false
 				) {
-					// Live codind/parse error or a pre-created exception. Nothing to do for us.
+					// Live coding/parse error or a pre-created exception. Nothing to do for us.
 					return;
 				}
 
@@ -470,7 +470,7 @@ class EscapeOutputSniff extends AbstractFunctionRestrictionsSniff {
 				&& $this->tokens[ $next_non_empty ]['parenthesis_closer'] !== $last_non_empty
 			)
 		) {
-			// If there is a (long) ternary skip over the part before the ?.
+			// If there is a (long) ternary, skip over the part before the ?.
 			$ternary = $this->find_long_ternary( $start, $end );
 			if ( false !== $ternary ) {
 				$start = ( $ternary + 1 );
@@ -503,7 +503,7 @@ class EscapeOutputSniff extends AbstractFunctionRestrictionsSniff {
 				}
 
 				if ( $in_cast ) {
-					// Skip to the end of a function call if it has been casted to a safe value.
+					// Skip to the end of a function call if it has been cast to a safe value.
 					$i       = $this->tokens[ $i ]['parenthesis_closer'];
 					$in_cast = false;
 
@@ -625,7 +625,7 @@ class EscapeOutputSniff extends AbstractFunctionRestrictionsSniff {
 			if ( isset( ContextHelper::get_safe_cast_tokens()[ $this->tokens[ $i ]['code'] ] ) ) {
 				/*
 				 * If the next thing is a match expression, skip over it as whatever is
-				 * being returned will be safe casted.
+				 * being returned will be safely cast.
 				 * Do not set `$in_cast` to `true`.
 				 */
 				$next_non_empty = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $i + 1 ), $end, true );
@@ -660,7 +660,7 @@ class EscapeOutputSniff extends AbstractFunctionRestrictionsSniff {
 				continue;
 			}
 
-			// Now check that next token is a function call.
+			// Now check that the next token is a function call.
 			if ( \T_STRING === $this->tokens[ $i ]['code'] ) {
 				$ptr                    = $i;
 				$functionName           = $this->tokens[ $i ]['content'];
@@ -893,7 +893,7 @@ class EscapeOutputSniff extends AbstractFunctionRestrictionsSniff {
 			// Now check that the value returned by this match "leaf" is correctly escaped.
 			$this->check_code_is_escaped( $item_start, $item_end, $code );
 
-			// Independently of whether or not the check was succesfull or ran into (parse error) problems,
+			// Independently of whether or not the check was successful or ran into (parse error) problems,
 			// always skip to the identified end of the item.
 			$current = $item_end;
 		} while ( $current < $end );

--- a/WordPress/Sniffs/WP/ClassNameCaseSniff.php
+++ b/WordPress/Sniffs/WP/ClassNameCaseSniff.php
@@ -25,7 +25,7 @@ final class ClassNameCaseSniff extends AbstractClassRestrictionsSniff {
 	 *
 	 * Note: this list will be enhanced in the class constructor.
 	 *
-	 * {@internal To be updated after every major release. Last updated for WordPress 6.3-RC1.}
+	 * {@internal To be updated after every major release. Last updated for WordPress 6.5-RC3.}
 	 *
 	 * @since 3.0.0
 	 *
@@ -121,6 +121,8 @@ final class ClassNameCaseSniff extends AbstractClassRestrictionsSniff {
 		'WP_Application_Passwords_List_Table',
 		'WP_Automatic_Updater',
 		'WP_Block',
+		'WP_Block_Bindings_Registry',
+		'WP_Block_Bindings_Source',
 		'WP_Block_Editor_Context',
 		'WP_Block_List',
 		'WP_Block_Parser',
@@ -192,10 +194,21 @@ final class ClassNameCaseSniff extends AbstractClassRestrictionsSniff {
 		'WP_Filesystem_FTPext',
 		'WP_Filesystem_SSH2',
 		'WP_Filesystem_ftpsockets',
+		'WP_Font_Collection',
+		'WP_Font_Face',
+		'WP_Font_Face_Resolver',
+		'WP_Font_Library',
+		'WP_Font_Utils',
+		'WP_HTML_Active_Formatting_Elements',
 		'WP_HTML_Attribute_Token',
+		'WP_HTML_Open_Elements',
+		'WP_HTML_Processor',
+		'WP_HTML_Processor_State',
 		'WP_HTML_Span',
 		'WP_HTML_Tag_Processor',
 		'WP_HTML_Text_Replacement',
+		'WP_HTML_Token',
+		'WP_HTML_Unsupported_Exception',
 		'WP_HTTP_Fsockopen',
 		'WP_HTTP_IXR_Client',
 		'WP_HTTP_Proxy',
@@ -212,6 +225,8 @@ final class ClassNameCaseSniff extends AbstractClassRestrictionsSniff {
 		'WP_Image_Editor_GD',
 		'WP_Image_Editor_Imagick',
 		'WP_Importer',
+		'WP_Interactivity_API',
+		'WP_Interactivity_API_Directives_Processor',
 		'WP_Internal_Pointers',
 		'WP_Links_List_Table',
 		'WP_List_Table',
@@ -226,11 +241,13 @@ final class ClassNameCaseSniff extends AbstractClassRestrictionsSniff {
 		'WP_Meta_Query',
 		'WP_Metadata_Lazyloader',
 		'WP_Nav_Menu_Widget',
+		'WP_Navigation_Block_Renderer',
 		'WP_Navigation_Fallback',
 		'WP_Network',
 		'WP_Network_Query',
 		'WP_Object_Cache',
 		'WP_Paused_Extensions_Storage',
+		'WP_Plugin_Dependencies',
 		'WP_Plugin_Install_List_Table',
 		'WP_Plugins_List_Table',
 		'WP_Post',
@@ -257,6 +274,9 @@ final class ClassNameCaseSniff extends AbstractClassRestrictionsSniff {
 		'WP_REST_Comments_Controller',
 		'WP_REST_Controller',
 		'WP_REST_Edit_Site_Export_Controller',
+		'WP_REST_Font_Collections_Controller',
+		'WP_REST_Font_Faces_Controller',
+		'WP_REST_Font_Families_Controller',
 		'WP_REST_Global_Styles_Controller',
 		'WP_REST_Global_Styles_Revisions_Controller',
 		'WP_REST_Menu_Items_Controller',
@@ -282,6 +302,8 @@ final class ClassNameCaseSniff extends AbstractClassRestrictionsSniff {
 		'WP_REST_Sidebars_Controller',
 		'WP_REST_Site_Health_Controller',
 		'WP_REST_Taxonomies_Controller',
+		'WP_REST_Template_Autosaves_Controller',
+		'WP_REST_Template_Revisions_Controller',
 		'WP_REST_Templates_Controller',
 		'WP_REST_Term_Meta_Fields',
 		'WP_REST_Term_Search_Handler',
@@ -301,6 +323,7 @@ final class ClassNameCaseSniff extends AbstractClassRestrictionsSniff {
 		'WP_Role',
 		'WP_Roles',
 		'WP_Screen',
+		'WP_Script_Modules',
 		'WP_Scripts',
 		'WP_Session_Tokens',
 		'WP_Sidebar_Block_Editor_Control',
@@ -341,6 +364,11 @@ final class ClassNameCaseSniff extends AbstractClassRestrictionsSniff {
 		'WP_Theme_JSON_Resolver',
 		'WP_Theme_JSON_Schema',
 		'WP_Themes_List_Table',
+		'WP_Translation_Controller',
+		'WP_Translation_File',
+		'WP_Translation_File_MO',
+		'WP_Translation_File_PHP',
+		'WP_Translations',
 		'WP_Upgrader',
 		'WP_Upgrader_Skin',
 		'WP_User',
@@ -384,7 +412,7 @@ final class ClassNameCaseSniff extends AbstractClassRestrictionsSniff {
 	 *
 	 * Note: this list will be enhanced in the class constructor.
 	 *
-	 * {@internal To be updated after every major release. Last updated for WordPress 6.3-RC1.}
+	 * {@internal To be updated after every major release. Last updated for WordPress 6.5-RC3.}
 	 *
 	 * @since 3.0.0
 	 *
@@ -412,11 +440,33 @@ final class ClassNameCaseSniff extends AbstractClassRestrictionsSniff {
 	);
 
 	/**
-	 * List of all GetID3 classes include in WP Core.
+	 * List of all AVIF classes included in WP Core.
 	 *
 	 * Note: this list will be enhanced in the class constructor.
 	 *
-	 * {@internal To be updated after every major release. Last updated for WordPress 6.3-RC1.}
+	 * {@internal To be updated after every major release. Last updated for WordPress 6.5-RC3.}
+	 *
+	 * @since 3.1.0
+	 *
+	 * @var string[] The class names in their "proper" case.
+	 *               The constructor will add the lowercased class name as a key to each entry.
+	 */
+	private $avif_classes = array(
+		'Avifinfo\\Box',
+		'Avifinfo\\Chan_Prop',
+		'Avifinfo\\Dim_Prop',
+		'Avifinfo\\Features',
+		'Avifinfo\\Parser',
+		'Avifinfo\\Prop',
+		'Avifinfo\\Tile',
+	);
+
+	/**
+	 * List of all GetID3 classes included in WP Core.
+	 *
+	 * Note: this list will be enhanced in the class constructor.
+	 *
+	 * {@internal To be updated after every major release. Last updated for WordPress 6.5-RC3.}
 	 *
 	 * @since 3.0.0
 	 *
@@ -452,7 +502,7 @@ final class ClassNameCaseSniff extends AbstractClassRestrictionsSniff {
 	 *
 	 * Note: this list will be enhanced in the class constructor.
 	 *
-	 * {@internal To be updated after every major release. Last updated for WordPress 6.3-RC1.}
+	 * {@internal To be updated after every major release. Last updated for WordPress 6.5-RC3.}
 	 *
 	 * @since 3.0.0
 	 *
@@ -470,7 +520,7 @@ final class ClassNameCaseSniff extends AbstractClassRestrictionsSniff {
 	 *
 	 * Note: this list will be enhanced in the class constructor.
 	 *
-	 * {@internal To be updated after every major release. Last updated for WordPress 6.3-RC1.}
+	 * {@internal To be updated after every major release. Last updated for WordPress 6.5-RC3.}
 	 *
 	 * @since 3.0.0
 	 *
@@ -614,7 +664,7 @@ final class ClassNameCaseSniff extends AbstractClassRestrictionsSniff {
 	 *
 	 * Note: this list will be enhanced in the class constructor.
 	 *
-	 * {@internal To be updated after every major release. Last updated for WordPress 6.3-RC1.}
+	 * {@internal To be updated after every major release. Last updated for WordPress 6.5-RC3.}
 	 *
 	 * @since 3.0.0
 	 *
@@ -685,6 +735,17 @@ final class ClassNameCaseSniff extends AbstractClassRestrictionsSniff {
 	private $wp_themes_classes_lc = array();
 
 	/**
+	 * List of all AVIF classes in lowercase.
+	 *
+	 * This array is automatically generated in the class constructor based on the $avif_classes property.
+	 *
+	 * @since 3.1.0
+	 *
+	 * @var string[] The class names in lowercase.
+	 */
+	private $avif_classes_lc = array();
+
+	/**
 	 * List of all GetID3 classes in lowercase.
 	 *
 	 * This array is automatically generated in the class constructor based on the $phpmailer_classes property.
@@ -740,6 +801,7 @@ final class ClassNameCaseSniff extends AbstractClassRestrictionsSniff {
 	private $class_groups = array(
 		'wp_classes',
 		'wp_themes_classes',
+		'avif_classes',
 		'getid3_classes',
 		'phpmailer_classes',
 		'requests_classes',

--- a/WordPress/Sniffs/WP/DeprecatedClassesSniff.php
+++ b/WordPress/Sniffs/WP/DeprecatedClassesSniff.php
@@ -41,7 +41,7 @@ final class DeprecatedClassesSniff extends AbstractClassRestrictionsSniff {
 	 *
 	 * Version numbers should be fully qualified.
 	 *
-	 * Last update: July 2023 for WP 6.3 at https://github.com/WordPress/wordpress-develop/commit/6281ce432c50345a57768bf53854d9b65b6cdd52
+	 * {@internal To be updated after every major release. Last updated for WordPress 6.5-RC3.}
 	 *
 	 * @var array
 	 */
@@ -83,6 +83,16 @@ final class DeprecatedClassesSniff extends AbstractClassRestrictionsSniff {
 		'Services_JSON_Error' => array(
 			'alt'     => 'The PHP native JSON extension',
 			'version' => '5.3.0',
+		),
+
+		// WP 6.4.0.
+		'WP_Http_Curl' => array(
+			'alt'     => 'WP_Http',
+			'version' => '6.4.0',
+		),
+		'WP_Http_Streams' => array(
+			'alt'     => 'WP_Http',
+			'version' => '6.4.0',
 		),
 	);
 

--- a/WordPress/Sniffs/WP/DeprecatedFunctionsSniff.php
+++ b/WordPress/Sniffs/WP/DeprecatedFunctionsSniff.php
@@ -37,14 +37,13 @@ final class DeprecatedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 	/**
 	 * List of deprecated functions with alternative when available.
 	 *
-	 * To be updated after every major release.
-	 * Last updated for WordPress 6.3.
-	 *
 	 * Version numbers should be fully qualified.
 	 * Replacement functions should have parentheses.
 	 *
 	 * To retrieve a function list for comparison, the following tool is available:
 	 * https://github.com/JDGrimes/wp-deprecated-code-scanner
+	 *
+	 * {@internal To be updated after every major release. Last updated for WordPress 6.5-RC3.}
 	 *
 	 * @var array
 	 */
@@ -1596,6 +1595,62 @@ final class DeprecatedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 		'wp_tinycolor_string_to_rgb' => array(
 			'alt'     => '',
 			'version' => '6.3.0',
+		),
+
+		// WP 6.4.0.
+		'_admin_bar_bump_cb' => array(
+			'alt'     => 'wp_enqueue_admin_bar_bump_styles()',
+			'version' => '6.4.0',
+		),
+		'_inject_theme_attribute_in_block_template_content' => array(
+			'alt'     => 'traverse_and_serialize_blocks( parse_blocks( $template_content ), \'_inject_theme_attribute_in_template_part_block\' )',
+			'version' => '6.4.0',
+		),
+		'_remove_theme_attribute_in_block_template_content' => array(
+			'alt'     => 'traverse_and_serialize_blocks( parse_blocks( $template_content ), \'_remove_theme_attribute_from_template_part_block\' )',
+			'version' => '6.4.0',
+		),
+		'_wp_theme_json_webfonts_handler' => array(
+			'alt'     => 'wp_print_font_faces()',
+			'version' => '6.4.0',
+		),
+		'print_embed_styles' => array(
+			'alt'     => 'wp_enqueue_embed_styles()',
+			'version' => '6.4.0',
+		),
+		'print_emoji_styles' => array(
+			'alt'     => 'wp_enqueue_emoji_styles()',
+			'version' => '6.4.0',
+		),
+		'the_block_template_skip_link' => array(
+			'alt'     => 'wp_enqueue_block_template_skip_link()',
+			'version' => '6.4.0',
+		),
+		'wp_admin_bar_header' => array(
+			'alt'     => 'wp_enqueue_admin_bar_header_styles()',
+			'version' => '6.4.0',
+		),
+		'wp_img_tag_add_decoding_attr' => array(
+			'alt'     => 'wp_img_tag_add_loading_optimization_attrs()',
+			'version' => '6.4.0',
+		),
+		'wp_update_https_detection_errors' => array(
+			'alt'     => 'wp_get_https_detection_errors()',
+			'version' => '6.4.0',
+		),
+
+		// WP 6.5.0.
+		'block_core_file_ensure_interactivity_dependency' => array(
+			'alt'     => 'wp_register_script_module()',
+			'version' => '6.5.0',
+		),
+		'block_core_image_ensure_interactivity_dependency' => array(
+			'alt'     => 'wp_register_script_module()',
+			'version' => '6.5.0',
+		),
+		'block_core_query_ensure_interactivity_dependency' => array(
+			'alt'     => 'wp_register_script_module()',
+			'version' => '6.5.0',
 		),
 	);
 

--- a/WordPress/Sniffs/WP/PostsPerPageSniff.php
+++ b/WordPress/Sniffs/WP/PostsPerPageSniff.php
@@ -67,6 +67,10 @@ final class PostsPerPageSniff extends AbstractArrayAssignmentRestrictionsSniff {
 	public function callback( $key, $val, $line, $group ) {
 		$stripped_val = TextStrings::stripQuotes( $val );
 
+		if ( '' === $stripped_val ) {
+			return false;
+		}
+
 		if ( $val !== $stripped_val ) {
 			// The value was a text string. For text strings, we only accept purely numeric values.
 			if ( preg_match( '`^[0-9]+$`', $stripped_val ) !== 1 ) {

--- a/WordPress/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
@@ -26,7 +26,7 @@ use WordPressCS\WordPress\Sniff;
  * Last synced with base class 2021-11-20 at commit 7f11ffc8222b123c06345afd3261221561c3bb29.
  * Note: This class has diverged quite far from the original. All the same, checking occasionally
  * to see if there are upstream fixes made from which this sniff can benefit, is warranted.
- * @link https://github.com/squizlabs/PHP_CodeSniffer/blob/master/src/Standards/Squiz/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
+ * @link https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/src/Standards/Squiz/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
  */
 final class ControlStructureSpacingSniff extends Sniff {
 

--- a/WordPress/Sniffs/WhiteSpace/ObjectOperatorSpacingSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/ObjectOperatorSpacingSniff.php
@@ -20,7 +20,7 @@ use PHP_CodeSniffer\Util\Tokens;
  * - When the `::` operator is used in `::class`, no new line(s) before or after the object operator are allowed.
  *
  * @since 3.0.0
- * @link  https://github.com/squizlabs/PHP_CodeSniffer/blob/master/src/Standards/Squiz/Sniffs/WhiteSpace/ObjectOperatorSpacingSniff.php
+ * @link  https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/src/Standards/Squiz/Sniffs/WhiteSpace/ObjectOperatorSpacingSniff.php
  */
 final class ObjectOperatorSpacingSniff extends Squiz_ObjectOperatorSpacingSniff {
 

--- a/WordPress/Sniffs/WhiteSpace/OperatorSpacingSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/OperatorSpacingSniff.php
@@ -31,7 +31,7 @@ use PHP_CodeSniffer\Util\Tokens;
  * @since 0.13.0 Class name changed: this class is now namespaced.
  *
  * Last verified with base class June 2023 at commit 085b1e091b0f2e451333c0bc26dd50bba39402c4.
- * @link https://github.com/squizlabs/PHP_CodeSniffer/blob/master/CodeSniffer/Standards/Squiz/Sniffs/WhiteSpace/OperatorSpacingSniff.php
+ * @link https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/CodeSniffer/Standards/Squiz/Sniffs/WhiteSpace/OperatorSpacingSniff.php
  */
 final class OperatorSpacingSniff extends PHPCS_Squiz_OperatorSpacingSniff {
 

--- a/WordPress/Tests/DB/PreparedSQLPlaceholdersUnitTest.inc
+++ b/WordPress/Tests/DB/PreparedSQLPlaceholdersUnitTest.inc
@@ -343,10 +343,10 @@ $where = $wpdb->prepare(
 ); // OK.
 
 // Disregard comments in the array_fill() $value param.
-$wpdb->prepare( '
-	xxx IN ( ' . implode( ',', array_fill( 0, count( $post_types ), '%i' /*comment*/ ) ) . ' )',
-	$fields
-); // IdentifierWithinIN.
+// Also test handling of %i when minimum supported WP version is not high enough yet.
+// phpcs:set WordPress.DB.PreparedSQLPlaceholders minimum_wp_version 6.0
+$wpdb->prepare( 'xxx IN ( ' . implode( ',', array_fill( 0, count( $post_types ), '%i' /*comment*/ ) ) . ' )', $fields ); // IdentifierWithinIN.
+// phpcs:set WordPress.DB.PreparedSQLPlaceholders minimum_wp_version
 
 $where = $wpdb->prepare(
 	"{$wpdb->posts}.post_type IN ("

--- a/WordPress/Tests/DB/PreparedSQLPlaceholdersUnitTest.php
+++ b/WordPress/Tests/DB/PreparedSQLPlaceholdersUnitTest.php
@@ -101,7 +101,7 @@ final class PreparedSQLPlaceholdersUnitTest extends AbstractSniffUnitTest {
 			315 => 1,
 			322 => 1,
 
-			347 => 2, // UnsupportedIdentifierPlaceholder + IdentifierWithinIN.
+			348 => 2, // UnsupportedIdentifierPlaceholder + IdentifierWithinIN.
 			353 => 1,
 
 			// Named parameter support.

--- a/WordPress/Tests/DB/RestrictedClassesUnitTest.php
+++ b/WordPress/Tests/DB/RestrictedClassesUnitTest.php
@@ -37,7 +37,7 @@ final class RestrictedClassesUnitTest extends AbstractSniffUnitTest {
 	 * @return void
 	 */
 	protected function enhanceGroups() {
-		parent::setUp();
+		parent::setUpPrerequisites();
 
 		AbstractFunctionRestrictionsSniff::$unittest_groups = array(
 			'test' => array(

--- a/WordPress/Tests/DB/SlowDBQueryUnitTest.inc
+++ b/WordPress/Tests/DB/SlowDBQueryUnitTest.inc
@@ -21,3 +21,7 @@ $query = 'foo=bar&meta_key=foo&meta_value=bar';
 if ( ! isset( $widget['params'][0] ) ) {
 	$widget['params'][0] = array();
 }
+
+$query = 'foo=bar&meta_key=&meta_value=bar';
+$query = 'foo=bar&meta_key=foo&meta_value=';
+$query = 'foo=bar&meta_key=&meta_value=';

--- a/WordPress/Tests/DB/SlowDBQueryUnitTest.php
+++ b/WordPress/Tests/DB/SlowDBQueryUnitTest.php
@@ -44,6 +44,9 @@ final class SlowDBQueryUnitTest extends AbstractSniffUnitTest {
 			15 => 1,
 			16 => 1,
 			19 => 2,
+			25 => 2,
+			26 => 2,
+			27 => 2,
 		);
 	}
 }

--- a/WordPress/Tests/WP/DeprecatedClassesUnitTest.inc
+++ b/WordPress/Tests/WP/DeprecatedClassesUnitTest.inc
@@ -23,3 +23,10 @@ $json = new Services_JSON;
 $json = new Services_JSON_Error;
 class Prefix_Menu_section extends WP_Privacy_Data_Export_Requests_Table {}
 WP_Privacy_Data_Removal_Requests_Table::foo();
+
+/*
+ * Warning
+ */
+/* ============ WP 6.4 ============ */
+WP_Http_Curl::do_something();
+$streams = new WP_Http_Streams();

--- a/WordPress/Tests/WP/DeprecatedClassesUnitTest.php
+++ b/WordPress/Tests/WP/DeprecatedClassesUnitTest.php
@@ -43,6 +43,9 @@ final class DeprecatedClassesUnitTest extends AbstractSniffUnitTest {
 	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList() {
-		return array();
+		return array(
+			31 => 1,
+			32 => 1,
+		);
 	}
 }

--- a/WordPress/Tests/WP/DeprecatedFunctionsUnitTest.inc
+++ b/WordPress/Tests/WP/DeprecatedFunctionsUnitTest.inc
@@ -360,10 +360,6 @@ _excerpt_render_inner_columns_blocks();
 readonly();
 /* ============ WP 5.9.1 ============ */
 wp_render_duotone_filter_preset();
-
-/*
- * Warning.
- */
 /* ============ WP 6.0 ============ */
 image_attachment_fields_to_save();
 wp_add_iframed_editor_assets_html();
@@ -384,6 +380,10 @@ install_global_terms();
 sync_category_tag_slugs();
 wp_get_attachment_thumb_file();
 wp_typography_get_css_variable_inline_style();
+
+/*
+ * Warning.
+ */
 /* ============ WP 6.2 ============ */
 _resolve_home_block_template();
 get_page_by_title();
@@ -411,3 +411,18 @@ wp_tinycolor_hsl_to_rgb();
 wp_tinycolor_hue_to_rgb();
 wp_tinycolor_rgb_to_rgb();
 wp_tinycolor_string_to_rgb();
+/* ============ WP 6.4 ============ */
+_admin_bar_bump_cb();
+_inject_theme_attribute_in_block_template_content();
+_remove_theme_attribute_in_block_template_content();
+_wp_theme_json_webfonts_handler();
+print_embed_styles();
+print_emoji_styles();
+the_block_template_skip_link();
+wp_admin_bar_header();
+wp_img_tag_add_decoding_attr();
+wp_update_https_detection_errors();
+/* ============ WP 6.5 ============ */
+block_core_file_ensure_interactivity_dependency();
+block_core_image_ensure_interactivity_dependency();
+block_core_query_ensure_interactivity_dependency();

--- a/WordPress/Tests/WP/DeprecatedFunctionsUnitTest.php
+++ b/WordPress/Tests/WP/DeprecatedFunctionsUnitTest.php
@@ -28,7 +28,7 @@ final class DeprecatedFunctionsUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getErrorList() {
 		$start_line = 8;
-		$end_line   = 362;
+		$end_line   = 382;
 		$errors     = array_fill( $start_line, ( ( $end_line - $start_line ) + 1 ), 1 );
 
 		// Unset the lines related to version comments.
@@ -73,7 +73,11 @@ final class DeprecatedFunctionsUnitTest extends AbstractSniffUnitTest {
 			$errors[353],
 			$errors[357],
 			$errors[359],
-			$errors[361]
+			$errors[361],
+			$errors[363],
+			$errors[369],
+			$errors[371],
+			$errors[373]
 		);
 
 		return $errors;
@@ -85,17 +89,15 @@ final class DeprecatedFunctionsUnitTest extends AbstractSniffUnitTest {
 	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList() {
-		$start_line = 368;
-		$end_line   = 413;
+		$start_line = 388;
+		$end_line   = 428;
 		$warnings   = array_fill( $start_line, ( ( $end_line - $start_line ) + 1 ), 1 );
 
 		// Unset the lines related to version comments.
 		unset(
-			$warnings[373],
-			$warnings[375],
-			$warnings[377],
-			$warnings[387],
-			$warnings[390]
+			$warnings[390],
+			$warnings[414],
+			$warnings[425]
 		);
 
 		return $warnings;

--- a/WordPress/Tests/WP/DeprecatedFunctionsUnitTest.php
+++ b/WordPress/Tests/WP/DeprecatedFunctionsUnitTest.php
@@ -76,11 +76,6 @@ final class DeprecatedFunctionsUnitTest extends AbstractSniffUnitTest {
 			$errors[361]
 		);
 
-		// Temporarily until PHPCS supports PHP 8.2.
-		if ( \PHP_VERSION_ID >= 80200 ) {
-			unset( $errors[360] ); // Function call to readonly.
-		}
-
 		return $errors;
 	}
 

--- a/WordPress/Tests/WP/DeprecatedParametersUnitTest.inc
+++ b/WordPress/Tests/WP/DeprecatedParametersUnitTest.inc
@@ -94,6 +94,6 @@ wp_notify_postauthor( '', 'null' ); // Null as a string not null.
 wp_title_rss( 'deprecated' );
 wp_upload_bits( '', 'deprecated' );
 xfn_check( '', '', 'deprecated' );
+global_terms( $foo, 'deprecated' );
 
 // All will give an WARNING as they have been deprecated after WP 5.8.
-global_terms( $foo, 'deprecated' );

--- a/WordPress/Tests/WP/DeprecatedParametersUnitTest.php
+++ b/WordPress/Tests/WP/DeprecatedParametersUnitTest.php
@@ -28,7 +28,7 @@ final class DeprecatedParametersUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getErrorList() {
 		$start_line = 42;
-		$end_line   = 96;
+		$end_line   = 97;
 		$errors     = array_fill( $start_line, ( ( $end_line - $start_line ) + 1 ), 1 );
 
 		$errors[22] = 1;
@@ -51,10 +51,6 @@ final class DeprecatedParametersUnitTest extends AbstractSniffUnitTest {
 	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList() {
-		$start_line = 99;
-		$end_line   = 99;
-		$errors     = array_fill( $start_line, ( ( $end_line - $start_line ) + 1 ), 1 );
-
-		return $errors;
+		return array();
 	}
 }

--- a/WordPress/Tests/WP/PostsPerPageUnitTest.inc
+++ b/WordPress/Tests/WP/PostsPerPageUnitTest.inc
@@ -124,3 +124,17 @@ $args = array(
 	'posts_per_page' => 75.0, // OK (75).
 	'posts_per_page' => 150.000, // Bad (150).
 );
+
+$query = 'posts_per_page=' . (int) $_POST['limit']; // OK.
+
+$args = array(
+	'posts_per_page' => '', // OK.
+);
+
+_query_posts( 'nopaging=true&posts_per_page=' ); // OK.
+
+$query_args['posts_per_page'] = ''; // OK.
+
+$query_args[
+	'posts_per_page'
+] = ''; // OK.

--- a/WordPress/Tests/WhiteSpace/OperatorSpacingUnitTest.inc
+++ b/WordPress/Tests/WhiteSpace/OperatorSpacingUnitTest.inc
@@ -75,3 +75,7 @@ function fooBar( TypeA&namespace\TypeB $param ) : \TypeC&Partially\Qualified {}
 class Foo {
 	public readonly int|string $prop;
 }
+
+// Safeguard that declare statements are ignored.
+// Ref: https://github.com/PHPCSStandards/PHP_CodeSniffer/pull/289
+declare(ticks=1);

--- a/WordPress/Tests/WhiteSpace/OperatorSpacingUnitTest.inc.fixed
+++ b/WordPress/Tests/WhiteSpace/OperatorSpacingUnitTest.inc.fixed
@@ -75,3 +75,7 @@ function fooBar( TypeA&namespace\TypeB $param ) : \TypeC&Partially\Qualified {}
 class Foo {
 	public readonly int|string $prop;
 }
+
+// Safeguard that declare statements are ignored.
+// Ref: https://github.com/PHPCSStandards/PHP_CodeSniffer/pull/289
+declare(ticks=1);

--- a/WordPress/ruleset.xml
+++ b/WordPress/ruleset.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="WordPress" namespace="WordPressCS\WordPress" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/squizlabs/PHP_CodeSniffer/master/phpcs.xsd">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="WordPress" namespace="WordPressCS\WordPress" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
 
 	<description>WordPress Coding Standards</description>
 

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
 		"ext-tokenizer": "*",
 		"ext-xmlreader": "*",
 		"squizlabs/php_codesniffer": "^3.9.0",
-		"phpcsstandards/phpcsutils": "^1.0.9",
+		"phpcsstandards/phpcsutils": "^1.0.10",
 		"phpcsstandards/phpcsextra": "^1.2.1"
 	},
 	"require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -21,9 +21,9 @@
 		"ext-libxml": "*",
 		"ext-tokenizer": "*",
 		"ext-xmlreader": "*",
-		"squizlabs/php_codesniffer": "^3.7.2",
-		"phpcsstandards/phpcsutils": "^1.0.8",
-		"phpcsstandards/phpcsextra": "^1.2.0"
+		"squizlabs/php_codesniffer": "^3.8.0",
+		"phpcsstandards/phpcsutils": "^1.0.9",
+		"phpcsstandards/phpcsextra": "^1.2.1"
 	},
 	"require-dev": {
 		"phpcompatibility/php-compatibility": "^9.0",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
 		"ext-libxml": "*",
 		"ext-tokenizer": "*",
 		"ext-xmlreader": "*",
-		"squizlabs/php_codesniffer": "^3.8.0",
+		"squizlabs/php_codesniffer": "^3.9.0",
 		"phpcsstandards/phpcsutils": "^1.0.9",
 		"phpcsstandards/phpcsextra": "^1.2.1"
 	},

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
 		"ext-xmlreader": "*",
 		"squizlabs/php_codesniffer": "^3.7.2",
 		"phpcsstandards/phpcsutils": "^1.0.8",
-		"phpcsstandards/phpcsextra": "^1.1.0"
+		"phpcsstandards/phpcsextra": "^1.2.0"
 	},
 	"require-dev": {
 		"phpcompatibility/php-compatibility": "^9.0",

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
 	},
 	"require-dev": {
 		"phpcompatibility/php-compatibility": "^9.0",
-		"phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0",
+		"phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0",
 		"phpcsstandards/phpcsdevtools": "^1.2.0",
 		"php-parallel-lint/php-parallel-lint": "^1.3.2",
 		"php-parallel-lint/php-console-highlighter": "^1.0.0"

--- a/phpcs.xml.dist.sample
+++ b/phpcs.xml.dist.sample
@@ -1,12 +1,12 @@
 <?xml version="1.0"?>
-<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Example Project" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/squizlabs/PHP_CodeSniffer/master/phpcs.xsd">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Example Project" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
 
 	<description>A custom set of rules to check for a WPized WordPress project</description>
 
 	<!--
 	#############################################################################
 	COMMAND LINE ARGUMENTS
-	https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-Ruleset
+	https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Annotated-Ruleset
 	#############################################################################
 	-->
 
@@ -141,7 +141,7 @@
 	legitimate exclusion.
 
 	For more information on ruleset configuration optiones, check out the PHPCS wiki:
-	https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-Ruleset
+	https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Annotated-Ruleset
 	-->
 	<rule ref="WordPress.WP.GlobalVariablesOverride">
 		<exclude-pattern>/path/to/Tests/*Test\.php</exclude-pattern>

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,5 @@
 parameters:
-    #phpVersion: 50400 # Needs to be 70100 or higher... sigh...
+    phpVersion: 70100 # Needs to be 70100 or higher... sigh...
     level: 5
     paths:
         - WordPress

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -11,12 +11,6 @@ parameters:
         # Level 0
         - '#^Result of method \S+ \(void\) is used\.$#'
 
-        -
-            # False positive. Will be fixed via next version of PHPCSUtils.
-            count: 1
-            message: "#^Cannot unset offset 'query' on non-empty-array<int, array<string, int\\|string>>.$#"
-            path: WordPress/Sniffs/DB/PreparedSQLPlaceholdersSniff.php
-
         # Level 4
         - '#^Property \S+::\$\S+ \([^)]+\) in isset\(\) is not nullable\.$#'
         -
@@ -27,12 +21,6 @@ parameters:
             count: 1
             message: '#^Strict comparison using === between true and false will always evaluate to false\.$#'
             path: WordPress/Sniffs/Utils/I18nTextDomainFixerSniff.php
-
-        -
-            # False positive. Will be fixed via next version of PHPCSUtils.
-            count: 1
-            message: "#^Cannot unset offset 'file' on array<int, array<string, int\\|string>>.$#"
-            path: WordPress/Sniffs/Security/EscapeOutputSniff.php
 
         # Level 5
         - '#^Parameter \#3 \$value of method \S+File::recordMetric\(\) expects string, \(?(float|int|bool)(\|(float|int|bool))*\)? given\.$#'

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -11,6 +11,12 @@ parameters:
         # Level 0
         - '#^Result of method \S+ \(void\) is used\.$#'
 
+        -
+            # False positive. Will be fixed via next version of PHPCSUtils.
+            count: 1
+            message: "#^Cannot unset offset 'query' on non-empty-array<int, array<string, int\\|string>>.$#"
+            path: WordPress/Sniffs/DB/PreparedSQLPlaceholdersSniff.php
+
         # Level 4
         - '#^Property \S+::\$\S+ \([^)]+\) in isset\(\) is not nullable\.$#'
         -
@@ -21,6 +27,12 @@ parameters:
             count: 1
             message: '#^Strict comparison using === between true and false will always evaluate to false\.$#'
             path: WordPress/Sniffs/Utils/I18nTextDomainFixerSniff.php
+
+        -
+            # False positive. Will be fixed via next version of PHPCSUtils.
+            count: 1
+            message: "#^Cannot unset offset 'file' on array<int, array<string, int\\|string>>.$#"
+            path: WordPress/Sniffs/Security/EscapeOutputSniff.php
 
         # Level 5
         - '#^Parameter \#3 \$value of method \S+File::recordMetric\(\) expects string, \(?(float|int|bool)(\|(float|int|bool))*\)? given\.$#'

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -4,6 +4,10 @@
 	xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/6.3/phpunit.xsd"
 	backupGlobals="true"
 	bootstrap="./Tests/bootstrap.php"
+	convertErrorsToExceptions="true"
+	convertWarningsToExceptions="true"
+	convertNoticesToExceptions="true"
+	convertDeprecationsToExceptions="true"
 	beStrictAboutTestsThatDoNotTestAnything="false"
 	colors="true"
 	forceCoversAnnotation="true">


### PR DESCRIPTION
:warning: **DO NOT MERGE (YET)** :warning:

**Please **do** add approvals if you agree as otherwise we won't be able to release.**

PR for tracking changes for the 3.1.0 release. Target release date: **Monday March 25, 2024**.

## Release checklist

### General

- [x] Verify, and if necessary, update the allowed version ranges for various dependencies in the `composer.json` - PR #2437
- [x] PHPCS: check if there have been [releases][phpcs-releases] since the last WordPressCS release and check through the changelog to see if there is anything WordPressCS could take advantage of - PR #2429
- [x] PHPCSUtils: check if there have been [releases][phpcsutils-releases] since the last WordPressCS release and update WordPressCS code to take advantage of any new utilities - PR #2437
- [x] PHPCSExtra: check if there have been [releases][phpcsextra-releases] since the last WordPressCS release and check through the changelog to see if there is anything WordPressCS could take advantage of - PR #2409
- [x] Check if the minimum WP version property needs updating in `MinimumWPVersionTrait::$default_minimum_wp_version` and if so, action it - PR #2436
- [x] Check if any of the list based sniffs need updating and if so, action it.
    :pencil2: Make sure the "last updated" annotation in the docblocks for these lists has also been updated!
    List based sniffs:
    - [x] `WordPress.WP.ClassNameCase` - PR #2436
    - [x] `WordPress.WP.DeprecatedClasses` - PR #2436
    - [x] `WordPress.WP.DeprecatedFunctions` - PR #2436
    - [x] `WordPress.WP.DeprecatedParameters` - _N/A_
    - [x] `WordPress.WP.DeprecatedParameterValues` - _N/A_
- [x] Check if any of the other lists containing information about WP Core need updating and if so, action it.
    - [x] `$allowed_core_constants` in `WordPress.NamingConventions.PrefixAllGlobals` -  _N/A_
    - [x] `$pluggable_functions` in `WordPress.NamingConventions.PrefixAllGlobals` - PR #2436
    - [x] `$pluggable_classes` in `WordPress.NamingConventions.PrefixAllGlobals` -  _N/A_
    - [x] `$target_functions` in `WordPress.Security.PluginMenuSlug` -  _N/A_
    - [x] `$reserved_names` in `WordPress.NamingConventions.ValidPostTypeSlug` - PR #2436
    - [x] `$wp_time_constants` in `WordPress.WP.CronInterval` -  _N/A_
    - [x] `$known_test_classes` in `IsUnitTestTrait` - PR #2407
    - [ ] ...etc...

### Release prep

- [x] Add changelog for the release - PR #2438
    :pencil2: Remember to add a release link at the bottom!
- [x] Update `README` (if applicable) - _N/A_
- [x] Update wiki (new customizable properties etc.) (if applicable)

### Release

- [ ] Merge this PR.
- [ ] Make sure all CI builds are green.
- [ ] Tag and create a release against `main` (careful, GH defaults to `develop`!) & copy & paste the changelog to it.
    :pencil2: Check if anything from the link collection at the bottom of the changelog needs to be copied in!
- [ ] Make sure all CI builds are green.
- [ ] Close the milestone.
- [ ] Open a new milestone for the next release.
- [ ] If any open PRs/issues which were milestoned for this release did not make it into the release, update their milestone.
- [ ] Fast-forward `develop` to be equal to `main`.

### After release

- [ ] Open a Trac ticket for WordPress Core to update.

### Publicize

- [ ] Tweet, toot, etc about the release.
- [ ] Post about it in Slack.
- [ ] Submit for ["Month in WordPress"][month-in-wp].
- [ ] Submit for the ["Monthy Dev Roundup"][dev-roundup].

[phpcs-releases]:      https://github.com/PHPCSStandards/PHP_CodeSniffer/releases
[phpcsutils-releases]: https://github.com/PHPCSStandards/PHPCSUtils/releases
[phpcsextra-releases]: https://github.com/PHPCSStandards/PHPCSExtra/releases
[month-in-wp]:         https://make.wordpress.org/community/month-in-wordpress-submissions/
[dev-roundup]:         https://github.com/WordPress/developer-blog-content/issues?q=is%3Aissue+label%3A%22Monthly+Roundup%22


