### PR TITLE
GH Actions: add a basic spellcheck CI check + fix some typos

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -31,7 +31,7 @@ Alternatively, if you have push access to this repo, create a feature branch pre
 ## Public properties
 
 When writing sniffs, always remember that any `public` sniff property can be overruled via a custom ruleset by the end-user.
-Only make a property `public` if that is the intended behaviour.
+Only make a property `public` if that is the intended behavior.
 
 When you introduce new `public` sniff properties, or your sniff extends a class from which you inherit a `public` property, please don't forget to update the [public properties wiki page](https://github.com/WordPress/WordPress-Coding-Standards/wiki/Customizable-sniff-properties) with the relevant details once your PR has been merged into the `develop` branch.
 

--- a/.github/workflows/basic-qa.yml
+++ b/.github/workflows/basic-qa.yml
@@ -254,3 +254,15 @@ jobs:
 
       - name: Run PHPStan
         run: phpstan analyse
+
+  typos-check:
+    name: "Find typos"
+
+    runs-on: "ubuntu-latest"
+
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@v4"
+
+      - name: "Search for misspellings"
+        uses: "crate-ci/typos@v1"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -768,7 +768,7 @@ If you are a maintainer of an external standard based on WordPressCS and any of 
 - The `vip_powered_wpcom` function from the `Sniff::$autoEscapedFunctions` list which is used by the `WordPress.Security.EscapeOutput` sniff.
 - The `AbstractVariableRestrictionsSniff` class, which was deprecated since WordPressCS 1.0.0.
 - The `Sniff::has_html_open_tag()` utility method, which was deprecated since WordPressCS 1.0.0.
-- The internal `$php_reserved_vars` property from the `WordPress.NamingConventions.ValidVariableName` sniff in favour of using a PHPCS native property which is now available.
+- The internal `$php_reserved_vars` property from the `WordPress.NamingConventions.ValidVariableName` sniff in favor of using a PHPCS native property which is now available.
 - The class aliases and WPCS native autoloader used for PHPCS cross-version support.
 - The unit test framework workarounds for PHPCS cross-version unit testing.
 - Support for the `@codingStandardsChangeSetting` annotation, which is generally only used in unit tests.
@@ -865,8 +865,8 @@ Note: This will be the last release supporting PHP_CodeSniffer 2.x.
 
 ### Changed
 - The `PEAR.Functions.FunctionCallSignature` sniff, which is part of the `WordPress-Core` ruleset, used to allow multiple function call parameters per line in multi-line function calls. This will no longer be allowed.
-    As of this release, if a function call is multi-line, each parameter should start on a new line and an `error` will be thrown if the code being analysed does not comply with that rule.
-    The sniff behaviour for single-line function calls is not affected by this change.
+    As of this release, if a function call is multi-line, each parameter should start on a new line and an `error` will be thrown if the code being analyzed does not comply with that rule.
+    The sniff behavior for single-line function calls is not affected by this change.
 - Moved the `WordPress.CodeAnalysis.EmptyStatement` sniff from the `WordPress-Extra` to the `WordPress-Core` ruleset.
 - Moved the `Squiz.PHP.CommentedOutCode` sniff from the `WordPress-Docs` to the `WordPress-Extra` ruleset and lowered the threshold for determining whether or not a comment is commented out code from 45% to 40%.
 - The `WordPress.NamingConventions.PrefixAllGlobals` sniff now has improved support for recognizing whether or not (non-prefixed) globals are declared in the context of unit tests.
@@ -881,7 +881,7 @@ Note: This will be the last release supporting PHP_CodeSniffer 2.x.
 ### Fixed
 - The `WordPress.Security.ValidatedSanitizedInput` sniff will now recognize array keys in superglobals independently of the string quote-style used for the array key.
 - The `WordPress.WhiteSpace.PrecisionAlignment` sniff will no longer throw false positives for DocBlocks for JavaScript functions within inline HTML.
