### PR TITLE
Update list based sniffs for WP 6.8.1

### DIFF
--- a/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
+++ b/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
@@ -147,7 +147,7 @@ final class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 	 * Only overrulable constants are listed, i.e. those defined within core within
 	 * a `if ( ! defined() ) {}` wrapper.
 	 *
-	 * {@internal To be updated after every major release. Last updated for WordPress 6.5-RC3.}
+	 * {@internal To be updated after every major release. Last updated for WordPress 6.8.1.}
 	 *
 	 * @since 1.0.0
 	 * @since 3.0.0 Renamed from `$whitelisted_core_constants` to `$allowed_core_constants`.
@@ -201,7 +201,7 @@ final class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 	 *
 	 * Note: deprecated functions should still be included in this list as plugins may support older WP versions.
 	 *
-	 * {@internal To be updated after every major release. Last updated for WordPress 6.5-RC3.}
+	 * {@internal To be updated after every major release. Last updated for WordPress 6.8.1.}
 	 *
 	 * @since 3.0.0.
 	 *
@@ -322,6 +322,13 @@ final class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 		'twentytwenty_get_customizer_css'                => true,
 		'twentytwenty_get_theme_svg'                     => true,
 		'twentytwenty_the_theme_svg'                     => true,
+		'twentytwentyfive_block_styles'                  => true,
+		'twentytwentyfive_editor_style'                  => true,
+		'twentytwentyfive_enqueue_styles'                => true,
+		'twentytwentyfive_format_binding'                => true,
+		'twentytwentyfive_pattern_categories'            => true,
+		'twentytwentyfive_post_format_setup'             => true,
+		'twentytwentyfive_register_block_bindings'       => true,
 		'twentytwentyfour_block_styles'                  => true,
 		'twentytwentyfour_block_stylesheets'             => true,
 		'twentytwentyfour_pattern_categories'            => true,
@@ -358,6 +365,7 @@ final class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 		'wp_notify_postauthor'                           => true,
 		'wp_parse_auth_cookie'                           => true,
 		'wp_password_change_notification'                => true,
+		'wp_password_needs_rehash'                       => true,
 		'wp_rand'                                        => true,
 		'wp_redirect'                                    => true,
 		'wp_safe_redirect'                               => true,
@@ -382,7 +390,7 @@ final class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 	 *
 	 * Note: deprecated classes should still be included in this list as plugins may support older WP versions.
 	 *
-	 * {@internal To be updated after every major release. Last updated for WordPress 6.5-RC3.}
+	 * {@internal To be updated after every major release. Last updated for WordPress 6.8.1.}
 	 *
 	 * @since 3.0.0.
 	 *

