### PR TITLE
Update parameter description for `$stackPtr` in `ConstantsHelper::is_use_of_global_constant()`

### DIFF
--- a/WordPress/Helpers/ConstantsHelper.php
+++ b/WordPress/Helpers/ConstantsHelper.php
@@ -42,7 +42,7 @@ final class ConstantsHelper {
 	 *              - The `$phpcsFile` parameter was added.
 	 *
 	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
-	 * @param int                         $stackPtr  The position of the function call token.
+	 * @param int                         $stackPtr  The position of the T_STRING token.
 	 *
 	 * @return bool
 	 */


### PR DESCRIPTION
The parameter description incorrectly mentioned that `$strackPtr` should be the pointer to a function call token, while it actually should be the pointer to a T_STRING token.