### PR TITLE
Add ValidTaxonomySlugSniff

### DIFF
--- a/.github/release-checklist.md
+++ b/.github/release-checklist.md
@@ -28,7 +28,8 @@ PR for tracking changes for the x.x.x release. Target release date: **DOW MONTH 
     - [ ] `$pluggable_functions` in `WordPress.NamingConventions.PrefixAllGlobals` - PR #xxx
     - [ ] `$pluggable_classes` in `WordPress.NamingConventions.PrefixAllGlobals` - PR #xxx
     - [ ] `$target_functions` in `WordPress.Security.PluginMenuSlug` - PR #xxx
-    - [ ] `$reserved_names` in `WordPress.NamingConventions.ValidPostTypeSlug` - PR #xxx
+    - [ ] `$post_types` in `WPReservedKeywordHelper` - PR #xxx
+    - [ ] `$terms` in `WPReservedKeywordHelper` - PR #xxx
     - [ ] `$wp_time_constants` in `WordPress.WP.CronInterval` - PR #xxx
     - [ ] `$known_test_classes` in `IsUnitTestTrait` - PR #xxx
     - [ ] ...etc...

--- a/WordPress-Extra/ruleset.xml
+++ b/WordPress-Extra/ruleset.xml
@@ -132,6 +132,9 @@
 	<!-- Validates post type slugs for valid characters, length and reserved keywords. -->
 	<rule ref="WordPress.NamingConventions.ValidPostTypeSlug"/>
 
+	<!-- Validates post type slugs for valid characters, length and reserved keywords. -->
+	<rule ref="WordPress.NamingConventions.ValidTaxonomySlug"/>
+
 	<!-- https://github.com/WordPress/WordPress-Coding-Standards/issues/1157 -->
 	<rule ref="WordPress.Security.PluginMenuSlug"/>
 	<rule ref="WordPress.WP.CronInterval"/>