--- a/WordPress/Sniffs/NamingConventions/ValidPostTypeSlugSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidPostTypeSlugSniff.php
@@ -63,7 +63,7 @@ final class ValidPostTypeSlugSniff extends AbstractFunctionParameterSniff {
 	 *
 	 * Source: {@link https://developer.wordpress.org/reference/functions/register_post_type/#reserved-post-types}
 	 *
-	 * {@internal To be updated after every major release. Last updated for WordPress 6.5-RC3.}
+	 * {@internal To be updated after every major release. Last updated for WordPress 6.8.1.}
 	 *
 	 * @since 2.2.0
 	 *

--- a/WordPress/Sniffs/WP/CapabilitiesSniff.php
+++ b/WordPress/Sniffs/WP/CapabilitiesSniff.php
@@ -173,7 +173,7 @@ final class CapabilitiesSniff extends AbstractFunctionParameterSniff {
 	 *
 	 * List is sorted alphabetically.
 	 *
-	 * {@internal To be updated after every major release. Last updated for WordPress 6.1.0.}
+	 * {@internal To be updated after every major release. Last updated for WordPress 6.8.1.}
 	 *
 	 * @since 3.0.0
 	 *
@@ -229,6 +229,7 @@ final class CapabilitiesSniff extends AbstractFunctionParameterSniff {
 		'edit_app_password'           => true,
 		'edit_categories'             => true,
 		'edit_block'                  => true, // Only seen in tests.
+		'edit_block_binding'          => true,
 		'edit_blocks'                 => true, // Alias for 'edit_posts', but supported.
 		'edit_comment'                => true, // Alias, but supported.
 		'edit_comment_meta'           => true,

--- a/WordPress/Sniffs/WP/ClassNameCaseSniff.php
+++ b/WordPress/Sniffs/WP/ClassNameCaseSniff.php
@@ -25,7 +25,7 @@ final class ClassNameCaseSniff extends AbstractClassRestrictionsSniff {
 	 *
 	 * Note: this list will be enhanced in the class constructor.
 	 *
-	 * {@internal To be updated after every major release. Last updated for WordPress 6.5-RC3.}
+	 * {@internal To be updated after every major release. Last updated for WordPress 6.8.1.}
 	 *
 	 * @since 3.0.0
 	 *
@@ -97,6 +97,7 @@ final class ClassNameCaseSniff extends AbstractClassRestrictionsSniff {
 		'Text_Diff_Op_delete',
 		'Text_Diff_Renderer',
 		'Text_Diff_Renderer_inline',
+		'Text_Exception',
 		'Text_MappedDiff',
 		'Theme_Installer_Skin',
 		'Theme_Upgrader',
@@ -125,6 +126,7 @@ final class ClassNameCaseSniff extends AbstractClassRestrictionsSniff {
 		'WP_Block_Bindings_Source',
 		'WP_Block_Editor_Context',
 		'WP_Block_List',
+		'WP_Block_Metadata_Registry',
 		'WP_Block_Parser',
 		'WP_Block_Parser_Block',
 		'WP_Block_Parser_Frame',
@@ -133,6 +135,7 @@ final class ClassNameCaseSniff extends AbstractClassRestrictionsSniff {
 		'WP_Block_Styles_Registry',
 		'WP_Block_Supports',
 		'WP_Block_Template',
+		'WP_Block_Templates_Registry',
 		'WP_Block_Type',
 		'WP_Block_Type_Registry',
 		'WP_Classic_To_Block_Menu_Converter',
@@ -186,6 +189,7 @@ final class ClassNameCaseSniff extends AbstractClassRestrictionsSniff {
 		'WP_Duotone',
 		'WP_Embed',
 		'WP_Error',
+		'WP_Exception',
 		'WP_Fatal_Error_Handler',
 		'WP_Feed_Cache',
 		'WP_Feed_Cache_Transient',
@@ -201,10 +205,13 @@ final class ClassNameCaseSniff extends AbstractClassRestrictionsSniff {
 		'WP_Font_Utils',
 		'WP_HTML_Active_Formatting_Elements',
 		'WP_HTML_Attribute_Token',
+		'WP_HTML_Decoder',
+		'WP_HTML_Doctype_Info',
 		'WP_HTML_Open_Elements',
 		'WP_HTML_Processor',
 		'WP_HTML_Processor_State',
 		'WP_HTML_Span',
+		'WP_HTML_Stack_Event',
 		'WP_HTML_Tag_Processor',
 		'WP_HTML_Text_Replacement',
 		'WP_HTML_Token',
@@ -246,6 +253,7 @@ final class ClassNameCaseSniff extends AbstractClassRestrictionsSniff {
 		'WP_Network',
 		'WP_Network_Query',
 		'WP_Object_Cache',
+		'WP_PHPMailer',
 		'WP_Paused_Extensions_Storage',
 		'WP_Plugin_Dependencies',
 		'WP_Plugin_Install_List_Table',
@@ -343,6 +351,7 @@ final class ClassNameCaseSniff extends AbstractClassRestrictionsSniff {
 		'WP_Sitemaps_Stylesheet',
 		'WP_Sitemaps_Taxonomies',
 		'WP_Sitemaps_Users',
+		'WP_Speculation_Rules',
 		'WP_Style_Engine',
 		'WP_Style_Engine_CSS_Declarations',
 		'WP_Style_Engine_CSS_Rule',
@@ -364,11 +373,13 @@ final class ClassNameCaseSniff extends AbstractClassRestrictionsSniff {
 		'WP_Theme_JSON_Resolver',
 		'WP_Theme_JSON_Schema',
 		'WP_Themes_List_Table',
+		'WP_Token_Map',
 		'WP_Translation_Controller',
 		'WP_Translation_File',
 		'WP_Translation_File_MO',
 		'WP_Translation_File_PHP',
 		'WP_Translations',
+		'WP_URL_Pattern_Prefixer',
 		'WP_Upgrader',
 		'WP_Upgrader_Skin',
 		'WP_User',
@@ -412,7 +423,7 @@ final class ClassNameCaseSniff extends AbstractClassRestrictionsSniff {
 	 *
 	 * Note: this list will be enhanced in the class constructor.
 	 *
-	 * {@internal To be updated after every major release. Last updated for WordPress 6.5-RC3.}
+	 * {@internal To be updated after every major release. Last updated for WordPress 6.8.1.}
 	 *
 	 * @since 3.0.0
 	 *
@@ -444,7 +455,7 @@ final class ClassNameCaseSniff extends AbstractClassRestrictionsSniff {
 	 *
 	 * Note: this list will be enhanced in the class constructor.
 	 *
-	 * {@internal To be updated after every major release. Last updated for WordPress 6.5-RC3.}
+	 * {@internal To be updated after every major release. Last updated for WordPress 6.8.1.}
 	 *
 	 * @since 3.1.0
 	 *
@@ -466,7 +477,7 @@ final class ClassNameCaseSniff extends AbstractClassRestrictionsSniff {
 	 *
 	 * Note: this list will be enhanced in the class constructor.
 	 *
-	 * {@internal To be updated after every major release. Last updated for WordPress 6.5-RC3.}
+	 * {@internal To be updated after every major release. Last updated for WordPress 6.8.1.}
 	 *
 	 * @since 3.0.0
 	 *
@@ -502,7 +513,7 @@ final class ClassNameCaseSniff extends AbstractClassRestrictionsSniff {
 	 *
 	 * Note: this list will be enhanced in the class constructor.
 	 *
-	 * {@internal To be updated after every major release. Last updated for WordPress 6.5-RC3.}
+	 * {@internal To be updated after every major release. Last updated for WordPress 6.8.1.}
 	 *
 	 * @since 3.0.0
 	 *
@@ -520,7 +531,7 @@ final class ClassNameCaseSniff extends AbstractClassRestrictionsSniff {
 	 *
 	 * Note: this list will be enhanced in the class constructor.
 	 *
-	 * {@internal To be updated after every major release. Last updated for WordPress 6.5-RC3.}
+	 * {@internal To be updated after every major release. Last updated for WordPress 6.8.1.}
 	 *
 	 * @since 3.0.0
 	 *
@@ -664,7 +675,7 @@ final class ClassNameCaseSniff extends AbstractClassRestrictionsSniff {
 	 *
 	 * Note: this list will be enhanced in the class constructor.
 	 *
-	 * {@internal To be updated after every major release. Last updated for WordPress 6.5-RC3.}
+	 * {@internal To be updated after every major release. Last updated for WordPress 6.8.1.}
 	 *
 	 * @since 3.0.0
 	 *
@@ -672,11 +683,18 @@ final class ClassNameCaseSniff extends AbstractClassRestrictionsSniff {
 	 *               The constructor will add the lowercased class name as a key to each entry.
 	 */
 	private $simplepie_classes = array(
-		// Interfaces.
+		// Interfaces, SimplePie v1.
 		'SimplePie_Cache_Base',
 
-		// Classes.
+		// Interfaces, SimplePie v2 (with BC layer in v1).
+		'SimplePie\Cache\Base',
+		'SimplePie\Cache\DataCache',
+		'SimplePie\Cache\NameFilter',
+		'SimplePie\RegistryAware',
+
+		// Classes, SimplePie v1.
 		'SimplePie',
+		'SimplePie_Autoloader',
 		'SimplePie_Author',
 		'SimplePie_Cache',
 		'SimplePie_Cache_DB',
@@ -710,6 +728,43 @@ final class ClassNameCaseSniff extends AbstractClassRestrictionsSniff {
 		'SimplePie_Source',
 		'SimplePie_XML_Declaration_Parser',
 		'SimplePie_gzdecode',
+
+		// Classes, SimplePie v2 (with BC layer in v1).
+		'SimplePie\Author',
+		'SimplePie\Cache',
+		'SimplePie\Cache\BaseDataCache',
+		'SimplePie\Cache\CallableNameFilter',
+		'SimplePie\Cache\DB',
+		'SimplePie\Cache\File',
+		'SimplePie\Cache\Memcache',
+		'SimplePie\Cache\Memcached',
+		'SimplePie\Cache\MySQL',
+		'SimplePie\Cache\Psr16',
+		'SimplePie\Cache\Redis',
+		'SimplePie\Caption',
+		'SimplePie\Category',
+		'SimplePie\Content\Type\Sniffer',
+		'SimplePie\Copyright',
+		'SimplePie\Credit',
+		'SimplePie\Enclosure',
+		'SimplePie\Exception',
+		'SimplePie\File',
+		'SimplePie\Gzdecode',
+		'SimplePie\HTTP\Parser',
+		'SimplePie\IRI',
+		'SimplePie\Item',
+		'SimplePie\Locator',
+		'SimplePie\Misc',
+		'SimplePie\Net\IPv6',
+		'SimplePie\Parse\Date',
+		'SimplePie\Parser',
+		'SimplePie\Rating',
+		'SimplePie\Registry',
+		'SimplePie\Restriction',
+		'SimplePie\Sanitize',
+		'SimplePie\SimplePie',
+		'SimplePie\Source',
+		'SimplePie\XML\Declaration\Parser',
 	);
 
 	/**

--- a/WordPress/Sniffs/WP/DeprecatedClassesSniff.php
+++ b/WordPress/Sniffs/WP/DeprecatedClassesSniff.php
@@ -41,7 +41,7 @@ final class DeprecatedClassesSniff extends AbstractClassRestrictionsSniff {
 	 *
 	 * Version numbers should be fully qualified.
 	 *
-	 * {@internal To be updated after every major release. Last updated for WordPress 6.5-RC3.}
+	 * {@internal To be updated after every major release. Last updated for WordPress 6.8.1.}
 	 *
 	 * @var array
 	 */

--- a/WordPress/Sniffs/WP/DeprecatedFunctionsSniff.php
+++ b/WordPress/Sniffs/WP/DeprecatedFunctionsSniff.php
@@ -43,7 +43,7 @@ final class DeprecatedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 	 * To retrieve a function list for comparison, the following tool is available:
 	 * https://github.com/JDGrimes/wp-deprecated-code-scanner
 	 *
-	 * {@internal To be updated after every major release. Last updated for WordPress 6.5-RC3.}
+	 * {@internal To be updated after every major release. Last updated for WordPress 6.8.1.}
 	 *
 	 * @var array
 	 */
@@ -1529,6 +1529,7 @@ final class DeprecatedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 			'version' => '6.3.0',
 		),
 		'block_core_navigation_submenu_build_css_colors' => array(
+			// Verified correct alternative.
 			'alt'     => 'wp_apply_colors_support()',
 			'version' => '6.3.0',
 		),
@@ -1545,7 +1546,7 @@ final class DeprecatedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 			'version' => '6.3.0',
 		),
 		'wp_get_duotone_filter_svg' => array(
-			'alt'     => '',
+			'alt'     => 'WP_Duotone::get_filter_svg_from_preset()',
 			'version' => '6.3.0',
 		),
 		'wp_get_global_styles_svg_filters' => array(
@@ -1603,11 +1604,11 @@ final class DeprecatedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 			'version' => '6.4.0',
 		),
 		'_inject_theme_attribute_in_block_template_content' => array(
-			'alt'     => 'traverse_and_serialize_blocks( parse_blocks( $template_content ), \'_inject_theme_attribute_in_template_part_block\' )',
+			'alt'     => 'traverse_and_serialize_blocks( parse_blocks( $template_content ), "_inject_theme_attribute_in_template_part_block" )',
 			'version' => '6.4.0',
 		),
 		'_remove_theme_attribute_in_block_template_content' => array(
-			'alt'     => 'traverse_and_serialize_blocks( parse_blocks( $template_content ), \'_remove_theme_attribute_from_template_part_block\' )',
+			'alt'     => 'traverse_and_serialize_blocks( parse_blocks( $template_content ), "_remove_theme_attribute_from_template_part_block" )',
 			'version' => '6.4.0',
 		),
 		'_wp_theme_json_webfonts_handler' => array(
@@ -1635,6 +1636,7 @@ final class DeprecatedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 			'version' => '6.4.0',
 		),
 		'wp_update_https_detection_errors' => array(
+			// Verified correct alternative.
 			'alt'     => 'wp_get_https_detection_errors()',
 			'version' => '6.4.0',
 		),
@@ -1651,6 +1653,60 @@ final class DeprecatedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 		'block_core_query_ensure_interactivity_dependency' => array(
 			'alt'     => 'wp_register_script_module()',
 			'version' => '6.5.0',
+		),
+
+		// WP 6.6.0.
+		'wp_interactivity_process_directives_of_interactive_blocks' => array(
+			'alt'     => '',
+			'version' => '6.6.0',
+		),
+		'wp_render_elements_support' => array(
+			'alt'     => 'wp_render_elements_class_name()',
+			'version' => '6.6.0',
+		),
+
+		// WP 6.7.0.
+		'current_user_can_for_blog' => array(
+			'alt'     => 'current_user_can_for_site()',
+			'version' => '6.7.0',
+		),
+		'wp_create_block_style_variation_instance_name' => array(
+			'alt'     => 'wp_unique_id( $variation . \'--\' )',
+			'version' => '6.7.0',
+		),
+		'wp_enqueue_global_styles_custom_css' => array(
+			'alt'     => 'wp_enqueue_global_styles()',
+			'version' => '6.7.0',
+		),
+		'wp_get_global_styles_custom_css' => array(
+			'alt'     => 'wp_get_global_stylesheet() or WP_Theme_JSON::get_styles_for_block()',
+			'version' => '6.7.0',
+		),
+		'wp_init_targeted_link_rel_filters' => array(
+			'alt'     => '',
+			'version' => '6.7.0',
+		),
+		'wp_remove_targeted_link_rel_filters' => array(
+			'alt'     => '',
+			'version' => '6.7.0',
+		),
+		'wp_simplepie_autoload' => array(
+			'alt'     => 'SimplePie_Autoloader',
+			'version' => '6.7.0',
+		),
+		'wp_targeted_link_rel' => array(
+			'alt'     => '',
+			'version' => '6.7.0',
+		),
+		'wp_targeted_link_rel_callback' => array(
+			'alt'     => '',
+			'version' => '6.7.0',
+		),
+
+		// WP 6.8.0.
+		'wp_add_editor_classic_theme_styles' => array(
+			'alt'     => 'wp_enqueue_classic_theme_styles()',
+			'version' => '6.8.0',
 		),
 	);
 

--- a/WordPress/Sniffs/WP/DeprecatedParameterValuesSniff.php
+++ b/WordPress/Sniffs/WP/DeprecatedParameterValuesSniff.php
@@ -42,7 +42,8 @@ final class DeprecatedParameterValuesSniff extends AbstractFunctionParameterSnif
 	 * The list of deprecated parameter values can be found by
 	 * looking for `_deprecated_argument()`.
 	 * The list is sorted alphabetically by function name.
-	 * Last updated for WordPress 4.9.6.
+	 *
+	 * {@internal To be updated after every major release. Last updated for WordPress 6.8.1.}
 	 *
 	 * @since 1.0.0
 	 * @since 3.0.0 The format of the value has changed to support function calls
@@ -203,6 +204,21 @@ final class DeprecatedParameterValuesSniff extends AbstractFunctionParameterSnif
 					'comment_whitelist' => array(
 						'alt'     => 'comment_previously_approved',
 						'version' => '5.5.0',
+					),
+				),
+			),
+		),
+		'wp_get_typography_font_size_value' => array(
+			2 => array(
+				'name'   => 'settings',
+				'values' => array(
+					'true' => array(
+						'alt'     => 'an array',
+						'version' => '6.6.0',
+					),
+					'false' => array(
+						'alt'     => 'an array',
+						'version' => '6.6.0',
 					),
 				),
 			),

--- a/WordPress/Sniffs/WP/DeprecatedParametersSniff.php
+++ b/WordPress/Sniffs/WP/DeprecatedParametersSniff.php
@@ -49,7 +49,8 @@ final class DeprecatedParametersSniff extends AbstractFunctionParameterSniff {
 	 * Array of function, argument, and default value for deprecated argument.
 	 *
 	 * The functions are ordered alphabetically.
-	 * Last updated for WordPress 6.3.
+	 *
+	 * {@internal To be updated after every major release. Last updated for WordPress 6.8.1.}
 	 *
 	 * @since 0.12.0
 	 *
@@ -207,6 +208,13 @@ final class DeprecatedParametersSniff extends AbstractFunctionParameterSniff {
 				'name'    => 'deprecated',
 				'value'   => false,
 				'version' => '4.2.0',
+			),
+		),
+		'inject_ignored_hooked_blocks_metadata_attributes' => array(
+			2 => array(
+				'name'    => 'deprecated',
+				'value'   => null,
+				'version' => '6.5.3',
 			),
 		),
 		'install_search_form' => array(
@@ -408,6 +416,13 @@ final class DeprecatedParametersSniff extends AbstractFunctionParameterSniff {
 				'name'    => 'deprecated',
 				'value'   => null,
 				'version' => '3.8.0',
+			),
+		),
+		'wp_render_elements_support_styles' => array(
+			1 => array(
+				'name'    => 'parsed_block',
+				'value'   => null,
+				'version' => '6.6.0',
 			),
 		),
 		'wp_title_rss' => array(

--- a/WordPress/Tests/WP/DeprecatedFunctionsUnitTest.inc
+++ b/WordPress/Tests/WP/DeprecatedFunctionsUnitTest.inc
@@ -426,3 +426,18 @@ wp_update_https_detection_errors();
 block_core_file_ensure_interactivity_dependency();
 block_core_image_ensure_interactivity_dependency();
 block_core_query_ensure_interactivity_dependency();
+/* ============ WP 6.6 ============ */
+wp_interactivity_process_directives_of_interactive_blocks();
+wp_render_elements_support();
+/* ============ WP 6.7 ============ */
+current_user_can_for_blog();
+wp_create_block_style_variation_instance_name();
+wp_enqueue_global_styles_custom_css();
+wp_get_global_styles_custom_css();
+wp_init_targeted_link_rel_filters();
+wp_remove_targeted_link_rel_filters();
+wp_simplepie_autoload();
+wp_targeted_link_rel();
+wp_targeted_link_rel_callback();
+/* ============ WP 6.8 ============ */
+wp_add_editor_classic_theme_styles();

--- a/WordPress/Tests/WP/DeprecatedFunctionsUnitTest.php
+++ b/WordPress/Tests/WP/DeprecatedFunctionsUnitTest.php
@@ -90,14 +90,17 @@ final class DeprecatedFunctionsUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getWarningList() {
 		$start_line = 388;
-		$end_line   = 428;
+		$end_line   = 443;
 		$warnings   = array_fill( $start_line, ( ( $end_line - $start_line ) + 1 ), 1 );
 
 		// Unset the lines related to version comments.
 		unset(
 			$warnings[390],
 			$warnings[414],
-			$warnings[425]
+			$warnings[425],
+			$warnings[429],
+			$warnings[432],
+			$warnings[442]
 		);
 
 		return $warnings;

--- a/WordPress/Tests/WP/DeprecatedParameterValuesUnitTest.inc
+++ b/WordPress/Tests/WP/DeprecatedParameterValuesUnitTest.inc
@@ -50,5 +50,10 @@ update_option('blacklist_keys', $value);
 update_option('comment_whitelist', $value);
 update_option(autoload: true, value: $value, option: 'blacklist_keys');
 
+// Passing boolean $settings is deprecated since WP 6.6.0.
+wp_get_typography_font_size_value( $preset, array() ); // OK.
+wp_get_typography_font_size_value( $preset, true ); // Error.
+wp_get_typography_font_size_value( $preset, false ); // Error.
+
 // Live coding/parse error.
 get_bloginfo( show: /*to do*/, );

--- a/WordPress/Tests/WP/DeprecatedParameterValuesUnitTest.php
+++ b/WordPress/Tests/WP/DeprecatedParameterValuesUnitTest.php
@@ -61,6 +61,9 @@ final class DeprecatedParameterValuesUnitTest extends AbstractSniffUnitTest {
 	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList() {
-		return array();
+		return array(
+			55 => 1,
+			56 => 1,
+		);
 	}
 }

--- a/WordPress/Tests/WP/DeprecatedParametersUnitTest.inc
+++ b/WordPress/Tests/WP/DeprecatedParametersUnitTest.inc
@@ -96,4 +96,6 @@ wp_upload_bits( '', 'deprecated' );
 xfn_check( '', '', 'deprecated' );
 global_terms( $foo, 'deprecated' );
 
-// All will give an WARNING as they have been deprecated after WP 5.8.
+// All will give an WARNING as they have been deprecated after WP 6.2.
+inject_ignored_hooked_blocks_metadata_attributes('', 'deprecated');
+wp_render_elements_support_styles('deprecated');

--- a/WordPress/Tests/WP/DeprecatedParametersUnitTest.php
+++ b/WordPress/Tests/WP/DeprecatedParametersUnitTest.php
@@ -51,6 +51,9 @@ final class DeprecatedParametersUnitTest extends AbstractSniffUnitTest {
 	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList() {
-		return array();
+		return array(
+			100 => 1,
+			101 => 1,
+		);
 	}
 }


### PR DESCRIPTION
### NamingConventions/PrefixAllGlobals: update the functions list based on WP 6.8.1

Based on a scan of WP Core at commit WordPress/wordpress-develop@c5d3e24 using a preliminary sniff created for issue #1803.

### WP/Capabilities: update the capabilities list based on WP 6.8.1 

Based on a manual check of WP Core at commit WordPress/wordpress-develop@c5d3e24.

### WP/ClassNameCase: update the class lists based on WP 6.8.1 

Based on a scan of WP Core at commit WordPress/wordpress-develop@c5d3e24 using a preliminary sniff created for issue #1803.

### WP/DeprecatedFunctions: update the functions list based on WP 6.8.1 

Based on a scan of WP Core at commit WordPress/wordpress-develop@c5d3e24 using a preliminary sniff created for issue #1803.

Includes tests.

### WP/DeprecatedParameters: update the functions list based on WP 6.8.1 

Based on a scan of WP Core at commit WordPress/wordpress-develop@c5d3e24 using a preliminary sniff created for issue #1803.

Includes tests.

### WP/DeprecatedParameterValues: update the functions list based on WP 6.8.1

Based on a scan of WP Core at commit WordPress/wordpress-develop@c5d3e24 using a preliminary sniff created for issue #1803.

Includes tests.

### NamingConventions/ValidPostTypeSlug: update docs

### WP/DeprecatedFunctions: update docs