### PR TITLE
GH Actions: use explicit PHPStan major

### DIFF
--- a/.github/workflows/basic-qa.yml
+++ b/.github/workflows/basic-qa.yml
@@ -207,7 +207,7 @@ jobs:
         with:
           php-version: 'latest'
           coverage: none
-          tools: phpstan
+          tools: phpstan:1.x
 
       # Install dependencies and handle caching in one go.
       # Dependencies need to be installed to make sure the PHPCS and PHPUnit classes are recognized.


### PR DESCRIPTION
This Monday, [PHPStan 2.0 will be released](https://phpc.social/@OndrejMirtes/113441109253809720).

I've done some preliminary scans with PHPStan 2.0-dev to check if this would have an impact on this codebase and as things are, this would mean the build would start to fail.

For now, I'm proposing to make a small change in the GH Actions workflow to explicitly use PHPStan 1.x.

This buys us some time to evaluate PHPStan 2.0 properly and to make any changes needed to make the codebase compatible with PHPStan 2.x when we're ready for it.