### PR TITLE
PHP 8.3 typed class constants: add tests to two sniffs

### DIFF
--- a/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.1.inc
+++ b/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.1.inc
@@ -276,7 +276,7 @@ apply_filters( $_REQUEST['else'] ); // Warning.
 
 class Acronym_Dynamic_Hooks {
 	const FILTER = 'acronym';
-	const FILTER_WITH_UNDERSCORE = 'acronym_';
+	const ?string FILTER_WITH_UNDERSCORE = 'acronym_';
 
 	protected $filter = 'acronym';
 	protected $filter_with_underscore = 'acronym_';

--- a/WordPress/Tests/WP/CapitalPDangitUnitTest.1.inc
+++ b/WordPress/Tests/WP/CapitalPDangitUnitTest.1.inc
@@ -231,3 +231,16 @@ echo Some\Enum\WordPress::ENUM_CONSTANT;
 
 // Safeguard that the sniff doesn't act on anonymous classes.
 $anon = new class() {};
+
+/*
+ * Safeguard that PHP 8.3+ typed class constants are handled correctly.
+ */
+class TypeClassConstants {
+    public const string WORDPRESS = 'wordress';
+
+    public const ?string ANOTHER = 'value',
+        WORDPRESS_SOMETHING = 'wordpress';
+
+	// Ensures no false positives on incorrect casing in a class constant type name.
+    public const (\Fully\Qualified\MyClass&wordPRESS)|string ANOTHER_WORDPRESS = 'wordpress';
+}

--- a/WordPress/Tests/WP/CapitalPDangitUnitTest.1.inc
+++ b/WordPress/Tests/WP/CapitalPDangitUnitTest.1.inc
@@ -233,7 +233,7 @@ echo Some\Enum\WordPress::ENUM_CONSTANT;
 $anon = new class() {};
 
 /*
- * Safeguard that PHP 8.3+ typed class constants are handled correctly.
+ * Safeguard that PHP 8.3+ typed class constants are handled correctly (i.e. ignored).
  */
 class TypeClassConstants {
     public const string WORDPRESS = 'wordress';

--- a/WordPress/Tests/WP/CapitalPDangitUnitTest.1.inc.fixed
+++ b/WordPress/Tests/WP/CapitalPDangitUnitTest.1.inc.fixed
@@ -231,3 +231,16 @@ echo Some\Enum\WordPress::ENUM_CONSTANT;
 
 // Safeguard that the sniff doesn't act on anonymous classes.
 $anon = new class() {};
+
+/*
+ * Safeguard that PHP 8.3+ typed class constants are handled correctly.
+ */
+class TypeClassConstants {
+    public const string WORDPRESS = 'wordress';
+
+    public const ?string ANOTHER = 'value',
+        WORDPRESS_SOMETHING = 'wordpress';
+
+	// Ensures no false positives on incorrect casing in a class constant type name.
+    public const (\Fully\Qualified\MyClass&wordPRESS)|string ANOTHER_WORDPRESS = 'wordpress';
+}

--- a/WordPress/Tests/WP/CapitalPDangitUnitTest.1.inc.fixed
+++ b/WordPress/Tests/WP/CapitalPDangitUnitTest.1.inc.fixed
@@ -233,7 +233,7 @@ echo Some\Enum\WordPress::ENUM_CONSTANT;
 $anon = new class() {};
 
 /*
- * Safeguard that PHP 8.3+ typed class constants are handled correctly.
+ * Safeguard that PHP 8.3+ typed class constants are handled correctly (i.e. ignored).
  */
 class TypeClassConstants {
     public const string WORDPRESS = 'wordress';


### PR DESCRIPTION
Typed class constants were introduced in PHP 8.3 (https://wiki.php.net/rfc/typed_class_constants). PHPCS started supporting it in version 3.9.0 (https://github.com/PHPCSStandards/PHP_CodeSniffer/pull/321). Since WPCS requires PHPCS 3.13.x, with @jrfnl's help, I investigated what needed to be updated in the WPCS repository to accommodate this new syntax.

In this PR, I'm adding tests to `WordPress.NamingConventions.PrefixAllGlobals` and `WordPress.WP.CapitalPDangit` to safeguard that those two sniffs continue to handle type class constants correctly, as both sniffs use the `T_CONST` token. No changes were required to the code of those sniffs.

`ConstantsHelper::is_use_of_global_constant()` and `AbstractClassRestrictionsSniff` will need to be changed as well to support typed class constants. This will be addressed in another PR. For now, I documented this task in #2546.