### PR TITLE
CS/QA: remove redundant condition

### DIFF
--- a/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
+++ b/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
@@ -1289,7 +1289,7 @@ final class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 	 */
 	private function record_potential_prefix_metric( $stackPtr, $construct_name ) {
 		if ( preg_match( '`^([A-Z]*[a-z0-9]*+)`', ltrim( $construct_name, '\$_' ), $matches ) > 0
-			&& isset( $matches[1] ) && '' !== $matches[1]
+			&& '' !== $matches[1]
 		) {
 			$this->phpcsFile->recordMetric( $stackPtr, 'Prefix all globals: potential prefixes - start of non-prefixed construct', strtolower( $matches[1] ) );
 		}


### PR DESCRIPTION
Even though PR #2507 ensured we didn't automatically move onto PHPStan 2.0, the build is still failing as PHPStan 1.12.9 contained a change which causes a new error to show up.

This commit fixes [the newly flagged issue](https://github.com/WordPress/WordPress-Coding-Standards/actions/runs/11775908547/job/32797254994) to allow builds to pass again.

Ref: https://github.com/phpstan/phpstan/releases/tag/1.12.9