### PR TITLE
Composer: raise the minimum supported PHPCSUtils version to 1.1.0 + fix CI

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -39,9 +39,9 @@ When you introduce new `public` sniff properties, or your sniff extends a class 
 
 ## Pre-requisites
 * WordPress-Coding-Standards
-* PHP_CodeSniffer 3.9.0 or higher
-* PHPCSUtils 1.0.10 or higher
-* PHPCSExtra 1.2.1 or higher
+* PHP_CodeSniffer 3.13.0 or higher
+* PHPCSUtils 1.1.0 or higher
+* PHPCSExtra 1.4.0 or higher
 * PHPUnit 4.x - 9.x
 
 The WordPress Coding Standards use the `PHP_CodeSniffer` native unit test framework for unit testing the sniffs.

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -75,7 +75,7 @@ jobs:
 
           # Add extra build to test against PHPCS 4.
           #- php: '7.4'
-          #  dependencies: '4.0.x-dev as 3.9.99'
+          #  dependencies: '4.0.x-dev as 3.99.99'
 
     name: PHP ${{ matrix.php }} on PHPCS ${{ matrix.dependencies }}
 

--- a/WordPress/Tests/NamingConventions/ValidVariableNameUnitTest.inc
+++ b/WordPress/Tests/NamingConventions/ValidVariableNameUnitTest.inc
@@ -189,7 +189,7 @@ class MultiVarDeclarations {
 
 echo "This is $post_ID with $ThisShouldBeFlagged"; // Bad.
 
-// Safeguard that illegal property declarations are ignored.
+// Properties in interfaces are allowed since PHP 8.4.
 interface PropertiesNotAllowed {
 	public $notAllowed;
 }

--- a/WordPress/Tests/NamingConventions/ValidVariableNameUnitTest.php
+++ b/WordPress/Tests/NamingConventions/ValidVariableNameUnitTest.php
@@ -84,6 +84,7 @@ final class ValidVariableNameUnitTest extends AbstractSniffUnitTest {
 			184 => 1,
 			186 => 1,
 			190 => 1,
+			194 => 1,
 			199 => 1,
 			200 => 1,
 			202 => 1,

--- a/composer.json
+++ b/composer.json
@@ -21,9 +21,9 @@
 		"ext-libxml": "*",
 		"ext-tokenizer": "*",
 		"ext-xmlreader": "*",
-		"squizlabs/php_codesniffer": "^3.9.0",
-		"phpcsstandards/phpcsutils": "^1.0.10",
-		"phpcsstandards/phpcsextra": "^1.2.1"
+		"squizlabs/php_codesniffer": "^3.13.0",
+		"phpcsstandards/phpcsutils": "^1.1.0",
+		"phpcsstandards/phpcsextra": "^1.4.0"
 	},
 	"require-dev": {
 		"phpcompatibility/php-compatibility": "^9.0",


### PR DESCRIPTION
This PR is just to unblock WPCS/fix the failing test run.

Fixing the failure test run without these version bumps would mean having to polyfill support for PHP 8.4 properties in interfaces, which is not something we should want to do (that's why we use PHPCSUtils, which does the polyfill for PHPCS 3.x as PHPCS natively will only start supporting this in PHPCS 4.0).

This PR does **NOT**:
* Start using the new features from PHPCSUtils 1.1.0.
* Add support for all the new PHP syntaxes for which support was added to PHPCS + PHPCSUtils since PHPCS 3.9.0.


---

### Composer: raise the minimum supported PHPCSUtils version to 1.1.0 

... to benefit from new functionality.

This also automatically raises the minimum PHPCS version to `3.13.0` for PHP 8.2 DNF type support and tokenizer support for PHP 8.4 `final` properties and asymmetric visibility.

Includes syncing the PHPCSExtra version to a version which also has a minimum PHPCSUtils version of 1.1.0.

Ref:
* https://github.com/PHPCSStandards/PHPCSUtils/releases/tag/1.1.0
* https://github.com/PHPCSStandards/PHPCSExtra/releases/tag/1.4.0

### NamingConventions/ValidVariableName: allow for PHP 8.4 properties in interfaces