### PR TITLE
Fix the class description for ConstantsHelper and ListHelper

### DIFF
--- a/WordPress/Helpers/ConstantsHelper.php
+++ b/WordPress/Helpers/ConstantsHelper.php
@@ -16,7 +16,7 @@ use PHPCSUtils\Utils\Scopes;
 use WordPressCS\WordPress\Helpers\ContextHelper;
 
 /**
- * Helper utilities for checking the context in which a token is used.
+ * Helper utilities for identifying constants in PHP code.
  *
  * ---------------------------------------------------------------------------------------------
  * This class is only intended for internal use by WordPressCS and is not part of the public API.

--- a/WordPress/Helpers/ConstantsHelper.php
+++ b/WordPress/Helpers/ConstantsHelper.php
@@ -16,7 +16,7 @@ use PHPCSUtils\Utils\Scopes;
 use WordPressCS\WordPress\Helpers\ContextHelper;
 
 /**
- * Helper utilities for identifying constants in PHP code.
+ * Helper utilities for identifying the use of global constants in PHP code.
  *
  * ---------------------------------------------------------------------------------------------
  * This class is only intended for internal use by WordPressCS and is not part of the public API.

--- a/WordPress/Helpers/ListHelper.php
+++ b/WordPress/Helpers/ListHelper.php
@@ -15,7 +15,7 @@ use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\Lists;
 
 /**
- * Helper utilities for checking the context in which a token is used.
+ * Helper utilities for working with lists.
  *
  * ---------------------------------------------------------------------------------------------
  * This class is only intended for internal use by WordPressCS and is not part of the public API.


### PR DESCRIPTION
While working on an unrelated task, I noticed that the class description in the docblock for the `ConstantsHelper` and `ListHelper` classes was incorrect. The previous description contained information about the `ContextHelper` class. This PR fixes that.