### PR TITLE
GH Actions: always quote variables

### DIFF
--- a/.github/workflows/basic-qa.yml
+++ b/.github/workflows/basic-qa.yml
@@ -186,7 +186,7 @@ jobs:
           set +e
           $(pwd)/vendor/bin/phpcbf -pq ./WordPress/Tests/ --standard=WordPress --extensions=inc --exclude=Generic.PHP.Syntax --report=summary --ignore=/WordPress/Tests/WP/GlobalVariablesOverrideUnitTest.7.inc
           exitcode="$?"
-          echo "EXITCODE=$exitcode" >> $GITHUB_OUTPUT
+          echo "EXITCODE=$exitcode" >> "$GITHUB_OUTPUT"
           exit "$exitcode"
 
       - name: Fail the build on fixer conflicts and other errors

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -91,9 +91,9 @@ jobs:
         id: set_ini
         run: |
           if [ "${{ matrix.dependencies }}" != "dev" ]; then
-            echo 'PHP_INI=error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On' >> $GITHUB_OUTPUT
+            echo 'PHP_INI=error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On' >> "$GITHUB_OUTPUT"
           else
-            echo 'PHP_INI=error_reporting=-1, display_errors=On' >> $GITHUB_OUTPUT
+            echo 'PHP_INI=error_reporting=-1, display_errors=On' >> "$GITHUB_OUTPUT"
           fi
 
       - name: Set up PHP


### PR DESCRIPTION
... to satisfy shellcheck rule SC2086: "Double quote to prevent globbing and word splitting".

Ref: https://www.shellcheck.net/wiki/SC2086