### PR TITLE
Documentation: capitalization consistency fixes

### DIFF
--- a/WordPress/Docs/Arrays/MultipleStatementAlignmentStandard.xml
+++ b/WordPress/Docs/Arrays/MultipleStatementAlignmentStandard.xml
@@ -9,7 +9,7 @@
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: correct spacing between the key and value.">
+        <code title="Valid: Correct spacing between the key and value.">
         <![CDATA[
 $foo = array( 'cat'<em> => </em>22 );
 $bar = array( 'year'<em> => </em>$current_year );

--- a/WordPress/Docs/DateTime/CurrentTimeTimestampStandard.xml
+++ b/WordPress/Docs/DateTime/CurrentTimeTimestampStandard.xml
@@ -9,24 +9,24 @@
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: using time() to get a Unix (UTC) timestamp.">
+        <code title="Valid: Using time() to get a Unix (UTC) timestamp.">
         <![CDATA[
 $timestamp = <em>time()</em>;
         ]]>
         </code>
-        <code title="Invalid: using current_time() to get a Unix (UTC) timestamp.">
+        <code title="Invalid: Using current_time() to get a Unix (UTC) timestamp.">
         <![CDATA[
 $timestamp = <em>current_time( 'timestamp', true )</em>;
         ]]>
         </code>
     </code_comparison>
     <code_comparison>
-        <code title="Valid: using current_time() with a non-timestamp format.">
+        <code title="Valid: Using current_time() with a non-timestamp format.">
         <![CDATA[
 $timestamp = current_time( <em>'Y-m-d'</em> );
         ]]>
         </code>
-        <code title="Invalid: using current_time() to get a timezone corrected timestamp.">
+        <code title="Invalid: Using current_time() to get a timezone corrected timestamp.">
         <![CDATA[
 $timestamp = <em>current_time( 'U', false )</em>;
         ]]>

--- a/WordPress/Docs/NamingConventions/PrefixAllGlobalsStandard.xml
+++ b/WordPress/Docs/NamingConventions/PrefixAllGlobalsStandard.xml
@@ -29,7 +29,7 @@ apply_filter(
 );
         ]]>
         </code>
-        <code title="Invalid: non-prefixed code.">
+        <code title="Invalid: Non-prefixed code.">
         <![CDATA[
 define( <em>'PLUGIN_VERSION'</em>, '1.0' );
 
@@ -68,7 +68,7 @@ apply_filter(
 );
         ]]>
         </code>
