### PR TITLE
WordPress-Extra: remove the `Generic.Functions.CallTimePassByReference` sniff

### DIFF
--- a/WordPress-Extra/ruleset.xml
+++ b/WordPress-Extra/ruleset.xml
@@ -15,7 +15,6 @@
 		 https://github.com/WordPress/WordPress-Coding-Standards/pull/382 -->
 	<rule ref="Generic.PHP.DeprecatedFunctions"/>
 	<rule ref="Generic.PHP.ForbiddenFunctions"/>
-	<rule ref="Generic.Functions.CallTimePassByReference"/>
 	<rule ref="Generic.CodeAnalysis.EmptyStatement"/>
 	<rule ref="Generic.CodeAnalysis.ForLoopShouldBeWhileLoop"/>
 	<rule ref="Generic.CodeAnalysis.ForLoopWithTestFunctionCall"/>


### PR DESCRIPTION
The `Generic.Functions.CallTimePassByReference` sniff was deprecated in PHPCS 3.13.0, and [will be removed in PHPCS 4.0](https://github.com/PHPCSStandards/PHP_CodeSniffer/issues/921).

In this PR, I suggested that we remove it from WPCS. Removing this sniff from WordPress-Extra will be necessary anyway when preparing this repository for PHPCS 4.0, and I believe it is something that can be done now as call-time pass-by-reference was [deprecated in PHP 5.3](https://web.archive.org/web/20150920055013/http://us1.php.net/manual/en/migration53.deprecated.php) and [removed in PHP 5.4](https://web.archive.org/web/20140815142840/http://us2.php.net/manual/en/migration54.incompatible.php). PHP 5.4 was released in 2012, with the last security release in 2015. So it is unlikely users are still relying on it, and even if they are, there is a PHPCompatibility sniff to check for the use of call-time pass-by-reference: [PHPCompatibility.Syntax.ForbiddenCallTimePassByReference](https://github.com/PHPCompatibility/PHPCompatibility/blob/9013cd039fe5740953f9fdeebd19d901b80e26f2/PHPCompatibility/Sniffs/Syntax/ForbiddenCallTimePassByReferenceSniff.php#L128).

This sniff was added to WordPress-Extra via https://github.com/WordPress/WordPress-Coding-Standards/pull/382 back in 2015.

Closes #2528