### PR TITLE
Fix typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -337,7 +337,7 @@ More information is available in the [Upgrade Guide to WordPressCS 3.0.0 for Dev
     This fix has a positive impact on all sniffs which are based on this abstract (3 sniffs).
 - `AbstractFunctionRestrictionsSniff`: false positives on function declarations when the function returns by reference.
     This fix has a positive impact on all sniffs which are based on this abstract (nearly half of the WordPressCS sniffs).
-- `AbstractFunctionRestrictionsSniff`: false positives on instantiation of a class with the same name as a targetted function.
+- `AbstractFunctionRestrictionsSniff`: false positives on instantiation of a class with the same name as a targeted function.
     This fix has a positive impact on all sniffs which are based on this abstract (nearly half of the WordPressCS sniffs).
 - `AbstractFunctionRestrictionsSniff` now respects that function names in PHP are case-insensitive in more places.
     This fix has a positive impact on all sniffs which are based on this abstract (nearly half of the WordPressCS sniffs).
@@ -388,8 +388,8 @@ More information is available in the [Upgrade Guide to WordPressCS 3.0.0 for Dev
 - `WordPress.Security.EscapeOutput` could previously get confused when it encountered comments in the `$file` parameter for `_deprecated_file()`.
 - `WordPress.Security.EscapeOutput` now ignores significantly more operators which should yield more accurate results.
 - `WordPress.Security.EscapeOutput` now respects that function names in PHP are case-insensitive when checking whether a printing function is being used.
-- `WordPress.Security.EscapeOutput` no longer throws an `Internal.Exception` when it encounters a constant or property mirroring the name of one of the printing functions being targetted, nor will it throw false positives for those.
-- `WordPress.Security.EscapeOutput` no longer incorrectly handles method calls or calls to namespaced functions mirroring the name of one of the printing functions being targetted.
+- `WordPress.Security.EscapeOutput` no longer throws an `Internal.Exception` when it encounters a constant or property mirroring the name of one of the printing functions being targeted, nor will it throw false positives for those.
+- `WordPress.Security.EscapeOutput` no longer incorrectly handles method calls or calls to namespaced functions mirroring the name of one of the printing functions being targeted.
 - `WordPress.Security.EscapeOutput` now ignores `exit`/`die` statements without a status being passed, preventing false positives on code after the statement.
 - `WordPress.Security.EscapeOutput` now has improved recognition that `print` can also be used as an expression, not only as a statement.
 - `WordPress.Security.EscapeOutput` now has much, much, much more accurate handling of code involving ternary expressions and should now correctly ignore the ternary condition in all long ternaries being examined.
@@ -854,7 +854,7 @@ Note: This will be the last release supporting PHP_CodeSniffer 2.x.
 ### Added
 - New `WordPress.PHP.NoSilencedErrors` sniff. This sniff replaces the `Generic.PHP.NoSilencedErrors` sniff which was previously used and included in the `WordPress-Core` ruleset.
     The WordPress specific version of the sniff differs from the PHPCS version in that it:
-    * Allows the error control operator `@` if it preceeds a function call to a limited list of PHP functions for which no amount of error checking can prevent a PHP warning from being thrown.
+    * Allows the error control operator `@` if it precedes a function call to a limited list of PHP functions for which no amount of error checking can prevent a PHP warning from being thrown.
     * Allows for a used-defined list of (additional) function names to be passed to the sniff via the `custom_whitelist` property in a custom ruleset, for which - if the error control operator is detected in front of a function call to one of the functions in this whitelist - no warnings will be thrown.
     * Displays a brief snippet of code in the `warning` message text to show the context in which the error control operator is being used. The length of the snippet (in tokens) can be customized via the `context_length` property.
     * Contains a public `use_default_whitelist` property which can be set from a custom ruleset which regulates whether or not the standard whitelist of PHP functions should be used by the sniff.
@@ -942,7 +942,7 @@ If you are a maintainer of an external standard based on WPCS and any of your cu
     - `ValidatedSanitizedInput` from the `VIP` category to the `Security` category.
 - The `WordPress.VIP.PostsPerPage` sniff has been split into two distinct sniffs:
     - `WordPress.WP.PostsPerPage` which will check for the use of a high pagination limit and will throw a `warning` when this is encountered. For the `VIP` ruleset, the error level remains `error`.
-    - `WordPress.VIP.PostsPerPage` wich will check for disabling of pagination.
+    - `WordPress.VIP.PostsPerPage` which will check for disabling of pagination.
 - The default value for `minimum_supported_wp_version`, as used by a [number of sniffs detecting usage of deprecated WP features](https://github.com/WordPress/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#minimum-wp-version-to-check-for-usage-of-deprecated-functions-classes-and-function-parameters), has been updated to `4.6`.
 - The `WordPress.WP.AlternativeFunctions` sniff will now only throw a warning if/when the recommended alternative function is available in the minimum supported WP version of a project.
     In addition to this, certain alternatives are only valid alternatives in certain circumstances, like when the WP version only supports the first parameter of the PHP function it is trying to replace.
@@ -1009,7 +1009,7 @@ If you are a maintainer of an external standard based on WPCS and any of your cu
 - The `Sniff::has_html_open_tag()` utility method has been deprecated as it is now only used by deprecated sniffs. The method will be removed in WPCS 2.0.0.
 
 ### Removed
-- `cancel_comment_reply_link()`, `get_bookmark()`, `get_comment_date()`, `get_comment_time()`, `get_template_part()`, `has_post_thumbnail()`, `is_attachement()`, `post_password_required()` and `wp_attachment_is_image()` from the list of auto-escaped functions `Sniff::$autoEscapedFunctions`. This affects the `WordPress.Security.EscapeOutput` sniff.
+- `cancel_comment_reply_link()`, `get_bookmark()`, `get_comment_date()`, `get_comment_time()`, `get_template_part()`, `has_post_thumbnail()`, `is_attachment()`, `post_password_required()` and `wp_attachment_is_image()` from the list of auto-escaped functions `Sniff::$autoEscapedFunctions`. This affects the `WordPress.Security.EscapeOutput` sniff.
 - WPCS no longer explicitly supports HHVM and builds are no longer tested against HHVM.
     For now, running WPCS on HHVM to test PHP code may still work for a little while, but HHVM has announced they are [dropping PHP support](https://hhvm.com/blog/2017/09/18/the-future-of-hhvm.html).
 
@@ -1138,11 +1138,11 @@ If you are a maintainer of an external standard based on WPCS and any of your cu
 - The `WordPress.Classes.ClassInstantiation` sniff will now correctly handle detection when using `new $array['key']` or `new $array[0]`.
 - The `WordPress.NamingConventions.PrefixAllGlobals` sniff did not allow for arbitrary word separators in hook names.
 - The `WordPress.NamingConventions.PrefixAllGlobals` sniff did not correctly recognize namespaced constants as prefixed.
-- The `WordPress.PHP.StrictInArray` sniff would erronously trigger if the `true` for `$strict` was passed in uppercase.
+- The `WordPress.PHP.StrictInArray` sniff would erroneously trigger if the `true` for `$strict` was passed in uppercase.
 - The `WordPress.PHP.YodaConditions` sniff could get confused over complex ternaries containing assignments. This has been remedied.
-- The `WordPress.WP.PreparedSQL` sniff would erronously throw errors about comments found within a DB function call.
-- The `WordPress.WP.PreparedSQL` sniff would erronously throw errors about `(int)`, `(float)` and `(bool)` casts and would also flag the subsequent variable which had been safe casted.
-- The `WordPress.XSS.EscapeOutput` sniff would erronously trigger when using a fully qualified function call - including the global namespace `\` indicator - to one of the escaping functions.
+- The `WordPress.WP.PreparedSQL` sniff would erroneously throw errors about comments found within a DB function call.
+- The `WordPress.WP.PreparedSQL` sniff would erroneously throw errors about `(int)`, `(float)` and `(bool)` casts and would also flag the subsequent variable which had been safe casted.
+- The `WordPress.XSS.EscapeOutput` sniff would erroneously trigger when using a fully qualified function call - including the global namespace `\` indicator - to one of the escaping functions.
 - The lists of WP global variables and WP mixed case variables have been synchronized, which fixes some false positives.
 
 
@@ -1185,7 +1185,7 @@ If you are a maintainer of an external standard based on WPCS and any of your cu
 - `Squiz.Classes.SelfMemberReference` whitespace related checks to the `WordPress-Core` ruleset and the additional check for using `self` rather than a FQN to the `WordPress-Extra` ruleset.
 - `Squiz.PHP.EmbeddedPhp` sniff to the `WordPress-Core` ruleset to check PHP code embedded within HTML blocks.
 - `PSR2.ControlStructures.SwitchDeclaration` to the `WordPress-Core` ruleset to check for the correct layout of `switch` control structures.
-- `WordPress.Classes.ClassInstantion` sniff to the `WordPress-Extra` ruleset to detect - and auto-fix - missing parentheses on object instantiation and superfluous whitespace in PHP and JS files. The sniff will also detect `new` being assigned by reference.
+- `WordPress.Classes.ClassInstantiation` sniff to the `WordPress-Extra` ruleset to detect - and auto-fix - missing parentheses on object instantiation and superfluous whitespace in PHP and JS files. The sniff will also detect `new` being assigned by reference.
 - `WordPress.CodeAnalysis.EmptyStatement` sniff to the `WordPress-Extra` ruleset to detect - and auto-fix - superfluous semi-colons and empty PHP open-close tag combinations.
 - `WordPress.NamingConventions.PrefixAllGlobals` sniff to the `WordPress-Extra` ruleset to verify that all functions, classes, interfaces, traits, variables, constants and hook names which are declared/defined in the global namespace are prefixed with one of the prefixes provided via a custom property or via the command line.
     To activate this sniff, [one or more allowed prefixes should be provided to the sniff](https://github.com/WordPress/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#naming-conventions-prefix-everything-in-the-global-namespace). This can be done using a custom ruleset or via the command line.
@@ -1239,7 +1239,7 @@ If you are a maintainer of an external standard based on WPCS and any of your cu
 - The `WordPress.XSS.EscapeOutput` sniff will no now longer report issues when it encounters a `__DIR__`, `(unset)` cast or a floating point number, and will correctly disregard more arithmetic operators when deciding whether to report an issue or not.
 - The [whitelisting of errors using flags](https://github.com/WordPress/WordPress-Coding-Standards/wiki/Whitelisting-code-which-flags-errors) was sometimes a bit too eager and could accidentally whitelist code which was not intended to be whitelisted.
 - Various (potential) `Undefined variable`, `Undefined index` and `Undefined offset` notices.
-- Grammer in one of the `WordPress.WP.I18n` error messages.
+- Grammar in one of the `WordPress.WP.I18n` error messages.
 
 
 ## [0.11.0] - 2017-03-20
@@ -1514,7 +1514,7 @@ from the `WordPress-VIP` standard, since they are just parents for other sniffs.
 - `WordPress.CSRF.NonceVerification` sniff to flag form processing without nonce verification.
 - `in_array()` and `is_array()` to the list of sanitizing functions.
 - Support for automatic error fixing to the `WordPress.Arrays.ArrayDeclaration` sniff.
-- `WordPress.PHP.StrictComparisions` to the `WordPress-VIP` and `WordPress-Extra` rulesets.
+- `WordPress.PHP.StrictComparisons` to the `WordPress-VIP` and `WordPress-Extra` rulesets.
 - `WordPress-Docs` ruleset to sniff for proper commenting.
 - `Generic.PHP.LowerCaseKeyword`, `Generic.Files.EndFileNewline`, `Generic.Files.LowercasedFilename`, 
 `Generic.Formatting.SpaceAfterCast`, and `Generic.Functions.OpeningFunctionBraceKernighanRitchie` to the `WordPress-Core` ruleset.

--- a/WordPress-Docs/ruleset.xml
+++ b/WordPress-Docs/ruleset.xml
@@ -41,13 +41,13 @@
 		<exclude name="Squiz.Commenting.FileComment.MissingSubpackageTag"/>
 		<!-- WP doesn't require @copyright tags -->
 		<exclude name="Squiz.Commenting.FileComment.MissingCopyrightTag"/>
-		<!-- WP has a different prefered order of tags -->
+		<!-- WP has a different preferred order of tags -->
 		<exclude name="Squiz.Commenting.FileComment.PackageTagOrder"/>
-		<!-- WP has a different prefered order of tags -->
+		<!-- WP has a different preferred order of tags -->
 		<exclude name="Squiz.Commenting.FileComment.SubpackageTagOrder"/>
-		<!-- WP has a different prefered order of tags -->
+		<!-- WP has a different preferred order of tags -->
 		<exclude name="Squiz.Commenting.FileComment.AuthorTagOrder"/>
-		<!-- WP has a different prefered order of tags -->
+		<!-- WP has a different preferred order of tags -->
 		<exclude name="Squiz.Commenting.FileComment.CopyrightTagOrder"/>
 
 		<!-- WP prefers int and bool instead of integer and boolean -->
@@ -91,7 +91,7 @@
 	<rule ref="Generic.Commenting.DocComment">
 		<!-- WP has different alignment of tag values -->
 		<exclude name="Generic.Commenting.DocComment.TagValueIndent"/>
-		<!-- WP has a different prefered order of tags -->
+		<!-- WP has a different preferred order of tags -->
 		<exclude name="Generic.Commenting.DocComment.ParamNotFirst"/>
 		<!-- Excluded to allow param documentation for arrays  -->
 		<exclude name="Generic.Commenting.DocComment.ParamGroup"/>

--- a/WordPress/AbstractClassRestrictionsSniff.php
+++ b/WordPress/AbstractClassRestrictionsSniff.php
@@ -102,7 +102,7 @@ abstract class AbstractClassRestrictionsSniff extends AbstractFunctionRestrictio
 			return;
 		}
 
-		if ( true === $this->is_targeted_token( $stackPtr ) ) {
+		if ( true === $this->is_targetted_token( $stackPtr ) ) {
 			return $this->check_for_matches( $stackPtr );
 		}
 	}
@@ -116,7 +116,7 @@ abstract class AbstractClassRestrictionsSniff extends AbstractFunctionRestrictio
 	 *
 	 * @return bool
 	 */
-	public function is_targeted_token( $stackPtr ) {
+	public function is_targetted_token( $stackPtr ) {
 
 		$token     = $this->tokens[ $stackPtr ];
 		$classname = '';

--- a/WordPress/AbstractClassRestrictionsSniff.php
+++ b/WordPress/AbstractClassRestrictionsSniff.php
@@ -102,7 +102,7 @@ abstract class AbstractClassRestrictionsSniff extends AbstractFunctionRestrictio
 			return;
 		}
 
-		if ( true === $this->is_targetted_token( $stackPtr ) ) {
+		if ( true === $this->is_targeted_token( $stackPtr ) ) {
 			return $this->check_for_matches( $stackPtr );
 		}
 	}
@@ -116,7 +116,7 @@ abstract class AbstractClassRestrictionsSniff extends AbstractFunctionRestrictio
 	 *
 	 * @return bool
 	 */
-	public function is_targetted_token( $stackPtr ) {
+	public function is_targeted_token( $stackPtr ) {
 
 		$token     = $this->tokens[ $stackPtr ];
 		$classname = '';
@@ -159,7 +159,7 @@ abstract class AbstractClassRestrictionsSniff extends AbstractFunctionRestrictio
 	}
 
 	/**
-	 * Verify if the current token is one of the targetted classes.
+	 * Verify if the current token is one of the targeted classes.
 	 *
 	 * @since 0.11.0 Split out from the `process()` method.
 	 *

--- a/WordPress/AbstractFunctionRestrictionsSniff.php
+++ b/WordPress/AbstractFunctionRestrictionsSniff.php
@@ -208,7 +208,7 @@ abstract class AbstractFunctionRestrictionsSniff extends Sniff {
 			return;
 		}
 
-		if ( true === $this->is_targeted_token( $stackPtr ) ) {
+		if ( true === $this->is_targetted_token( $stackPtr ) ) {
 			return $this->check_for_matches( $stackPtr );
 		}
 	}
@@ -222,7 +222,7 @@ abstract class AbstractFunctionRestrictionsSniff extends Sniff {
 	 *
 	 * @return bool
 	 */
-	public function is_targeted_token( $stackPtr ) {
+	public function is_targetted_token( $stackPtr ) {
 		// Exclude function definitions, class methods, and namespaced calls.
 		if ( ContextHelper::has_object_operator_before( $this->phpcsFile, $stackPtr ) === true ) {
 			return false;

--- a/WordPress/AbstractFunctionRestrictionsSniff.php
+++ b/WordPress/AbstractFunctionRestrictionsSniff.php
@@ -208,7 +208,7 @@ abstract class AbstractFunctionRestrictionsSniff extends Sniff {
 			return;
 		}
 
-		if ( true === $this->is_targetted_token( $stackPtr ) ) {
+		if ( true === $this->is_targeted_token( $stackPtr ) ) {
 			return $this->check_for_matches( $stackPtr );
 		}
 	}
@@ -222,7 +222,7 @@ abstract class AbstractFunctionRestrictionsSniff extends Sniff {
 	 *
 	 * @return bool
 	 */
-	public function is_targetted_token( $stackPtr ) {
+	public function is_targeted_token( $stackPtr ) {
 		// Exclude function definitions, class methods, and namespaced calls.
 		if ( ContextHelper::has_object_operator_before( $this->phpcsFile, $stackPtr ) === true ) {
 			return false;
@@ -276,7 +276,7 @@ abstract class AbstractFunctionRestrictionsSniff extends Sniff {
 	}
 
 	/**
-	 * Verify if the current token is one of the targetted functions.
+	 * Verify if the current token is one of the targeted functions.
 	 *
 	 * @since 0.11.0 Split out from the `process()` method.
 	 *

--- a/WordPress/Docs/Arrays/ArrayIndentationStandard.xml
+++ b/WordPress/Docs/Arrays/ArrayIndentationStandard.xml
@@ -72,7 +72,7 @@ For heredocs/nowdocs, this does not apply to the content of the heredoc/nowdoc o
         <![CDATA[
 $args = array(
     'phrase' => 'start of phrase'
-        . 'concatented additional phrase'
+        . 'concatenated additional phrase'
         . 'more text',
 );
         ]]>
@@ -81,7 +81,7 @@ $args = array(
         <![CDATA[
 $args = array(
     'phrase' => 'start of phrase'
-. 'concatented additional phrase'
+. 'concatenated additional phrase'
 . 'more text',
 );
         ]]>
@@ -93,7 +93,7 @@ $args = array(
 $text = array(
     <<<EOD
     start of phrase
-    concatented additional phrase
+    concatenated additional phrase
     more text
 EOD
     ,
@@ -105,7 +105,7 @@ EOD
 $text = array(
 <em><<<EOD</em>
     start of phrase
-    concatented additional phrase
+    concatenated additional phrase
     more text
 EOD
 <em>,</em>

--- a/WordPress/Helpers/ContextHelper.php
+++ b/WordPress/Helpers/ContextHelper.php
@@ -31,7 +31,7 @@ use PHPCSUtils\Utils\PassedParameters;
 final class ContextHelper {
 
 	/**
-	 * Tokens which when they preceed code indicate the value is safely casted.
+	 * Tokens which when they precede code indicate the value is safely casted.
 	 *
 	 * @since 1.1.0
 	 * @since 3.0.0 - Moved from the Sniff class to this class.

--- a/WordPress/Helpers/SanitizationHelperTrait.php
+++ b/WordPress/Helpers/SanitizationHelperTrait.php
@@ -126,7 +126,7 @@ trait SanitizationHelperTrait {
 	 *
 	 * This list is complementary to the `$sanitizingFunctions` list.
 	 * Sanitizing functions should be added to this list if they also
-	 * implicitely unslash data and to the `$sanitizingFunctions` list
+	 * implicitly unslash data and to the `$sanitizingFunctions` list
 	 * if they don't.
 	 *
 	 * @since 0.5.0

--- a/WordPress/Sniffs/Arrays/ArrayIndentationSniff.php
+++ b/WordPress/Sniffs/Arrays/ArrayIndentationSniff.php
@@ -243,7 +243,7 @@ final class ArrayIndentationSniff extends Sniff {
 			 * Multi-line array items.
 			 *
 			 * Verify & if needed, correct the indentation of subsequent lines.
-			 * Subsequent lines may be indented more or less than the mimimum expected indent,
+			 * Subsequent lines may be indented more or less than the minimum expected indent,
 			 * but the "first line after" should be indented - at least - as much as the very first line
 			 * of the array item.
 			 * Indentation correction for subsequent lines will be based on that diff.

--- a/WordPress/Sniffs/Arrays/MultipleStatementAlignmentSniff.php
+++ b/WordPress/Sniffs/Arrays/MultipleStatementAlignmentSniff.php
@@ -112,7 +112,7 @@ final class MultipleStatementAlignmentSniff extends Sniff {
 	 *               * Setting this to `=0` is useless as in that case there are
 	 *                 no multi-line items in the array anyway.
 	 *
-	 * This setting will respect the `ignoreNewlines` and `maxColumnn` settings.
+	 * This setting will respect the `ignoreNewlines` and `maxColumn` settings.
 	 *
 	 * @since 0.14.0
 	 *

--- a/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
+++ b/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
@@ -861,7 +861,7 @@ final class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 	protected function process_variable_assignment( $stackPtr, $in_list = false ) {
 		/*
 		 * We're only concerned with variables which are being defined.
-		 * `is_assigment()` will not recognize property assignments, which is good in this case.
+		 * `is_assignment()` will not recognize property assignments, which is good in this case.
 		 * However it will also not recognize $b in `foreach( $a as $b )` as an assignment, so
 		 * we need a separate check for that.
 		 */
@@ -1138,7 +1138,7 @@ final class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 	 *
 	 * @since 0.12.0
 	 * @since 0.14.0 Allows for other non-word characters as well as underscores to better support hook names.
-	 * @since 1.0.0  Does not require a word seperator anymore after a prefix.
+	 * @since 1.0.0  Does not require a word separator anymore after a prefix.
 	 *               This allows for improved code style independent checking,
 	 *               i.e. allows for camelCase naming and the likes.
 	 * @since 1.0.1  - Added $stackPtr parameter.

--- a/WordPress/Sniffs/Security/PluginMenuSlugSniff.php
+++ b/WordPress/Sniffs/Security/PluginMenuSlugSniff.php
@@ -44,7 +44,7 @@ final class PluginMenuSlugSniff extends AbstractFunctionParameterSniff {
 	 *               array containing parameter positions to an array with the parameter
 	 *               position as the index and the parameter name as value.
 	 *
-	 * @var array<string, array<int, string|array>> Key is the name of the functions being targetted.
+	 * @var array<string, array<int, string|array>> Key is the name of the functions being targeted.
 	 *                                              Value is an array with parameter positions as the
 	 *                                              keys and parameter names as the values
 	 */

--- a/WordPress/Sniffs/Utils/I18nTextDomainFixerSniff.php
+++ b/WordPress/Sniffs/Utils/I18nTextDomainFixerSniff.php
@@ -536,7 +536,7 @@ final class I18nTextDomainFixerSniff extends AbstractFunctionParameterSniff {
 				$error_msg .= ' and preceding argument(s)';
 				$error_code = 'MissingArgs';
 
-				// Expected preceeding param also missing, just throw the warning.
+				// Expected preceding param also missing, just throw the warning.
 				$this->phpcsFile->addWarning( $error_msg, $stackPtr, $error_code );
 			}
 
@@ -570,7 +570,7 @@ final class I18nTextDomainFixerSniff extends AbstractFunctionParameterSniff {
 		$old_domain = TextStrings::stripQuotes( $this->tokens[ $domain_token ]['content'] );
 
 		if ( ! \in_array( $old_domain, $this->old_text_domain, true ) ) {
-			// Not a text domain targetted for replacement, ignore.
+			// Not a text domain targeted for replacement, ignore.
 			return;
 		}
 

--- a/WordPress/Sniffs/WP/CapabilitiesSniff.php
+++ b/WordPress/Sniffs/WP/CapabilitiesSniff.php
@@ -57,7 +57,7 @@ final class CapabilitiesSniff extends AbstractFunctionParameterSniff {
 	 *
 	 * @since 3.0.0
 	 *
-	 * @var array<string, array> The key is the name of a function we're targetting,
+	 * @var array<string, array> The key is the name of a function we're targeting,
 	 *                           the value is an array containing the 1-based parameter position
 	 *                           of the "capability" parameter within the function, as well as
 	 *                           the name of the parameter as declared in the function.

--- a/WordPress/Sniffs/WP/DeprecatedParameterValuesSniff.php
+++ b/WordPress/Sniffs/WP/DeprecatedParameterValuesSniff.php
@@ -244,7 +244,7 @@ final class DeprecatedParameterValuesSniff extends AbstractFunctionParameterSnif
 	 *
 	 * @param string $matched_content The token content (function name) which was matched
 	 *                                in lowercase.
-	 * @param array  $parameter       Array with start and end token positon of the parameter.
+	 * @param array  $parameter       Array with start and end token position of the parameter.
 	 * @param array  $parameter_args  Array with alternative and WordPress deprecation version of the parameter.
 	 *
 	 * @return void

--- a/WordPress/Sniffs/WP/GlobalVariablesOverrideSniff.php
+++ b/WordPress/Sniffs/WP/GlobalVariablesOverrideSniff.php
@@ -33,7 +33,7 @@ use WordPressCS\WordPress\Sniff;
  * @since 0.13.0 Class name changed: this class is now namespaced.
  * @since 1.0.0  This sniff has been moved from the `Variables` category to the `WP`
  *               category and renamed from `GlobalVariables` to `GlobalVariablesOverride`.
- * @since 1.1.0  The sniff now also detects variables being overriden in the global namespace.
+ * @since 1.1.0  The sniff now also detects variables being overridden in the global namespace.
  * @since 2.2.0  The sniff now also detects variable assignments via the list() construct.
  *
  * @uses \WordPressCS\WordPress\Helpers\IsUnitTestTrait::$custom_test_classes

--- a/WordPress/Sniffs/WP/I18nSniff.php
+++ b/WordPress/Sniffs/WP/I18nSniff.php
@@ -449,7 +449,7 @@ final class I18nSniff extends AbstractFunctionParameterSniff {
 	 *                                     in lowercase.
 	 * @param string      $param_name      The name of the parameter being examined.
 	 * @param array|false $param_info      Parameter info array for an individual parameter,
-	 *                                     as received from the PassedParemeters class.
+	 *                                     as received from the PassedParameters class.
 	 *
 	 * @return bool Whether or not the argument is a string literal.
 	 */
@@ -550,7 +550,7 @@ final class I18nSniff extends AbstractFunctionParameterSniff {
 	 *                                     in lowercase.
 	 * @param string      $param_name      The name of the parameter being examined.
 	 * @param array|false $param_info      Parameter info array for an individual parameter,
-	 *                                     as received from the PassedParemeters class.
+	 *                                     as received from the PassedParameters class.
 	 *
 	 * @return void
 	 */
@@ -642,7 +642,7 @@ final class I18nSniff extends AbstractFunctionParameterSniff {
 	 *                                     in lowercase.
 	 * @param string      $param_name      The name of the parameter being examined.
 	 * @param array|false $param_info      Parameter info array for an individual parameter,
-	 *                                     as received from the PassedParemeters class.
+	 *                                     as received from the PassedParameters class.
 	 *
 	 * @return void
 	 */
@@ -724,7 +724,7 @@ final class I18nSniff extends AbstractFunctionParameterSniff {
 	 *                                     in lowercase.
 	 * @param string      $param_name      The name of the parameter being examined.
 	 * @param array|false $param_info      Parameter info array for an individual parameter,
-	 *                                     as received from the PassedParemeters class.
+	 *                                     as received from the PassedParameters class.
 	 *
 	 * @return bool Whether or not the text string has translatable content.
 	 */
@@ -759,7 +759,7 @@ final class I18nSniff extends AbstractFunctionParameterSniff {
 	 *                                     in lowercase.
 	 * @param string      $param_name      The name of the parameter being examined.
 	 * @param array|false $param_info      Parameter info array for an individual parameter,
-	 *                                     as received from the PassedParemeters class.
+	 *                                     as received from the PassedParameters class.
 	 *
 	 * @return void
 	 */
@@ -813,9 +813,9 @@ final class I18nSniff extends AbstractFunctionParameterSniff {
 	 *
 	 * @param int   $stackPtr          The position of the function call token in the stack.
 	 * @param array $param_info_single Parameter info array for the `$single` parameter,
-	 *                                 as received from the PassedParemeters class.
+	 *                                 as received from the PassedParameters class.
 	 * @param array $param_info_plural Parameter info array for the `$plural` parameter,
-	 *                                 as received from the PassedParemeters class.
+	 *                                 as received from the PassedParameters class.
 	 *
 	 * @return void
 	 */

--- a/WordPress/Tests/DB/DirectDatabaseQueryUnitTest.inc
+++ b/WordPress/Tests/DB/DirectDatabaseQueryUnitTest.inc
@@ -290,7 +290,7 @@ function nullsafe_object_operator() {
 
 function stabilize_token_walking($other_db) {
 	global $wpdb;
-	// Overwritting $wpdb is bad, of course, but that's not the concern of this sniff.
+	// Overwriting $wpdb is bad, of course, but that's not the concern of this sniff.
 	// This test is making sure that the `$other_db->query` code is not flagged as if it were a call to a `$wpdb` method.
 	$wpdb = $other_db->query;
 }

--- a/WordPress/Tests/DB/PreparedSQLPlaceholdersUnitTest.inc
+++ b/WordPress/Tests/DB/PreparedSQLPlaceholdersUnitTest.inc
@@ -154,7 +154,7 @@ $where = $wpdb->prepare(
 ); // Bad x 2 - quotes between the () for the IN.
 
 /*
- * Test distinguising wildcard _ and %'s in LIKE statements.
+ * Test distinguishing wildcard _ and %'s in LIKE statements.
  */
 $sql = $wpdb->prepare( "SELECT * FROM $wpdb->posts WHERE post_content LIKE %s", $like ); // OK.
 $sql = $wpdb->prepare( 'SELECT * FROM ' . $wpdb->posts . ' WHERE post_content LIKE \'a string\'' ); // Warning x 2. Like without wildcard, no need for prepare.

--- a/WordPress/Tests/DB/PreparedSQLUnitTest.1.inc
+++ b/WordPress/Tests/DB/PreparedSQLUnitTest.1.inc
@@ -140,7 +140,7 @@ $wpdb = new WPDB();
 $foo = $wpdb->propertyAccess;
 echo $wpdb::CONSTANT_NAME;
 
-// Not an identifyable method call.
+// Not an identifiable method call.
 $wpdb->{$methodName}('query');
 
 // Don't throw an error during live coding.

--- a/WordPress/Tests/DB/RestrictedFunctionsUnitTest.php
+++ b/WordPress/Tests/DB/RestrictedFunctionsUnitTest.php
@@ -35,7 +35,7 @@ final class RestrictedFunctionsUnitTest extends AbstractSniffUnitTest {
 		parent::setUp();
 
 		AbstractFunctionRestrictionsSniff::$unittest_groups = array(
-			'test-empty-funtions-array' => array(
+			'test-empty-functions-array' => array(
 				'type'      => 'error',
 				'message'   => 'Detected usage of %s.',
 				'functions' => array(),

--- a/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.1.inc
+++ b/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.1.inc
@@ -509,7 +509,7 @@ function a_do_something(){}
 // phpcs:set WordPress.NamingConventions.PrefixAllGlobals prefixes[] aa
 function aa_do_something(){}
 
-// The following line mimicks an empty prefix value.
+// The following line mimics an empty prefix value.
 // phpcs:set WordPress.NamingConventions.PrefixAllGlobals prefixes[] ,
 function aaa_do_something(){}
 

--- a/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.8.inc
+++ b/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.8.inc
@@ -4,7 +4,7 @@
 
 /*
  * This test safeguards a few edge cases and makes sure the sniff bows out correctly when it finds:
- * - $GLOBALS without a key. Note: overwritting the $GLOBALS variable is no longer allowed since PHP 8.1.
+ * - $GLOBALS without a key. Note: overwriting the $GLOBALS variable is no longer allowed since PHP 8.1.
  * - $GLOBALS without a key due to live coding.
  *
  * This test file should generate no errors or warnings.

--- a/WordPress/Tests/Security/EscapeOutputUnitTest.1.inc
+++ b/WordPress/Tests/Security/EscapeOutputUnitTest.1.inc
@@ -462,7 +462,7 @@ echo 1_000_000 + 2_0_0 + 0o12 + 0o20_00, 0XAB953C, 6.674_083e+11, 0b1010;
  */
 user_error( error_level: E_USER_NOTICE ); // OK, well not really, required $message parameter missing, but that's not our concern.
 trigger_error(
-	message: "There was an error: {$message}",
+	messege: "There was an error: {$message}",
 	error_level: E_USER_NOTICE,
 ); // OK, well not really, typo in $message param name, but that's not our concern.
 user_error(

--- a/WordPress/Tests/Security/EscapeOutputUnitTest.1.inc
+++ b/WordPress/Tests/Security/EscapeOutputUnitTest.1.inc
@@ -39,7 +39,7 @@ echo 'Some Raw String';  // Good.
 echo '' . $bad; // Bad, should not validate.
 echo "this is $bad"; // Bad.
 echo esc_html( $good . $better ) . $foo; // Bad, should escape all concatenated elements.
-echo esc_html( $food . 'include'  ); // Good, eveything inside the escaping/sanitizing function should pass.
+echo esc_html( $food . 'include'  ); // Good, everything inside the escaping/sanitizing function should pass.
 echo esc_html( strtoupper( $ok ) ) . $foo; // Bad, again.
 echo esc_html( strtoupper( $ok ) ) . ' ' . esc_html( strtolower( $ok ) ); // Ok.
 
@@ -462,7 +462,7 @@ echo 1_000_000 + 2_0_0 + 0o12 + 0o20_00, 0XAB953C, 6.674_083e+11, 0b1010;
  */
 user_error( error_level: E_USER_NOTICE ); // OK, well not really, required $message parameter missing, but that's not our concern.
 trigger_error(
-	messege: "There was an error: {$message}",
+	message: "There was an error: {$message}",
 	error_level: E_USER_NOTICE,
 ); // OK, well not really, typo in $message param name, but that's not our concern.
 user_error(

--- a/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.4.inc
+++ b/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.4.inc
@@ -167,7 +167,7 @@ _get_path_to_translation_from_lang_dir();
 _get_path_to_translation();
 
 /*
- * Missing text domain and preceeding args, only throw warning.
+ * Missing text domain and preceding args, only throw warning.
  */
 __();
 _e(   /* comment */  );

--- a/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.4.inc.fixed
+++ b/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.4.inc.fixed
@@ -171,7 +171,7 @@ _get_path_to_translation_from_lang_dir( 'something-else' );
 _get_path_to_translation( 'something-else' );
 
 /*
- * Missing text domain and preceeding args, only throw warning.
+ * Missing text domain and preceding args, only throw warning.
  */
 __();
 _e(   /* comment */  );

--- a/phpcs.xml.dist.sample
+++ b/phpcs.xml.dist.sample
@@ -140,7 +140,7 @@
 	so excluding test files from the `WordPress.Files.Filename` sniff can be a
 	legitimate exclusion.
 
-	For more information on ruleset configuration optiones, check out the PHPCS wiki:
+	For more information on ruleset configuration options, check out the PHPCS wiki:
 	https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Annotated-Ruleset
 	-->
 	<rule ref="WordPress.WP.GlobalVariablesOverride">


### PR DESCRIPTION
Found few misspellings.

Remaining ones: "post_statusses" and [cachable](https://github.com/search?q=repo%3AWordPress%2FWordPress-Coding-Standards%20cachable&type=code)

https://github.com/crate-ci/typos