### PR TITLE
Extra: add two new sniffs related to heredoc/nowdocs

### DIFF
--- a/WordPress-Extra/ruleset.xml
+++ b/WordPress-Extra/ruleset.xml
@@ -29,6 +29,8 @@
 			<property name="allowMultiline" value="true"/>
 		</properties>
 	</rule>
+	<rule ref="Generic.Strings.UnnecessaryHeredoc"/>
+	<rule ref="Generic.WhiteSpace.HereNowdocIdentifierSpacing"/>
 
 	<!-- More generic PHP best practices.
 		 https://github.com/WordPress/WordPress-Coding-Standards/issues/607 -->


### PR DESCRIPTION
Two new sniffs were introduced in PHPCS 3.11.0:

* The `Generic.Strings.UnnecessaryHeredoc` sniff recommends using nowdoc syntax for heredocs which don't contain interpolation or expressions. This is similar to the `Squiz.Strings.DoubleQuoteUsage` sniff which is included in the WP-Core ruleset. Ref: https://github.com/WordPress/WordPress-Coding-Standards/blob/48e59e97eb950dc011d25a6759feb949afd802a0/WordPress-Core/ruleset.xml#L58-L60
* The `Generic.WhiteSpace.HereNowdocIdentifierSpacing` sniff required that there is no space between the `<<<` and the heredoc/nowdoc identifier.

Both seem like useful additions to me,

I also think both sniffs should be regarded as candidates for moving them to the WPCS Core ruleset if/when a next update proposal is posted on Make.