-        <code title="Invalid: using a non-prefixed namespace.">
+        <code title="Invalid: Using a non-prefixed namespace.">
         <![CDATA[
 namespace <em>Admin</em>;
 

--- a/WordPress/Docs/NamingConventions/ValidFunctionNameStandard.xml
+++ b/WordPress/Docs/NamingConventions/ValidFunctionNameStandard.xml
@@ -9,26 +9,26 @@
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: lowercase function name.">
+        <code title="Valid: Lowercase function name.">
         <![CDATA[
 function <em>prefix_function_name()</em> {}
         ]]>
         </code>
-        <code title="Invalid: mixed case function name.">
+        <code title="Invalid: Mixed case function name.">
         <![CDATA[
 function <em>Prefix_Function_NAME()</em> {}
         ]]>
         </code>
     </code_comparison>
     <code_comparison>
-        <code title="Valid: words separated by underscores.">
+        <code title="Valid: Words separated by underscores.">
         <![CDATA[
 class My_Class {
     public static <em>method_name()</em> {}
 }
         ]]>
         </code>
-        <code title="Invalid: using camel case to separate words.">
+        <code title="Invalid: Using camel case to separate words.">
         <![CDATA[
 class My_Class {
     public static <em>methodName()</em> {}

--- a/WordPress/Docs/NamingConventions/ValidHookNameStandard.xml
+++ b/WordPress/Docs/NamingConventions/ValidHookNameStandard.xml
@@ -9,24 +9,24 @@
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: lowercase hook name.">
+        <code title="Valid: Lowercase hook name.">
         <![CDATA[
 do_action( <em>'prefix_hook_name'</em>, $var );
         ]]>
         </code>
-        <code title="Invalid: mixed case hook name.">
+        <code title="Invalid: Mixed case hook name.">
         <![CDATA[
 do_action( <em>'Prefix_Hook_NAME'</em>, $var );
         ]]>
         </code>
     </code_comparison>
     <code_comparison>
-        <code title="Valid: words separated by underscores.">
+        <code title="Valid: Words separated by underscores.">
         <![CDATA[
 apply_filters( <em>'prefix_hook_name'</em>, $var );
         ]]>
         </code>
-        <code title="Invalid: using non-underscore characters to separate words.">
+        <code title="Invalid: Using non-underscore characters to separate words.">
         <![CDATA[
 apply_filters( <em>'prefix\hook-name'</em>, $var );
         ]]>

--- a/WordPress/Docs/NamingConventions/ValidPostTypeSlugStandard.xml
+++ b/WordPress/Docs/NamingConventions/ValidPostTypeSlugStandard.xml
@@ -9,7 +9,7 @@
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: short post type slug.">
+        <code title="Valid: Short post type slug.">
         <![CDATA[
 register_post_type( 
     <em>'my_short_slug'</em>, 
@@ -17,7 +17,7 @@ register_post_type(
 );
         ]]>
         </code>
-        <code title="Invalid: too long post type slug.">
+        <code title="Invalid: Too long post type slug.">
         <![CDATA[
 register_post_type( 
     <em>'my_own_post_type_too_long'</em>, 
@@ -32,7 +32,7 @@ register_post_type(
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: no special characters in post type slug.">
+        <code title="Valid: No special characters in post type slug.">
         <![CDATA[
 register_post_type( 
     <em>'my_post_type_slug'</em>, 
@@ -40,7 +40,7 @@ register_post_type(
 );
         ]]>
         </code>
-        <code title="Invalid: invalid characters in post type slug.">
+        <code title="Invalid: Invalid characters in post type slug.">
         <![CDATA[
 register_post_type( 
     <em>'my/post/type/slug'</em>, 
@@ -55,7 +55,7 @@ register_post_type(
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: static post type slug.">
+        <code title="Valid: Static post type slug.">
         <![CDATA[
 register_post_type( 
     <em>'my_post_active'</em>, 
@@ -63,7 +63,7 @@ register_post_type(
 );
         ]]>
         </code>
-        <code title="Invalid: dynamic post type slug.">
+        <code title="Invalid: Dynamic post type slug.">
         <![CDATA[
 register_post_type( 
     <em>"my_post_{$status}"</em>, 
@@ -78,7 +78,7 @@ register_post_type(
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: prefixed post slug.">
+        <code title="Valid: Prefixed post slug.">
         <![CDATA[
 register_post_type( 
     <em>'prefixed_author'</em>, 
@@ -86,7 +86,7 @@ register_post_type(
 );
         ]]>
         </code>
-        <code title="Invalid: using a reserved keyword as slug.">
+        <code title="Invalid: Using a reserved keyword as slug.">
         <![CDATA[
 register_post_type( 
     <em>'author'</em>, 
@@ -101,7 +101,7 @@ register_post_type(
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: custom prefix post slug.">
+        <code title="Valid: Custom prefix post slug.">
         <![CDATA[
 register_post_type( 
     <em>'prefixed_author'</em>, 
@@ -109,7 +109,7 @@ register_post_type(
 );
         ]]>
         </code>
-        <code title="Invalid: using a reserved prefix.">
+        <code title="Invalid: Using a reserved prefix.">
         <![CDATA[
 register_post_type( 
     <em>'wp_author'</em>, 

--- a/WordPress/Docs/PHP/IniSetStandard.xml
+++ b/WordPress/Docs/PHP/IniSetStandard.xml
@@ -9,12 +9,12 @@
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: ini_set() for a possibly breaking setting.">
+        <code title="Valid: (Not) using ini_set() for a possibly breaking setting.">
         <![CDATA[
 // ini_set() should not be used.
         ]]>
         </code>
-        <code title="Invalid: ini_set() for a possibly breaking setting.">
+        <code title="Invalid: Using ini_set() for a possibly breaking setting.">
         <![CDATA[
 ini_set( <em>'short_open_tag'</em>, 'off' );
         ]]>
@@ -26,12 +26,12 @@ ini_set( <em>'short_open_tag'</em>, 'off' );
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: WordPress functional alternative.">
+        <code title="Valid: Using WordPress functional alternative.">
         <![CDATA[
 <em>wp_raise_memory_limit();</em>
         ]]>
         </code>
-        <code title="Invalid: ini_set() to alter memory limits.">
+        <code title="Invalid: Using ini_set() to alter memory limits.">
         <![CDATA[
 ini_set( <em>'memory_limit'</em>, '256M' );
         ]]>

--- a/WordPress/Docs/PHP/StrictInArrayStandard.xml
+++ b/WordPress/Docs/PHP/StrictInArrayStandard.xml
@@ -11,13 +11,13 @@
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: calling in_array() with the $strict parameter set to `true`.">
+        <code title="Valid: Calling in_array() with the $strict parameter set to `true`.">
         <![CDATA[
 $array = array( '1', 1, true );
 if ( in_array( $value, $array, <em>true</em> ) ) {}
         ]]>
         </code>
-        <code title="Invalid: calling in_array() without passing the $strict parameter.">
+        <code title="Invalid: Calling in_array() without passing the $strict parameter.">
         <![CDATA[
 $array = array( '1', 1, true );
 if ( in_array( $value, $array<em> </em>) ) {}
@@ -26,12 +26,12 @@ if ( in_array( $value, $array<em> </em>) ) {}
     </code_comparison>
 
     <code_comparison>
-        <code title="Valid: calling array_search() with the $strict parameter set to `true`.">
+        <code title="Valid: Calling array_search() with the $strict parameter set to `true`.">
         <![CDATA[
 $key = array_search( 1, $array, <em>true</em> );
         ]]>
         </code>
-        <code title="Invalid: calling array_search() without passing the $strict parameter.">
+        <code title="Invalid: Calling array_search() without passing the $strict parameter.">
         <![CDATA[
 $key = array_search( 1, $array<em> </em>);
         ]]>
@@ -39,12 +39,12 @@ $key = array_search( 1, $array<em> </em>);
     </code_comparison>
 
     <code_comparison>
-        <code title="Valid: calling array_keys() with a $search_value and the $strict parameter set to `true`.">
+        <code title="Valid: Calling array_keys() with a $search_value and the $strict parameter set to `true`.">
         <![CDATA[
 $keys = array_keys( $array, $key, <em>true</em> );
         ]]>
         </code>
-        <code title="Invalid: calling array_keys() with a $search_value without passing the $strict parameter.">
+        <code title="Invalid: Calling array_keys() with a $search_value without passing the $strict parameter.">
         <![CDATA[
 $keys = array_keys( $array, $key<em> </em>);
         ]]>

--- a/WordPress/Docs/WP/CapabilitiesStandard.xml
+++ b/WordPress/Docs/WP/CapabilitiesStandard.xml
@@ -9,12 +9,12 @@
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: a WP native or registered custom user capability is used.">
+        <code title="Valid: A WP native or registered custom user capability is used.">
         <![CDATA[
 if ( author_can( $post, <em>'manage_sites'</em> ) ) { }
         ]]>
         </code>
-        <code title="Invalid: unknown/unsupported user capability is used.">
+        <code title="Invalid: Unknown/unsupported user capability is used.">
         <![CDATA[
 map_meta_cap( <em>'manage_site'</em>, $user->ID );
         ]]>
@@ -26,7 +26,7 @@ map_meta_cap( <em>'manage_site'</em>, $user->ID );
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: user capability is used.">
+        <code title="Valid: User capability is used.">
         <![CDATA[
 add_options_page(
     esc_html__( 'Options', 'textdomain' ),
@@ -37,7 +37,7 @@ add_options_page(
 );
         ]]>
         </code>
-        <code title="Invalid: user role is used instead of a capability.">
+        <code title="Invalid: User role is used instead of a capability.">
         <![CDATA[
 add_options_page(
     esc_html__( 'Options', 'textdomain' ),
@@ -55,12 +55,12 @@ add_options_page(
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: a WP native or registered custom user capability is used.">
+        <code title="Valid: A WP native or registered custom user capability is used.">
         <![CDATA[
 if ( author_can( $post, <em>'read'</em> ) ) { }
         ]]>
         </code>
-        <code title="Invalid: deprecated user capability is used.">
+        <code title="Invalid: Deprecated user capability is used.">
         <![CDATA[
 if ( author_can( $post, <em>'level_6'</em> ) ) { }
         ]]>

--- a/WordPress/Docs/WP/ClassNameCaseStandard.xml
+++ b/WordPress/Docs/WP/ClassNameCaseStandard.xml
@@ -9,12 +9,12 @@
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: reference to a WordPress native class name using the correct case.">
+        <code title="Valid: Reference to a WordPress native class name using the correct case.">
         <![CDATA[
 $obj = new WP_Query;
         ]]>
         </code>
-        <code title="Invalid: reference to a WordPress native class name not using the correct case.">
+        <code title="Invalid: Reference to a WordPress native class name not using the correct case.">
         <![CDATA[
 $obj = new wp_query;
         ]]>

--- a/WordPress/Docs/WP/DeprecatedClassesStandard.xml
+++ b/WordPress/Docs/WP/DeprecatedClassesStandard.xml
@@ -9,12 +9,12 @@
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: use of a current (non-deprecated) class.">
+        <code title="Valid: Use of a current (non-deprecated) class.">
         <![CDATA[
 $a = new <em>WP_User_Query</em>();
         ]]>
         </code>
-        <code title="Invalid: use of a deprecated class.">
+        <code title="Invalid: Use of a deprecated class.">
         <![CDATA[
 $a = new <em>WP_User_Search</em>(); // Deprecated WP 3.1.
         ]]>

--- a/WordPress/Docs/WP/DeprecatedFunctionsStandard.xml
+++ b/WordPress/Docs/WP/DeprecatedFunctionsStandard.xml
@@ -9,12 +9,12 @@
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: use of a current (non-deprecated) function.">
+        <code title="Valid: Use of a current (non-deprecated) function.">
         <![CDATA[
 $sites = <em>get_sites</em>();
         ]]>
         </code>
-        <code title="Invalid: use of a deprecated function.">
+        <code title="Invalid: Use of a deprecated function.">
         <![CDATA[
 $sites = <em>wp_get_sites</em>(); // Deprecated WP 4.6.
         ]]>

--- a/WordPress/Docs/WP/DeprecatedParameterValuesStandard.xml
+++ b/WordPress/Docs/WP/DeprecatedParameterValuesStandard.xml
@@ -9,12 +9,12 @@
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: passing a valid function parameter value.">
+        <code title="Valid: Passing a valid function parameter value.">
         <![CDATA[
 bloginfo( <em>'url'</em> );
         ]]>
         </code>
-        <code title="Invalid: passing a deprecated function parameter value.">
+        <code title="Invalid: Passing a deprecated function parameter value.">
         <![CDATA[
 bloginfo ( <em>'home'</em> ); // Deprecated WP 2.2.0.
         ]]>

--- a/WordPress/Docs/WP/DeprecatedParametersStandard.xml
+++ b/WordPress/Docs/WP/DeprecatedParametersStandard.xml
@@ -10,13 +10,13 @@
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: not passing a deprecated parameter.">
+        <code title="Valid: Not passing a deprecated parameter.">
         <![CDATA[
 // First - and only - parameter deprecated.
 get_the_author();
         ]]>
         </code>
-        <code title="Invalid: passing a deprecated parameter.">
+        <code title="Invalid: Passing a deprecated parameter.">
         <![CDATA[
 // First - and only - parameter deprecated.
 get_the_author( <em>$string</em> );
@@ -24,13 +24,13 @@ get_the_author( <em>$string</em> );
         </code>
     </code_comparison>
     <code_comparison>
-        <code title="Valid: passing default value for a deprecated parameter.">
+        <code title="Valid: Passing default value for a deprecated parameter.">
         <![CDATA[
 // Third parameter deprecated in WP 2.3.0.
 add_option( 'option_name', 123, <em>''</em>, 'yes' );
         ]]>
         </code>
-        <code title="Invalid: not passing the default value for a deprecated parameter.">
+        <code title="Invalid: Not passing the default value for a deprecated parameter.">
         <![CDATA[
 // Third parameter deprecated in WP 2.3.0.
 add_option( 'my_name', 123, <em>'oops'</em>, 'yes' );

--- a/WordPress/Docs/WhiteSpace/CastStructureSpacingStandard.xml
+++ b/WordPress/Docs/WhiteSpace/CastStructureSpacingStandard.xml
@@ -10,7 +10,7 @@
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: space before typecast.">
+        <code title="Valid: Space before typecast.">
         <![CDATA[
 $a =<em> </em>(int) '420';
 
@@ -18,7 +18,7 @@ $a =<em> </em>(int) '420';
 $a = function_call( <em>...(array)</em> $mixed );
         ]]>
         </code>
-        <code title="Invalid: no space before typecast.">
+        <code title="Invalid: No space before typecast.">
         <![CDATA[
 $a <em>=(</em>int) '420';
         ]]>

--- a/WordPress/Docs/WhiteSpace/OperatorSpacingStandard.xml
+++ b/WordPress/Docs/WhiteSpace/OperatorSpacingStandard.xml
@@ -10,13 +10,13 @@
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: one space before and after an operator.">
+        <code title="Valid: One space before and after an operator.">
         <![CDATA[
 if ( $a<em> === </em>$b<em> && </em>$b<em> === </em>$c ) {}
 if (<em> ! </em>$var ) {}
         ]]>
         </code>
-        <code title="Invalid: too much/little space.">
+        <code title="Invalid: Too much/little space.">
         <![CDATA[
 // Too much space.
 if ( $a === $b<em>   &&   </em>$b<em> ===      </em>$c ) {}
@@ -29,14 +29,14 @@ if (<em> !</em>$var ) {}
         </code>
     </code_comparison>
     <code_comparison>
-        <code title="Valid: a new line instead of a space is okay too.">
+        <code title="Valid: A new line instead of a space is okay too.">
         <![CDATA[
 if ( $a === $b<em>
     && </em>$b === $c
 ) {}
         ]]>
         </code>
-        <code title="Invalid: too much space after operator on new line.">
+        <code title="Invalid: Too much space after operator on new line.">
         <![CDATA[
 if ( $a === $b<em>
     &&     </em>$b === $c
@@ -45,13 +45,13 @@ if ( $a === $b<em>
         </code>
     </code_comparison>
     <code_comparison>
-        <code title="Valid: one space after assignment operator.">
+        <code title="Valid: One space after assignment operator.">
         <![CDATA[
 $a   <em>= </em>'foo';
 $all <em>= </em>'foobar';
         ]]>
         </code>
-        <code title="Invalid: too much/little space after assignment operator.">
+        <code title="Invalid: Too much/little space after assignment operator.">
         <![CDATA[
 $a   <em>=     </em>'foo';
 $all <em>=</em>'foobar';


### PR DESCRIPTION
Follow up on #2468

Darn! Looks like I forgot to push an update to the commit. Sorry about that.

This adds the capitalization consistency fixes for the `<code>` `title` attributes.