### PR TITLE
GH Actions/quicktest: fix failing build when contributors update their fork

### DIFF
--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -64,15 +64,15 @@ jobs:
         run: composer lint
 
       - name: Run the unit tests without code coverage
-        if: ${{ github.ref_name != 'develop' }}
+        if: ${{ github.repository_owner != 'WordPress' || github.ref_name != 'develop' }}
         run: composer run-tests
 
       - name: Run the unit tests with code coverage
-        if: ${{ github.ref_name == 'develop' }}
+        if: ${{ github.repository_owner == 'WordPress' && github.ref_name == 'develop' }}
         run: composer coverage
 
       - name: Send coverage report to Codecov
-        if: ${{ success() && github.ref_name == 'develop' }}
+        if: ${{ success() && github.repository_owner == 'WordPress' && github.ref_name == 'develop' }}
         uses: codecov/codecov-action@v5
         with:
           files: ./build/logs/clover.xml


### PR DESCRIPTION
The `quicktest` workflow runs the code coverage for merges to `develop`, but wasn't limited to this repo.

The net effect of this is failing builds for contributors who have actions enabled on their fork and who update the `develop` branch in their own fork. The reason for the failure is that they don't have access to the `CODECOV_TOKEN`.

This commit changes the conditions on when to run the tests normally and when to run with code coverage to take the organisation where the repo lives into account. That should prevent the failing builds.