### PR TITLE
Remove unused variables from a few sniffs

### DIFF
--- a/WordPress/Sniffs/Security/EscapeOutputSniff.php
+++ b/WordPress/Sniffs/Security/EscapeOutputSniff.php
@@ -185,7 +185,6 @@ class EscapeOutputSniff extends AbstractFunctionRestrictionsSniff {
 	 */
 	public function process_token( $stackPtr ) {
 		$start = ( $stackPtr + 1 );
-		$end   = $start;
 
 		switch ( $this->tokens[ $stackPtr ]['code'] ) {
 			case \T_STRING:

--- a/WordPress/Sniffs/WP/I18nSniff.php
+++ b/WordPress/Sniffs/WP/I18nSniff.php
@@ -873,7 +873,7 @@ final class I18nSniff extends AbstractFunctionParameterSniff {
 				continue;
 			}
 
-			if ( preg_match( self::SPRINTF_PLACEHOLDER_REGEX, $param_info['clean'], $placeholders ) === 1 ) {
+			if ( preg_match( self::SPRINTF_PLACEHOLDER_REGEX, $param_info['clean'] ) === 1 ) {
 				$needs_translators_comment = true;
 				break;
 			}
@@ -969,7 +969,7 @@ final class I18nSniff extends AbstractFunctionParameterSniff {
 	 * @return bool
 	 */
 	private function is_translators_comment( $content ) {
-		if ( preg_match( '`^(?:(?://|/\*{1,2}) )?translators:`i', $content, $matches ) === 1 ) {
+		if ( preg_match( '`^(?:(?://|/\*{1,2}) )?translators:`i', $content ) === 1 ) {
 			return true;
 		}
 		return false;

--- a/WordPress/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
@@ -410,7 +410,7 @@ final class ControlStructureSpacingSniff extends Sniff {
 
 			// Move past end comments.
 			if ( $this->tokens[ $trailingContent ]['line'] === $this->tokens[ $scopeCloser ]['line'] ) {
-				if ( preg_match( '`^//[ ]?end`i', $this->tokens[ $trailingContent ]['content'], $matches ) > 0 ) {
+				if ( preg_match( '`^//[ ]?end`i', $this->tokens[ $trailingContent ]['content'] ) > 0 ) {
 					$scopeCloser     = $trailingContent;
 					$trailingContent = $this->phpcsFile->findNext( \T_WHITESPACE, ( $trailingContent + 1 ), null, true );
 				}


### PR DESCRIPTION
As discussed in https://github.com/WordPress/WordPress-Coding-Standards/pull/2513#issuecomment-2510860338, this PR removes unused variables detected automatically using PHPStorm code inspection from a few sniffs.

I have checked that the removed variables do not trigger errors at PHPStan levels higher than what we are currently using and that the modified code has at least minimal test coverage.

@dingo-d, in the screenshot that you shared in https://github.com/WordPress/WordPress-Coding-Standards/pull/2513#issuecomment-2510860338, `EnqueuedResourcesSniff.php` is included, but I was not able to find any unused variables in this file.