### PR TITLE
Add tests for code handling STDIN for the sniffs FileName and I18nTextDomainFixer

### DIFF
--- a/WordPress/Tests/Files/FileNameUnitTest.php
+++ b/WordPress/Tests/Files/FileNameUnitTest.php
@@ -9,7 +9,11 @@
 
 namespace WordPressCS\WordPress\Tests\Files;
 
+use PHP_CodeSniffer\Files\DummyFile;
+use PHP_CodeSniffer\Ruleset;
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHPCSUtils\BackCompat\Helper;
+use PHPCSUtils\TestUtils\ConfigDouble;
 
 /**
  * Unit test class for the FileName sniff.
@@ -171,5 +175,27 @@ final class FileNameUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getWarningList() {
 		return array();
+	}
+
+	/**
+	 * Test the sniff bails early when handling STDIN.
+	 *
+	 * @return void
+	 */
+	public function testStdIn() {
+		$config = new ConfigDouble();
+		Helper::setConfigData( 'installed_paths', dirname( dirname( __DIR__ ) ), true, $config );
+		$config->standards = array( 'WordPress' );
+		$config->sniffs    = array( 'WordPress.Files.FileName' );
+
+		$ruleset = new Ruleset( $config );
+
+		$content = '<?php ';
+		$file    = new DummyFile( $content, $ruleset, $config );
+		$file->process();
+
+		$this->assertSame( 0, $file->getErrorCount() );
+		$this->assertSame( 0, $file->getWarningCount() );
+		$this->assertCount( 0, $file->getErrors() );
 	}
 }


### PR DESCRIPTION
This PR adds a test to cover code handling STDIN for the two sniffs that check it: `WordPress.Files.FileName` and `WordPress.Utils.I18nTextDomainFixer`. This is based on a related suggestion from @jrfnl for a PHPCS sniff: https://github.com/PHPCSStandards/PHP_CodeSniffer/pull/681#pullrequestreview-2456746389.

I'm not sure if I missed something, but I could not make the `ConfigDouble` class work passing the standard and sniff names as parameters. I had to create a custom ruleset file and include the sniff passing its path. I believe this happens because the `ConfigDouble` class erases the config data, and thus, `installed_paths` is empty.