### PR TITLE
Fix typo in AbstractFunctionRestrictionsSniff::is_targetted_token() DocBlock

### DIFF
--- a/WordPress/AbstractFunctionRestrictionsSniff.php
+++ b/WordPress/AbstractFunctionRestrictionsSniff.php
@@ -214,7 +214,7 @@ abstract class AbstractFunctionRestrictionsSniff extends Sniff {
 	}
 
 	/**
-	 * Verify is the current token is a function call.
+	 * Verify if the current token is a function call.
 	 *
 	 * @since 0.11.0 Split out from the `process()` method.
 	 *


### PR DESCRIPTION
This PR fixes a small typo in the `AbstractFunctionRestrictionsSniff::is_targetted_token()` DocBlock.