--- a/WordPress/AbstractValidSlugSniff.php
+++ b/WordPress/AbstractValidSlugSniff.php
@@ -1,0 +1,276 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MITnamespace WordPressCS\WordPress;
+ */
+
+namespace WordPressCS\WordPress;
+
+use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Tokens\Collections;
+use PHPCSUtils\Utils\PassedParameters;
+use PHPCSUtils\Utils\TextStrings;
+use WordPressCS\WordPress\AbstractFunctionParameterSniff;
+
+/**
+ * Validates names passed to a function call.
+ *
+ * Checks slugs for the presence of invalid characters, excessive length,
+ * and reserved keywords.
+ */
+abstract class AbstractValidSlugSniff extends AbstractFunctionParameterSniff {
+
+	/**
+	 * Slug type. E.g. 'post type' for a post type slug.
+	 *
+	 * @var string
+	 */
+	protected $slug_type;
+
+	/**
+	 * Plural of the slug type. E.g. 'post types' for a post type slug.
+	 *
+	 * @var string
+	 */
+	protected $slug_type_plural;
+
+	/**
+	 * Max length of a slug is limited by the SQL field.
+	 *
+	 * @var int
+	 */
+	protected $max_length;
+
+	/**
+	 * Regex to validate the characters that can be used as the slug.
+	 *
+	 * @var string
+	 */
+	protected $valid_characters;
+
+	/**
+	 * Array of reserved names which can not be used by themes and plugins.
+	 *
+	 * @var array<string, true> Key is reserved name, value irrelevant.
+	 */
+	protected $reserved_names;
+
+	/**
+	 * All valid tokens for the slug parameter.
+	 *
+	 * Set in `register()`.
+	 *
+	 * @var array<int|string, int|string>
+	 */
+	private $valid_tokens = array();
+
+	/**
+	 * Constructor.
+	 *
+	 * @since 3.0.0
+	 */
+	public function __construct() {
+		$this->target_functions = $this->get_target_functions();
+		$this->slug_type        = $this->get_slug_type();
+		$this->slug_type_plural = $this->get_slug_type_plural();
+		$this->valid_characters = $this->get_valid_characters();
+		$this->max_length       = $this->get_max_length();
+		$this->reserved_names   = $this->get_reserved_names();
+	}
+
+	/**
+	 * Retrieve function and parameter(s) pairs this sniff is looking for.
+	 *
+	 * The parameter or an array of parameters keyed by target function.
+	 * An array of names is supported to allow for functions for which the
+	 * parameter names have undergone name changes over time.
+	 *
+	 * @return array<string, string|array<string>> Function parameter(s) pairs.
+	 */
+	abstract protected function get_target_functions();
+
+	/**
+	 * Retrieve the slug type.
+	 *
+	 * @return string The slug type.
+	 */
+	abstract protected function get_slug_type();
+
+	/**
+	 * Retrieve the plural slug type.
+	 *
+	 * @return string The plural slug type.
+	 */
+	abstract protected function get_slug_type_plural();
+
+	/**
+	 * Retrieve the regex to validate the characters that can be used as
+	 * the slug.
+	 *
+	 * @return string Regular expression.
+	 */
+	abstract protected function get_valid_characters();
+
+	/**
+	 * Retrieve the max length of a slug.
+	 *
+	 * The length is limited by the SQL field.
+	 *
+	 * @return int The maximum length of a slug.
+	 */
+	abstract protected function get_max_length();
+
+	/**
+	 * Retrieve the reserved names which can not be used by themes and plugins.
+	 *
+	 * @return array<string, true> Key is reserved name, value irrelevant.
+	 */
+	abstract protected function get_reserved_names();
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @return array
+	 */
+	public function register() {
+		$this->valid_tokens = Tokens::$textStringTokens + Tokens::$heredocTokens + Tokens::$emptyTokens;
+		return parent::register();
+	}
+
+	/**
+	 * Process the parameter of a matched function.
+	 *
+	 * Errors on invalid names when reserved keywords are used,
+	 * the name is too long, or contains invalid characters.
+	 *
+	 * @param int    $stackPtr        The position of the current token in the stack.
+	 * @param string $group_name      The name of the group which was matched.
+	 * @param string $matched_content The token content (function name) which was matched
+	 *                                in lowercase.
+	 * @param array  $parameters      Array with information about the parameters.
+	 *
+	 * @return void
+	 */
+	public function process_parameters( $stackPtr, $group_name, $matched_content, $parameters ) {
+		$slug_param = PassedParameters::getParameterFromStack(
+			$parameters,
+			1,
+			$this->target_functions[ $matched_content ]
+		);
+		if ( false === $slug_param || '' === $slug_param['clean'] ) {
+			// Error for using empty slug.
+			$this->phpcsFile->addError(
+				'%s() called without a %s slug. The slug must be a non-empty string.',
+				false === $slug_param ? $stackPtr : $slug_param['start'],
+				'Empty',
+				array(
+					$matched_content,
+					$this->slug_type,
+				)
+			);
+			return;
+		}
+
+		$string_start = $this->phpcsFile->findNext( Collections::textStringStartTokens(), $slug_param['start'], ( $slug_param['end'] + 1 ) );
+		$string_pos   = $this->phpcsFile->findNext( Tokens::$textStringTokens, $slug_param['start'], ( $slug_param['end'] + 1 ) );
+
+		$has_invalid_tokens = $this->phpcsFile->findNext( $this->valid_tokens, $slug_param['start'], ( $slug_param['end'] + 1 ), true );
+		if ( false !== $has_invalid_tokens || false === $string_pos ) {
+			// Check for non string based slug parameter (we cannot determine if this is valid).
+			$this->phpcsFile->addWarning(
+				'The %s slug is not a string literal. It is not possible to automatically determine the validity of this slug. Found: %s.',
+				$stackPtr,
+				'NotStringLiteral',
+				array(
+					$this->slug_type,
+					$slug_param['clean'],
+				),
+				3
+			);
+			return;
+		}
+
+		$slug = TextStrings::getCompleteTextString( $this->phpcsFile, $string_start );
+		if ( isset( Tokens::$heredocTokens[ $this->tokens[ $string_start ]['code'] ] ) ) {
+			// Trim off potential indentation from PHP 7.3 flexible heredoc/nowdoc content.
+			$slug = ltrim( $slug );
+		}
+
+		// Warn for dynamic parts in the slug parameter.
+		if ( 'T_DOUBLE_QUOTED_STRING' === $this->tokens[ $string_pos ]['type']
+			|| ( 'T_HEREDOC' === $this->tokens[ $string_pos ]['type']
+			&& strpos( $this->tokens[ $string_pos ]['content'], '$' ) !== false )
+		) {
+			$this->phpcsFile->addWarning(
+				'The %s slug may, or may not, get too long with dynamic contents and could contain invalid characters. Found: "%s".',
+				$string_pos,
+				'PartiallyDynamic',
+				array(
+					$this->slug_type,
+					$slug,
+				)
+			);
+			$slug = TextStrings::stripEmbeds( $slug );
+		}
+
+		if ( preg_match( $this->valid_characters, $slug ) === 0 ) {
+			// Error for invalid characters.
+			$this->phpcsFile->addError(
+				'%s() called with invalid %s "%s". %s contains invalid characters. Only lowercase alphanumeric characters, dashes, and underscores are allowed.',
+				$string_pos,
+				'InvalidCharacters',
+				array(
+					$matched_content,
+					$this->slug_type,
+					ucfirst( $this->slug_type ),
+					$slug,
+				)
+			);
+		}
+
+		if ( isset( $this->reserved_names[ $slug ] ) ) {
+			// Error for using reserved slug names.
+			$this->phpcsFile->addError(
+				'%s() called with reserved %s "%s". Reserved %s should not be used as they interfere with the functioning of WordPress itself.',
+				$string_pos,
+				'Reserved',
+				array(
+					$matched_content,
+					$this->slug_type,
+					$slug,
+					$this->slug_type_plural,
+				)
+			);
+		} elseif ( stripos( $slug, 'wp_' ) === 0 ) {
+			// Error for using reserved slug prefix.
+			$this->phpcsFile->addError(
+				'The %s passed to %s() uses a prefix reserved for WordPress itself. Found: "%s".',
+				$string_pos,
+				'ReservedPrefix',
+				array(
+					$this->slug_type,
+					$matched_content,
+					$slug,
+				)
+			);
+		}
+
+		// Error for slugs that are too long.
+		if ( strlen( $slug ) > $this->max_length ) {
+			$this->phpcsFile->addError(
+				'A %s slug must not exceed %d characters. Found: "%s" (%d characters).',
+				$string_pos,
+				'TooLong',
+				array(
+					$this->slug_type,
+					$this->max_length,
+					$slug,
+					strlen( $slug ),
+				)
+			);
+		}
+	}
+}

