### PR TITLE
I18nTextDomainFixer: remove unnecessary variable initialization

### DIFF
--- a/WordPress/Sniffs/Utils/I18nTextDomainFixerSniff.php
+++ b/WordPress/Sniffs/Utils/I18nTextDomainFixerSniff.php
@@ -674,7 +674,6 @@ final class I18nTextDomainFixerSniff extends AbstractFunctionParameterSniff {
 		$regex   = $this->plugin_header_regex;
 		$headers = $this->plugin_headers;
 		$type    = 'plugin';
-		$skip_to = $stackPtr;
 
 		$file = TextStrings::stripQuotes( $this->phpcsFile->getFileName() );
 		if ( 'STDIN' === $file ) {


### PR DESCRIPTION
While working on #2512, I noticed an unnecessary variable initialization, so I'm creating this PR to suggest that it be removed. Its value is immediately overridden in an if/else below.

https://github.com/rodrigoprimo/WordPress-Coding-Standards/blob/690f05a51d190586e0bb0426a0f04242224d0723/WordPress/Sniffs/Utils/I18nTextDomainFixerSniff.php#L727

https://github.com/rodrigoprimo/WordPress-Coding-Standards/blob/690f05a51d190586e0bb0426a0f04242224d0723/WordPress/Sniffs/Utils/I18nTextDomainFixerSniff.php#L749