-- `WordPress.WP.DeprecatedClasses`: The error codes for this sniff were unstable as they were based on the code being analysed instead of on fixed values.
+- `WordPress.WP.DeprecatedClasses`: The error codes for this sniff were unstable as they were based on the code being analyzed instead of on fixed values.
 - Various bugfixes for the `WordPress.WP.GlobalVariablesOverride` sniff:
     - Previously, the sniff only checked variables in the global namespace when a `global` statement would be encountered. As of now, all variable assignments in the global namespace will be checked.
     - Nested functions/closures/classes which don't import the global variable will now be skipped over when encountered within another function, preventing false positives.
@@ -1089,8 +1089,8 @@ If you are a maintainer of an external standard based on WPCS and any of your cu
 
 ### Added
 - `WordPress.Arrays.MultipleStatementAlignment` sniff to the `WordPress-Core` ruleset which will align the array assignment operator for multi-item, multi-line associative arrays.
-    This new sniff offers four custom properties to customize its behaviour: [`ignoreNewlines`](https://github.com/WordPress/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#array-alignment-allow-for-new-lines), [`exact`](https://github.com/WordPress/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#array-alignment-allow-non-exact-alignment), [`maxColumn`](https://github.com/WordPress/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#array-alignment-maximum-column) and [`alignMultilineItems`](https://github.com/WordPress/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#array-alignment-dealing-with-multi-line-items).
-- `WordPress.DB.PreparedSQLPlaceholders` sniff to the `WordPress-Core` ruleset which will analyse the placeholders passed to `$wpdb->prepare()` for their validity, check whether queries using `IN ()` and `LIKE` statements are created correctly and will check whether a correct number of replacements are passed.
+    This new sniff offers four custom properties to customize its behavior: [`ignoreNewlines`](https://github.com/WordPress/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#array-alignment-allow-for-new-lines), [`exact`](https://github.com/WordPress/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#array-alignment-allow-non-exact-alignment), [`maxColumn`](https://github.com/WordPress/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#array-alignment-maximum-column) and [`alignMultilineItems`](https://github.com/WordPress/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#array-alignment-dealing-with-multi-line-items).
+- `WordPress.DB.PreparedSQLPlaceholders` sniff to the `WordPress-Core` ruleset which will analyze the placeholders passed to `$wpdb->prepare()` for their validity, check whether queries using `IN ()` and `LIKE` statements are created correctly and will check whether a correct number of replacements are passed.
     This sniff should help detect queries which are impacted by the security fixes to `$wpdb->prepare()` which shipped with WP 4.8.2 and 4.8.3.
     The sniff also adds a new ["PreparedSQLPlaceholders replacement count" whitelist comment](https://github.com/WordPress/WordPress-Coding-Standards/wiki/Whitelisting-code-which-flags-errors#preparedsql-placeholders-vs-replacements) for pertinent replacement count vs placeholder mismatches. Please consider carefully whether something could be a bug when you are tempted to use the whitelist comment and if so, [report it](https://github.com/WordPress/WordPress-Coding-Standards/issues/new).
 - `WordPress.PHP.DiscourageGoto` sniff to the `WordPress-Core` ruleset.
@@ -1110,7 +1110,7 @@ If you are a maintainer of an external standard based on WPCS and any of your cu
 - When passing an array property via a custom ruleset to PHP_CodeSniffer, spaces around the key/value are taken as intentional and parsed as part of the array key/value. In practice, this leads to confusion and WPCS does not expect any values which could be preceded/followed by a space, so for the WordPress Coding Standard native array properties, like `customAutoEscapedFunction`, `text_domain`, `prefixes`, WPCS will now trim whitespace from the keys/values received before use.
 - The WPCS native whitelist comments used to only work when they were put on the _end of the line_ of the code they applied to. As of now, they will also be recognized when they are be put at the _end of the statement_ they apply to.
 - The `WordPress.Arrays.ArrayDeclarationSpacing` sniff used to enforce all associative arrays to be multi-line. The handbook has been updated to only require this for multi-item associative arrays and the sniff has been updated accordingly.
-    [The original behaviour can still be enforced](https://github.com/WordPress/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#arrays-forcing-single-item-associative-arrays-to-be-multi-line) by setting the new `allow_single_item_single_line_associative_arrays` property to `false` in a custom ruleset.
+    [The original behavior can still be enforced](https://github.com/WordPress/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#arrays-forcing-single-item-associative-arrays-to-be-multi-line) by setting the new `allow_single_item_single_line_associative_arrays` property to `false` in a custom ruleset.
 - The `WordPress.NamingConventions.PrefixAllGlobals` sniff will now allow for a limited list of WP core hooks which are intended to be called by plugins and themes.
 - The `WordPress.PHP.DiscouragedFunctions` sniff used to include `create_function`. This check has been moved to the new `WordPress.PHP.RestrictedFunctions` sniff.
 - The `WordPress.PHP.StrictInArray` sniff now has a separate error code `FoundNonStrictFalse` for when the `$strict` parameter has been set to `false`. This allows for excluding the warnings for that particular situation, which will normally be intentional, via a custom ruleset.
@@ -1329,7 +1329,7 @@ You are also encouraged to check the file history of any WPCS classes you extend
 ### Removed
 - Warnings thrown by individual sniffs about parse errors they encounter. This is left up to the `Generic.PHP.Syntax` sniff which is included in the `WordPress-Extra` ruleset.
 - The `post_class()` function from the `autoEscapedFunctions` list used by the `WordPress.XSS.EscapeOutput` sniff.
-- The `Generic.Files.LowercasedFilename` sniff from the `WordPress-Core` ruleset in favour of the improved `WordPress.Files.FileName` sniff to prevent duplicate messages being thrown.
+- The `Generic.Files.LowercasedFilename` sniff from the `WordPress-Core` ruleset in favor of the improved `WordPress.Files.FileName` sniff to prevent duplicate messages being thrown.
 - Some temporary work-arounds for changes which were pulled and merged into PHPCS upstream.
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 * [Rulesets](#rulesets)
     + [Standards subsets](#standards-subsets)
     + [Using a custom ruleset](#using-a-custom-ruleset)
-    + [Customizing sniff behaviour](#customizing-sniff-behaviour)
+    + [Customizing sniff behavior](#customizing-sniff-behavior)
     + [Recommended additional rulesets](#recommended-additional-rulesets)
 * [How to use](#how-to-use)
     + [Command line](#command-line)
@@ -135,9 +135,9 @@ When you name this file either `.phpcs.xml`, `phpcs.xml`, `.phpcs.xml.dist` or `
 
 For more info, read about [using a default configuration file](https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Advanced-Usage#using-a-default-configuration-file). See also the provided WordPressCS [`phpcs.xml.dist.sample`](phpcs.xml.dist.sample) file and the [fully annotated example ruleset](https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Annotated-ruleset.xml) in the PHP_CodeSniffer documentation.
 
-### Customizing sniff behaviour
+### Customizing sniff behavior
 
-The WordPress Coding Standard contains a number of sniffs which are configurable. This means that you can turn parts of the sniff on or off, or change the behaviour by setting a property for the sniff in your custom `[.]phpcs.xml[.dist]` file.
+The WordPress Coding Standard contains a number of sniffs which are configurable. This means that you can turn parts of the sniff on or off, or change the behavior by setting a property for the sniff in your custom `[.]phpcs.xml[.dist]` file.
 
 You can find a complete list of all the properties you can change for the WordPressCS sniffs in the [wiki](https://github.com/WordPress/WordPress-Coding-Standards/wiki/Customizable-sniff-properties).
 
@@ -151,7 +151,7 @@ Information on custom properties which can be set for sniffs from PHP_CodeSniffe
 #### PHPCompatibility
 
 The [PHPCompatibility](https://github.com/PHPCompatibility/PHPCompatibility) ruleset and its subset [PHPCompatibilityWP](https://github.com/PHPCompatibility/PHPCompatibilityWP) come highly recommended.
-The [PHPCompatibility](https://github.com/PHPCompatibility/PHPCompatibility) sniffs are designed to analyse your code for cross-version PHP compatibility.
+The [PHPCompatibility](https://github.com/PHPCompatibility/PHPCompatibility) sniffs are designed to analyze your code for cross-version PHP compatibility.
 
 The [PHPCompatibilityWP](https://github.com/PHPCompatibility/PHPCompatibilityWP) ruleset is based on PHPCompatibility, but specifically crafted to prevent false positives for projects which expect to run within the context of WordPress, i.e. core, plugins and themes.
 

--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -718,7 +718,7 @@
 	Ref: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#increment-decrement-operators
 	#############################################################################
 	-->
-	<!-- Covers rule: Pre-increment/decrement should be favoured over post-increment/decrement
+	<!-- Covers rule: Pre-increment/decrement should be favored over post-increment/decrement
 		 for stand-alone statements. -->
 	<rule ref="Universal.Operators.DisallowStandalonePostIncrementDecrement">
 		<type>warning</type>
@@ -778,7 +778,7 @@
 	<rule ref="Generic.Formatting.DisallowMultipleStatements"/>
 
 	<!-- Covers rule: Unless absolutely necessary, loose comparisons should not be used,
-		 as their behaviour can be misleading. -->
+		 as their behavior can be misleading. -->
 	<rule phpcs-only="true" ref="Universal.Operators.StrictComparisons">
 		<type>warning</type>
 	</rule>
@@ -940,8 +940,8 @@
 	<!-- Check that class name references use the correct case. -->
 	<rule ref="WordPress.WP.ClassNameCase"/>
 
-	<!-- Check that __DIR__ is favoured over dirname(__FILE__)
-		 and that dirname( __DIR__, $levels ) is favoured over nested calls to dirname().
+	<!-- Check that __DIR__ is favored over dirname(__FILE__)
+		 and that dirname( __DIR__, $levels ) is favored over nested calls to dirname().
 		 See: https://core.trac.wordpress.org/ticket/48082 -->
 	<rule ref="Modernize.FunctionCalls.Dirname"/>
 

--- a/WordPress/AbstractArrayAssignmentRestrictionsSniff.php
+++ b/WordPress/AbstractArrayAssignmentRestrictionsSniff.php
@@ -21,7 +21,7 @@ use WordPressCS\WordPress\Sniff;
  * Restricts array assignment of certain keys.
  *
  * @since 0.3.0
- * @since 0.10.0 Class became a proper abstract class. This was already the behaviour.
+ * @since 0.10.0 Class became a proper abstract class. This was already the behavior.
  *               Moved the file and renamed the class from
  *               `\WordPressCS\WordPress\Sniffs\Arrays\ArrayAssignmentRestrictionsSniff` to
  *               `\WordPressCS\WordPress\AbstractArrayAssignmentRestrictionsSniff`.

--- a/WordPress/AbstractFunctionRestrictionsSniff.php
+++ b/WordPress/AbstractFunctionRestrictionsSniff.php
@@ -20,7 +20,7 @@ use WordPressCS\WordPress\Sniff;
  * Restricts usage of some functions.
  *
  * @since 0.3.0
- * @since 0.10.0 Class became a proper abstract class. This was already the behaviour.
+ * @since 0.10.0 Class became a proper abstract class. This was already the behavior.
  *               Moved the file and renamed the class from
  *               `\WordPressCS\WordPress\Sniffs\Functions\FunctionRestrictionsSniff` to
  *               `\WordPressCS\WordPress\AbstractFunctionRestrictionsSniff`.

--- a/WordPress/Docs/PHP/DontExtractStandard.xml
+++ b/WordPress/Docs/PHP/DontExtractStandard.xml
@@ -5,7 +5,7 @@
     >
     <standard>
     <![CDATA[
-    Forbids the usage of the PHP native `extract()` function. Using `extract()` makes code harder to debug, harder to understand and may cause unexpected behaviour when variables names conflict.
+    Forbids the usage of the PHP native `extract()` function. Using `extract()` makes code harder to debug, harder to understand and may cause unexpected behavior when variables names conflict.
     ]]>
     </standard>
     <code_comparison>

--- a/WordPress/Helpers/MinimumWPVersionTrait.php
+++ b/WordPress/Helpers/MinimumWPVersionTrait.php
@@ -35,7 +35,7 @@ trait MinimumWPVersionTrait {
 	 * `WordPress.WP.DeprecatedClasses`, `WordPress.WP.DeprecatedFunctions`,
 	 * `WordPress.WP.DeprecatedParameter` and the `WordPress.WP.DeprecatedParameterValues` sniff.
 	 *
-	 * These sniffs will adapt their behaviour based on the minimum supported WP version
+	 * These sniffs will adapt their behavior based on the minimum supported WP version
 	 * indicated.
 	 * By default, it is set to presume that a project will support the current
 	 * WP version and up to three releases before.
@@ -141,7 +141,7 @@ trait MinimumWPVersionTrait {
 	 * Ensures that a version number is comparable via the PHP version_compare() function
 	 * by making sure it complies with the minimum "PHP-standardized" version number requirements.
 	 *
-	 * Presumes the input is a numeric version number string. The behaviour with other input is undefined.
+	 * Presumes the input is a numeric version number string. The behavior with other input is undefined.
 	 *
 	 * @since 3.0.0
 	 *

--- a/WordPress/Helpers/WPDBTrait.php
+++ b/WordPress/Helpers/WPDBTrait.php
@@ -37,7 +37,7 @@ trait WPDBTrait {
 	 * @since 3.0.0  - Moved from the Sniff class to this dedicated Trait.
 	 *               - The `$phpcsFile` parameter was added.
 	 *
-	 * {@internal This method should be refactored to not exhibit "magic" behaviour
+	 * {@internal This method should be refactored to not exhibit "magic" behavior
 	 *            for properties in the sniff class(es) using it.}}
 	 *
 	 * @param \PHP_CodeSniffer\Files\File $phpcsFile      The file being scanned.

--- a/WordPress/Sniffs/Arrays/ArrayDeclarationSpacingSniff.php
+++ b/WordPress/Sniffs/Arrays/ArrayDeclarationSpacingSniff.php
@@ -34,9 +34,9 @@ use WordPressCS\WordPress\Sniff;
  *               The `WordPress.Arrays.ArrayDeclaration` sniff has now been deprecated.
  * @since 0.13.0 Class name changed: this class is now namespaced.
  * @since 0.14.0 Single item associative arrays are now by default exempt from the
- *               "must be multi-line" rule. This behaviour can be changed using the
+ *               "must be multi-line" rule. This behavior can be changed using the
  *               `allow_single_item_single_line_associative_arrays` property.
- * @since 3.0.0  Removed various whitespace related checks and fixers in favour of the PHPCSExtra
+ * @since 3.0.0  Removed various whitespace related checks and fixers in favor of the PHPCSExtra
  *               `NormalizedArrays.Arrays.ArrayBraceSpacing` sniff.
  */
 final class ArrayDeclarationSpacingSniff extends Sniff {

--- a/WordPress/Sniffs/CodeAnalysis/AssignmentInTernaryConditionSniff.php
+++ b/WordPress/Sniffs/CodeAnalysis/AssignmentInTernaryConditionSniff.php
@@ -23,7 +23,7 @@ use WordPressCS\WordPress\Sniff;
  *
  * @since 0.14.0
  * @since 3.0.0  - The generic "assignment in condition" logic has been removed from the sniff
- *                 in favour of the upstream `Generic.CodeAnalysis.AssignmentInCondition` sniff.
+ *                 in favor of the upstream `Generic.CodeAnalysis.AssignmentInCondition` sniff.
  *               - The sniff has been renamed from `AssignmentInCondition` to `AssignmentInTernaryCondition`.
  *
  * @link https://github.com/squizlabs/PHP_CodeSniffer/pull/1594 Upstream sniff.

--- a/WordPress/Sniffs/DB/PreparedSQLPlaceholdersSniff.php
+++ b/WordPress/Sniffs/DB/PreparedSQLPlaceholdersSniff.php
@@ -232,7 +232,7 @@ final class PreparedSQLPlaceholdersSniff extends Sniff {
 						if ( ! empty( $sprintf_parameters ) ) {
 							/*
 							 * Check for named params. sprintf() does not support this due to its variadic nature,
-							 * and we cannot analyse the code correctly if it is used, so skip the whole sprintf()
+							 * and we cannot analyze the code correctly if it is used, so skip the whole sprintf()
 							 * in that case.
 							 */
 							$valid_sprintf = true;
@@ -347,7 +347,7 @@ final class PreparedSQLPlaceholdersSniff extends Sniff {
 			}
 
 			/*
-			 * Analyse the query for incorrect LIKE queries.
+			 * Analyze the query for incorrect LIKE queries.
 			 *
 			 * - `LIKE %s` is the only correct one.
 			 * - `LIKE '%s'` or `LIKE "%s"` will not be reported here, but in the quote check.
@@ -419,7 +419,7 @@ final class PreparedSQLPlaceholdersSniff extends Sniff {
 			}
 
 			/*
-			 * Analyse the query for unsupported placeholders.
+			 * Analyze the query for unsupported placeholders.
 			 */
 			if ( preg_match_all( self::UNSUPPORTED_PLACEHOLDER_REGEX, $content, $matches ) > 0 ) {
 				if ( ! empty( $matches[0] ) ) {
@@ -463,7 +463,7 @@ final class PreparedSQLPlaceholdersSniff extends Sniff {
 			}
 
 			/*
-			 * Analyse the query for single/double quoted simple value placeholders
+			 * Analyze the query for single/double quoted simple value placeholders
 			 * Identifiers are checked separately.
 			 */
 			$regex = '`(' . $regex_quote . ')%[dfFs]\1`';
@@ -482,7 +482,7 @@ final class PreparedSQLPlaceholdersSniff extends Sniff {
 			}
 
 			/*
-			 * Analyse the query for quoted identifier placeholders.
+			 * Analyze the query for quoted identifier placeholders.
 			 */
 			$regex = '/(' . $regex_quote . '|`)(?<placeholder>' . self::PREPARE_PLACEHOLDER_REGEX . ')\1/x';
 			if ( preg_match_all( $regex, $content, $matches ) > 0 ) {
@@ -502,7 +502,7 @@ final class PreparedSQLPlaceholdersSniff extends Sniff {
 			}
 
 			/*
-			 * Analyse the query for unquoted complex placeholders.
+			 * Analyze the query for unquoted complex placeholders.
 			 */
 			$regex = '`(?<!' . $regex_quote . ')' . self::PREPARE_PLACEHOLDER_REGEX . '(?!' . $regex_quote . ')`x';
 			if ( preg_match_all( $regex, $content, $matches ) > 0 ) {
@@ -650,7 +650,7 @@ final class PreparedSQLPlaceholdersSniff extends Sniff {
 	}
 
 	/**
-	 * Analyse a sprintf() query wrapper to see if it contains a specific code pattern
+	 * Analyze a sprintf() query wrapper to see if it contains a specific code pattern
 	 * to deal correctly with `IN` queries.
 	 *
 	 * The pattern we are searching for is:
@@ -687,7 +687,7 @@ final class PreparedSQLPlaceholdersSniff extends Sniff {
 	}
 
 	/**
-	 * Analyse an implode() function call to see if it contains a specific code pattern
+	 * Analyze an implode() function call to see if it contains a specific code pattern
 	 * to dynamically create placeholders.
 	 *
 	 * The pattern we are searching for is:

--- a/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
+++ b/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
@@ -617,7 +617,7 @@ final class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 					if ( DeprecationHelper::is_function_deprecated( $this->phpcsFile, $stackPtr ) === true ) {
 						/*
 						 * Deprecated functions don't have to comply with the naming conventions,
-						 * otherwise functions deprecated in favour of a function with a compliant
+						 * otherwise functions deprecated in favor of a function with a compliant
 						 * name would still trigger an error.
 						 */
 						return;

--- a/WordPress/Sniffs/NamingConventions/ValidFunctionNameSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidFunctionNameSniff.php
@@ -59,7 +59,7 @@ final class ValidFunctionNameSniff extends Sniff {
 		if ( DeprecationHelper::is_function_deprecated( $this->phpcsFile, $stackPtr ) === true ) {
 			/*
 			 * Deprecated functions don't have to comply with the naming conventions,
-			 * otherwise functions deprecated in favour of a function with a compliant
+			 * otherwise functions deprecated in favor of a function with a compliant
 			 * name would still trigger an error.
 			 */
 			return;

--- a/WordPress/Sniffs/PHP/NoSilencedErrorsSniff.php
+++ b/WordPress/Sniffs/PHP/NoSilencedErrorsSniff.php
@@ -69,7 +69,7 @@ final class NoSilencedErrorsSniff extends Sniff {
 	 *
 	 * Errors caused by calls to any of these native PHP functions
 	 * are allowed to be silenced as file system permissions and such
-	 * can cause E_WARNINGs to be thrown which cannot be prevented via
+	 * can cause `E_WARNING`s to be thrown which cannot be prevented via
 	 * error checking.
 	 *
 	 * Note: only calls to global functions - in contrast to class methods -

--- a/WordPress/Sniffs/WhiteSpace/CastStructureSpacingSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/CastStructureSpacingSniff.php
@@ -22,7 +22,7 @@ use WordPressCS\WordPress\Sniff;
  * @since 0.11.0 The error level for all errors thrown by this sniff has been raised from warning to error.
  * @since 0.12.0 This class now extends the WordPressCS native `Sniff` class.
  * @since 0.13.0 Class name changed: this class is now namespaced.
- * @since 1.2.0  Removed the `NoSpaceAfterCloseParenthesis` error code in favour of the
+ * @since 1.2.0  Removed the `NoSpaceAfterCloseParenthesis` error code in favor of the
  *               upstream `Generic.Formatting.SpaceAfterCast.NoSpace` error.
  * @since 2.2.0  Added exception for whitespace between spread operator and cast.
  */

--- a/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.5.inc
+++ b/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.5.inc
@@ -1,7 +1,7 @@
 <?php
 // phpcs:set WordPress.Utils.I18nTextDomainFixer new_text_domain
 
-// Testing behaviour when the `new_text_domain` property is not set.
+// Testing behavior when the `new_text_domain` property is not set.
 
 load_textdomain( 'something-else', '/path/to/file.mo' );
 __( $text, 'something-else' );

--- a/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.6.inc
+++ b/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.6.inc
@@ -2,7 +2,7 @@
 // phpcs:set WordPress.Utils.I18nTextDomainFixer old_text_domain[]
 // phpcs:set WordPress.Utils.I18nTextDomainFixer new_text_domain something-else
 
-// Testing behaviour when the `old_text_domain` property is not set.
+// Testing behavior when the `old_text_domain` property is not set.
 
 load_textdomain( 'old-domain', '/path/to/file.mo' );
 __( $text, 'old-domain' );

--- a/_typos.toml
+++ b/_typos.toml
@@ -22,3 +22,5 @@ extend-ignore-identifiers-re = [
 ]
 
 [default.extend-words]
+# Don't correct a limited list of specific words.
+Automattic = "Automattic"

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,24 @@
+[files]
+extend-exclude = [
+    "WordPress/Tests/*/*.inc",
+    "WordPress/Tests/*/*.fixed",
+    "WordPress/Tests/*/*.css",
+    "WordPress/Tests/*/*.js",
+]
+ignore-hidden = true
+
+[default]
+locale = "en-us"
+check-filename = true
+extend-ignore-identifiers-re = [
+    # Renaming these (function/array key) names would be a BC-break.
+    'analyse_implode',
+    'analyse_sprintf',
+    'cachable',
+    'is_targetted_token',
+    # These are search targets for sniffs, can't be helped.
+    'avail_post_stati',
+    'url_is_accessable_via_ssl',
+]
+
+[default.extend-words]


### PR DESCRIPTION
### GH Actions: add a basic spellcheck CI check 

Follow up on PR #2472 - safeguarding that no new typos get introduced.

Notes:
* The "Typos" tool is known for having a low false positive ratio and being aware of code contexts. However, this also means, it may at times miss some things.
    When selecting it, I deemed the low false positive ratio more important.
* The language has been set to `en-US` as that's the language predominantly used for the WordPress documentation.
    This does mean that various phrases using `en-GB` spelling will need to be fixed/updated.

Ref: https://github.com/crate-ci/typos

### Spellcheck: add some exceptions and fix some typos 

Mostly US English vs UK English and as WP Core predominantly uses US English, I think we should standardize on that for this spellcheck as well.

Note: where text was copied from the rules on https://developer.wordpress.org/coding-standards/ (typically to the `ruleset.xml` files), the text upstream has been updated via WordPress/wpcs-docs#151.