--- a/WordPress/Docs/NamingConventions/ValidTaxonomySlugStandard.xml
+++ b/WordPress/Docs/NamingConventions/ValidTaxonomySlugStandard.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Valid Taxonomy Slug"
+    >
+    <standard>
+    <![CDATA[
+    The taxonomy slug used in register_taxonomy() must be between 1 and 32 characters.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: Short taxonomy slug.">
+        <![CDATA[
+register_taxonomy(
+    <em>'my_short_slug'</em>,
+    array()
+);
+        ]]>
+        </code>
+        <code title="Invalid: Too long taxonomy slug.">
+        <![CDATA[
+register_taxonomy(
+    <em>'my_very_own_taxonomy_is_much_too_long'</em>,
+    array()
+);
+        ]]>
+        </code>
+    </code_comparison>
+    <standard>
+    <![CDATA[
+    The taxonomy slug used in register_taxonomy() can only contain lowercase alphanumeric characters, dashes and underscores.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: No special characters in taxonomy slug.">
+        <![CDATA[
+register_taxonomy(
+    <em>'my_taxonomy_slug'</em>,
+    array()
+);
+        ]]>
+        </code>
+        <code title="Invalid: Invalid characters in taxonomy slug.">
+        <![CDATA[
+register_taxonomy(
+    <em>'my/taxonomy/slug'</em>,
+    array()
+);
+        ]]>
+        </code>
+    </code_comparison>
+    <standard>
+    <![CDATA[
+    One should be careful with passing dynamic slug names to "register_taxonomy()", as the slug may become too long and could contain invalid characters.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: Static taxonomy slug.">
+        <![CDATA[
+register_taxonomy(
+    <em>'my_taxonomy_active'</em>,
+    array()
+);
+        ]]>
+        </code>
+        <code title="Invalid: Dynamic taxonomy slug.">
+        <![CDATA[
+register_taxonomy(
+    <em>"my_taxonomy_{$status}"</em>,
+    array()
+);
+        ]]>
+        </code>
+    </code_comparison>
+    <standard>
+    <![CDATA[
+    The taxonomy slug used in register_taxonomy() can not use reserved keywords, such as the ones used by WordPress itself.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: Prefixed taxonomy slug.">
+        <![CDATA[
+register_taxonomy(
+    <em>'prefixed_post_tag'</em>,
+    array()
+);
+        ]]>
+        </code>
+        <code title="Invalid: Using a reserved keyword as slug.">
+        <![CDATA[
+register_taxonomy(
+    <em>'post_tag'</em>,
+    array()
+);
+        ]]>
+        </code>
+    </code_comparison>
+    <standard>
+    <![CDATA[
+    The taxonomy slug used in register_taxonomy() can not use reserved prefixes, such as 'wp_', which is used by WordPress itself.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: Custom prefix taxonomy slug.">
+        <![CDATA[
+register_taxonomy(
+    <em>'prefixed_post_tag'</em>,
+    array()
+);
+        ]]>
+        </code>
+        <code title="Invalid: Using a reserved prefix.">
+        <![CDATA[
+register_taxonomy(
+    <em>'wp_post_tag'</em>,
+    array()
+);
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/WordPress/Helpers/WPReservedKeywordHelper.php
+++ b/WordPress/Helpers/WPReservedKeywordHelper.php
@@ -1,0 +1,187 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPressCS\WordPress\Helpers;
+
+/**
+ * Helper utilities for recognizing WP reserved keywords.
+ */
+final class WPReservedKeywordHelper {
+	/**
+	 * Array of reserved post type names which can not be used by themes and plugins.
+	 *
+	 * Source: {@link https://developer.wordpress.org/reference/functions/register_post_type/#reserved-post-types}
+	 *
+	 * {@internal To be updated after every major release. Last updated for WordPress 6.5-RC3.}
+	 *
+	 * @var array<string, true> Key is reserved post type name, value irrelevant.
+	 */
+	private static $post_types = array(
+		'action'              => true, // Not a WP post type, but prevents other problems.
+		'attachment'          => true,
+		'author'              => true, // Not a WP post type, but prevents other problems.
+		'custom_css'          => true,
+		'customize_changeset' => true,
+		'nav_menu_item'       => true,
+		'oembed_cache'        => true,
+		'order'               => true, // Not a WP post type, but prevents other problems.
+		'page'                => true,
+		'post'                => true,
+		'revision'            => true,
+		'theme'               => true, // Not a WP post type, but prevents other problems.
+		'user_request'        => true,
+		'wp_block'            => true,
+		'wp_font_face'        => true,
+		'wp_font_family'      => true,
+		'wp_global_styles'    => true,
+		'wp_navigation'       => true,
+		'wp_template'         => true,
+		'wp_template_part'    => true,
+	);
+
+	/**
+	 * Array of reserved taxonomy names which can not be used by themes and plugins.
+	 *
+	 * Source: {@link https://developer.wordpress.org/reference/functions/register_taxonomy/#reserved-terms}
+	 *
+	 * {@internal To be updated after every major release.}
+	 *
+	 * @var array<string, true> Key is reserved taxonomy name, value irrelevant.
+	 */
+	private static $terms = array(
+		'attachment'                  => true,
+		'attachment_id'               => true,
+		'author'                      => true,
+		'author_name'                 => true,
+		'calendar'                    => true,
+		'cat'                         => true,
+		'category'                    => true,
+		'category__and'               => true,
+		'category__in'                => true,
+		'category__not_in'            => true,
+		'category_name'               => true,
+		'comments_per_page'           => true,
+		'comments_popup'              => true,
+		'custom'                      => true,
+		'customize_messenger_channel' => true,
+		'customized'                  => true,
+		'cpage'                       => true,
+		'day'                         => true,
+		'debug'                       => true,
+		'embed'                       => true,
+		'error'                       => true,
+		'exact'                       => true,
+		'feed'                        => true,
+		'fields'                      => true,
+		'hour'                        => true,
+		'link_category'               => true,
+		'm'                           => true,
+		'minute'                      => true,
+		'monthnum'                    => true,
+		'more'                        => true,
+		'name'                        => true,
+		'nav_menu'                    => true,
+		'nonce'                       => true,
+		'nopaging'                    => true,
+		'offset'                      => true,
+		'order'                       => true,
+		'orderby'                     => true,
+		'p'                           => true,
+		'page'                        => true,
+		'page_id'                     => true,
+		'paged'                       => true,
+		'pagename'                    => true,
+		'pb'                          => true,
+		'perm'                        => true,
+		'post'                        => true,
+		'post__in'                    => true,
+		'post__not_in'                => true,
+		'post_format'                 => true,
+		'post_mime_type'              => true,
+		'post_status'                 => true,
+		'post_tag'                    => true,
+		'post_type'                   => true,
+		'posts'                       => true,
+		'posts_per_archive_page'      => true,
+		'posts_per_page'              => true,
+		'preview'                     => true,
+		'robots'                      => true,
+		's'                           => true,
+		'search'                      => true,
+		'second'                      => true,
+		'sentence'                    => true,
+		'showposts'                   => true,
+		'static'                      => true,
+		'status'                      => true,
+		'subpost'                     => true,
+		'subpost_id'                  => true,
+		'tag'                         => true,
+		'tag__and'                    => true,
+		'tag__in'                     => true,
+		'tag__not_in'                 => true,
+		'tag_id'                      => true,
+		'tag_slug__and'               => true,
+		'tag_slug__in'                => true,
+		'taxonomy'                    => true,
+		'tb'                          => true,
+		'term'                        => true,
+		'terms'                       => true,
+		'theme'                       => true,
+		'title'                       => true,
+		'type'                        => true,
+		'types'                       => true,
+		'w'                           => true,
+		'withcomments'                => true,
+		'withoutcomments'             => true,
+		'year'                        => true,
+	);
+
+	/**
+	 * Verify if a given keyword is a reserved post type name.
+	 *
+	 * @param string $name The keyword to be checked.
+	 *
+	 * @return bool
+	 */
+	public static function is_reserved_post_type( $name ) {
+
+		return isset( self::$post_types[ $name ] );
+	}
+
+	/**
+	 * Verify if a given keyword is a reserved taxonomy name.
+	 *
+	 * @param string $name The keyword to be checked.
+	 *
+	 * @return bool
+	 */
+	public static function is_reserved_term( $name ) {
+
+		return isset( self::$terms[ $name ] )
+			|| isset( self::$post_types[ $name ] );
+	}
+
+	/**
+	 * Retrieve an array with the reserved post type names.
+	 *
+	 * @return array<string, true> Array with the post type names as keys. The value is irrelevant.
+	 */
+	public static function get_post_types() {
+		return self::$post_types;
+	}
+
+	/**
+	 * Retrieve an array with the reserved taxonomy names.
+	 *
+	 * @return array<string, true> Array with the taxonomy names as keys. The value is irrelevant.
+	 */
+	public static function get_terms() {
+		return array_merge( self::$post_types, self::$terms );
+	}
+}

--- a/WordPress/Sniffs/NamingConventions/ValidTaxonomySlugSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidTaxonomySlugSniff.php
@@ -13,16 +13,14 @@ use WordPressCS\WordPress\AbstractValidSlugSniff;
 use WordPressCS\WordPress\Helpers\WPReservedKeywordHelper;
 
 /**
- * Validates post type names.
+ * Validates taxonomy names.
  *
- * Checks post type slugs for the presence of invalid characters, excessive
+ * Checks taxonomy slugs for the presence of invalid characters, excessive
  * length, and reserved keywords.
  *
- * @link https://developer.wordpress.org/reference/functions/register_post_type/
- *
- * @since 2.2.0
+ * @link https://developer.wordpress.org/reference/functions/register_taxonomy/
  */
-final class ValidPostTypeSlugSniff extends AbstractValidSlugSniff {
+final class ValidTaxonomySlugSniff extends AbstractValidSlugSniff {
 
 	/**
 	 * Retrieve function and parameter(s) pairs this sniff is looking for.
@@ -31,7 +29,7 @@ final class ValidPostTypeSlugSniff extends AbstractValidSlugSniff {
 	 */
 	protected function get_target_functions() {
 		return array(
-			'register_post_type' => array( 'post_type' ),
+			'register_taxonomy' => array( 'taxonomy' ),
 		);
 	}
 
@@ -41,7 +39,7 @@ final class ValidPostTypeSlugSniff extends AbstractValidSlugSniff {
 	 * @return string The slug type.
 	 */
 	protected function get_slug_type() {
-		return 'post type';
+		return 'taxonomy';
 	}
 
 	/**
@@ -50,14 +48,14 @@ final class ValidPostTypeSlugSniff extends AbstractValidSlugSniff {
 	 * @return string The plural slug type.
 	 */
 	protected function get_slug_type_plural() {
-		return 'post types';
+		return 'taxonomies';
 	}
 
 	/**
 	 * Retrieve regex to validate the characters that can be used as the
-	 * post type slug.
+	 * taxonomy slug.
 	 *
-	 * @link https://developer.wordpress.org/reference/functions/register_post_type/
+	 * @link https://developer.wordpress.org/reference/functions/register_taxonomy/
 	 *
 	 * @var string
 	 */
@@ -66,21 +64,21 @@ final class ValidPostTypeSlugSniff extends AbstractValidSlugSniff {
 	}
 
 	/**
-	 * Retrieve max length of a post type name.
+	 * Retrieve max length of a taxonomy name.
 	 *
 	 * @var int
 	 */
 	protected function get_max_length() {
-		return 20;
+		return 32;
 	}
 
 	/**
-	 * Retrieve the reserved post type names which can not be used
+	 * Retrieve the reserved taxonomy names which can not be used
 	 * by themes and plugins.
 	 *
 	 * @return array<string, true>
 	 */
 	protected function get_reserved_names() {
-		return WPReservedKeywordHelper::get_post_types();
+		return WPReservedKeywordHelper::get_terms();
 	}
 }

--- a/WordPress/Tests/NamingConventions/ValidTaxonomySlugUnitTest.1.inc
+++ b/WordPress/Tests/NamingConventions/ValidTaxonomySlugUnitTest.1.inc
@@ -1,0 +1,70 @@
+<?php
+
+register_taxonomy( 'my-own-taxonomy', array() ); // OK.
+register_taxonomy( 'my_own_taxonomy', array() ); // OK.
+register_taxonomy( 'my-own-taxonomy-tooooooooooo-long', array() ); // Bad.
+register_taxonomy( 'post_tag', array() ); // Bad. Reserved slug name.
+register_taxonomy( 'My-Own-taxonomy', array() ); // Bad. Invalid chars: uppercase.
+register_taxonomy( 'my/own/taxonomy', array() ); // Bad. Invalid chars: "/".
+
+register_taxonomy( <<<EOD
+my_own_taxonomy
+EOD
+); // OK.
+register_taxonomy( <<<'EOD'
+my_own_taxonomy
+EOD
+); // OK.
+
+register_taxonomy( <<<'EOD'
+my/own/taxonomy
+EOD
+); // Bad. Invalid chars: "/".
+
+register_taxonomy( "my_taxonomy_{$i}" ); // Warning, taxonomy may or may not get too long with dynamic contents in the id.
+
+// Non string literals.
+register_taxonomy( sprintf( 'my_taxonomy_%d', $i ) ); // Non string literal. Warning with severity: 3
+register_taxonomy( post ); // = lowercase global constant. Non string literal. Warning with severity: 3
+register_taxonomy( self::ID ); // Non string literal. Warning with severity: 3
+register_taxonomy( $taxonomy_name ); // Non string literal. Warning with severity: 3
+register_taxonomy( $this->get_taxonomy_id() ); // Non string literal. Warning with severity: 3
+
+register_taxonomy( null, array() ); // Non string literal. Warning with severity: 3
+register_taxonomy( 1000, array() ); // Non string literal. Warning with severity: 3
+
+register_taxonomy( 'wp_', array() ); // Bad. Reserved prefix.
+register_taxonomy( 'wp_taxonomy', array() ); // Bad. Reserved prefix.
+
+register_taxonomy( '', array() ); // Bad. Empty taxonomy slug.
+register_taxonomy( /*comment*/, array() ); // Bad. No taxonomy slug.
+
+register_taxonomy( 'taxonomy_1', array() ); // OK.
+
+register_taxonomy( <<<EOD
+my_here_doc_{$i}
+EOD
+); // Warning, post type may or may not get too long with dynamic contents in the id.
+
+register_taxonomy( "my-own-taxonomy-toooooooooo-long-{$i}" ); // 1x Error, Too long. 1x Warning, post type may or may not get too long with dynamic contents in the id.
+register_taxonomy( 'my/own/taxonomy/tooooooooooo/long', array() ); // Bad. Invalid chars: "/" and too long.
+
+register_taxonomy( 'wp_block', array() ); // Bad. Must only error on reserved keyword, not invalid prefix.
+
+// Test handling of more complex embedded variables and expressions.
+register_taxonomy("testing123-${(foo)}-test");
+register_taxonomy("testing123-${foo["${bar['baz']}"]}-test");
+
+// Test ignoring invalid function calls/live coding.
+register_taxonomy(); // OK, ignore, presume live coding.
+
+// Safeguard support for PHP 8.0+ named parameters.
+register_taxonomy( args: array() ); // Bad. No taxonomy slug.
+register_taxonomy( args: array(), taxonomy: 'my_own_taxonomy',  ); // OK.
+register_taxonomy( args: array(), taxonomy: 'my-own-taxonomy-tooooooooooo-long' ); // Bad.
+
+// Safeguard that the information displayed in the error message is cleaned of comments.
+register_taxonomy(
+	// 'Taxonomy' name.
+	$name,// Non string literal. Warning with severity: 3
+);

--- a/WordPress/Tests/NamingConventions/ValidTaxonomySlugUnitTest.2.inc
+++ b/WordPress/Tests/NamingConventions/ValidTaxonomySlugUnitTest.2.inc
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * Tests with PHP 7.3+ flexible heredoc/nowdoc.
+ */
+register_taxonomy( <<<EOD
+    my_{$custom}_taxonomy
+    EOD
+); // 1x Warning, taxonomy may or may not get too long with dynamic contents in the id.
+
+register_taxonomy( <<<'EOD'
+		my_own_taxonomy
+	EOD
+); // OK.
+
+register_taxonomy( <<<'EOD'
+		my*own+taxo&nomy
+	EOD
+); // Bad. Invalid chars: "/".

--- a/WordPress/Tests/NamingConventions/ValidTaxonomySlugUnitTest.php
+++ b/WordPress/Tests/NamingConventions/ValidTaxonomySlugUnitTest.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * Unit test class for WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPressCS\WordPress\Tests\NamingConventions;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+/**
+ * Unit test class for the Taxonomy sniff.
+ *
+ * @covers \WordPressCS\WordPress\Sniffs\NamingConventions\ValidTaxonomySlugSniff
+ */
+final class ValidTaxonomySlugUnitTest extends AbstractSniffUnitTest {
+
+	/**
+	 * Set warnings level to 3 to trigger suggestions as warnings.
+	 *
+	 * @param string                  $filename The name of the file being tested.
+	 * @param \PHP_CodeSniffer\Config $config   The config data for the run.
+	 *
+	 * @return void
+	 */
+	public function setCliValues( $filename, $config ) {
+		$config->warningSeverity = 3;
+	}
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * @param string $testFile The name of the file being tested.
+	 *
+	 * @return array<int, int> Key is the line number, value is the number of expected errors.
+	 */
+	public function getErrorList( $testFile = '' ) {
+		switch ( $testFile ) {
+			case 'ValidTaxonomySlugUnitTest.1.inc':
+				return array(
+					5  => 1,
+					6  => 1,
+					7  => 1,
+					8  => 1,
+					20 => 1,
+					36 => 1,
+					37 => 1,
+					39 => 1,
+					40 => 1,
+					49 => 1,
+					50 => 2,
+					52 => 1,
+					62 => 1,
+					64 => 1,
+				);
+
+			case 'ValidTaxonomySlugUnitTest.2.inc':
+				// These tests will only yield reliable results when PHPCS is run on PHP 7.3 or higher.
+				if ( \PHP_VERSION_ID < 70300 ) {
+					return array();
+				}
+
+				return array(
+					17 => 1,
+				);
+
+			default:
+				return array();
+		}
+	}
+
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * @param string $testFile The name of the file being tested.
+	 *
+	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
+	 */
+	public function getWarningList( $testFile = '' ) {
+		switch ( $testFile ) {
+			case 'ValidTaxonomySlugUnitTest.1.inc':
+				return array(
+					24 => 1,
+					27 => 1,
+					28 => 1,
+					29 => 1,
+					30 => 1,
+					31 => 1,
+					33 => 1,
+					34 => 1,
+					45 => 1,
+					49 => 1,
+					55 => 1,
+					56 => 1,
+					67 => 1,
+				);
+
+			case 'ValidTaxonomySlugUnitTest.2.inc':
+				// These tests will only yield reliable results when PHPCS is run on PHP 7.3 or higher.
+				if ( \PHP_VERSION_ID < 70300 ) {
+					return array();
+				}
+
+				return array(
+					7 => 1,
+				);
+
+			default:
+				return array();
+		}
+	}
+}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -25,6 +25,7 @@
 			<file>./WordPress/AbstractClassRestrictionsSniff.php</file>
 			<file>./WordPress/AbstractFunctionParameterSniff.php</file>
 			<file>./WordPress/AbstractFunctionRestrictionsSniff.php</file>
+			<file>./WordPress/AbstractValidSlugSniff.php</file>
 			<directory>./WordPress/Sniffs/</directory>
 			<directory>./WordPress/Helpers/</directory>
 		</whitelist>


### PR DESCRIPTION
- Adds `AbstractValidSlugSniff`, which can serve as a base for sniffs that check a function parameter to ensure it is a valid slug.
- Refactors `ValidPostTypeSlugSniff` to extend `AbstractValidSlugSniff`.
- Introduces `ValidTaxonomySlugSniff`, which also extends `AbstractValidSlugSniff`.
- Adds `WPReservedKeywordHelper` to centrally store reserved keywords.

All sniff classes inherit the public property `$exclude` from `AbstractFunctionRestrictionsSniff`.

`WPReservedKeywordHelper::$terms` requires a "Last updated for WordPress x.x."