### PR TITLE
Various sniffs: simplify skipping the rest of the file

### DIFF
--- a/WordPress/Sniffs/Files/FileNameSniff.php
+++ b/WordPress/Sniffs/Files/FileNameSniff.php
@@ -154,7 +154,7 @@ final class FileNameSniff extends Sniff {
 		// Usage of `stripQuotes` is to ensure `stdin_path` passed by IDEs does not include quotes.
 		$file = TextStrings::stripQuotes( $this->phpcsFile->getFileName() );
 		if ( 'STDIN' === $file ) {
-			return;
+			return $this->phpcsFile->numTokens;
 		}
 
 		$class_ptr = $this->phpcsFile->findNext( \T_CLASS, $stackPtr );
@@ -163,7 +163,7 @@ final class FileNameSniff extends Sniff {
 			 * This rule should not be applied to test classes (at all).
 			 * @link https://github.com/WordPress/WordPress-Coding-Standards/issues/1995
 			 */
-			return;
+			return $this->phpcsFile->numTokens;
 		}
 
 		// Respect phpcs:disable comments as long as they are not accompanied by an enable.
@@ -184,7 +184,7 @@ final class FileNameSniff extends Sniff {
 
 				if ( false === $i ) {
 					// The entire (rest of the) file is disabled.
-					return;
+					return $this->phpcsFile->numTokens;
 				}
 			}
 		}
@@ -204,7 +204,7 @@ final class FileNameSniff extends Sniff {
 		}
 
 		// Only run this sniff once per file, no need to run it again.
-		return ( $this->phpcsFile->numTokens + 1 );
+		return $this->phpcsFile->numTokens;
 	}
 
 	/**

--- a/WordPress/Sniffs/Utils/I18nTextDomainFixerSniff.php
+++ b/WordPress/Sniffs/Utils/I18nTextDomainFixerSniff.php
@@ -394,7 +394,7 @@ final class I18nTextDomainFixerSniff extends AbstractFunctionParameterSniff {
 		if ( ! is_string( $this->new_text_domain )
 			|| '' === $this->new_text_domain
 		) {
-			return ( $this->phpcsFile->numTokens + 1 );
+			return $this->phpcsFile->numTokens;
 		}
 
 		if ( isset( $this->old_text_domain ) ) {
@@ -403,7 +403,7 @@ final class I18nTextDomainFixerSniff extends AbstractFunctionParameterSniff {
 			if ( ! is_array( $this->old_text_domain )
 				|| array() === $this->old_text_domain
 			) {
-				return ( $this->phpcsFile->numTokens + 1 );
+				return $this->phpcsFile->numTokens;
 			}
 		}
 
@@ -421,7 +421,7 @@ final class I18nTextDomainFixerSniff extends AbstractFunctionParameterSniff {
 					array( $this->new_text_domain )
 				);
 
-				return ( $this->phpcsFile->numTokens + 1 );
+				return $this->phpcsFile->numTokens;
 			}
 
 			if ( preg_match( '`^[a-z0-9-]+$`', $this->new_text_domain ) !== 1 ) {
@@ -432,14 +432,14 @@ final class I18nTextDomainFixerSniff extends AbstractFunctionParameterSniff {
 					array( $this->new_text_domain )
 				);
 
-				return ( $this->phpcsFile->numTokens + 1 );
+				return $this->phpcsFile->numTokens;
 			}
 
 			// If the text domain passed both validations, it should be considered valid.
 			$this->is_valid = true;
 
 		} elseif ( false === $this->is_valid ) {
-			return ( $this->phpcsFile->numTokens + 1 );
+			return $this->phpcsFile->numTokens;
 		}
 
 		if ( isset( $this->tab_width ) === false ) {
@@ -685,7 +685,7 @@ final class I18nTextDomainFixerSniff extends AbstractFunctionParameterSniff {
 		if ( isset( $this->phpcsFile->tokenizerType ) && 'CSS' === $this->phpcsFile->tokenizerType ) {
 			if ( 'style.css' !== $file_name && ! defined( 'PHP_CODESNIFFER_IN_TESTS' ) ) {
 				// CSS files only need to be examined for the file header.
-				return ( $this->phpcsFile->numTokens + 1 );
+				return $this->phpcsFile->numTokens;
 			}
 
 			$regex   = $this->theme_header_regex;


### PR DESCRIPTION
This commit updates various sniffs to use `return $phpcsFile->numTokens` instead of `return ($phpcsFile->numTokens + 1)`.

If a sniff file contains 50 tokens, the last `$stackPtr` will be 49, so returning `50` will already get us passed the end of the token stack and the `+ 1` is redundant.

Includes changing a few plain `return` statements to `return $phpcsFile->numTokens` for efficiency.