### PR TITLE
Add do_blocks to the $autoEscapedFunctions list

### DIFF
--- a/WordPress/Helpers/EscapingFunctionsTrait.php
+++ b/WordPress/Helpers/EscapingFunctionsTrait.php
@@ -117,6 +117,7 @@ trait EscapingFunctionsTrait {
 		'comment_class'           => true,
 		'count'                   => true,
 		'disabled'                => true,
+		'do_blocks'               => true,
 		'do_shortcode'            => true,
 		'do_shortcode_tag'        => true,
 		'get_archives_link'       => true,


### PR DESCRIPTION
Add `do_blocks` to the `$autoEscapedFunctions` list.

Closes #2524.