### PR TITLE
Tests: remove unnecessary trailing spaces from the test files

### DIFF
--- a/WordPress/Tests/DB/RestrictedClassesUnitTest.2.inc
+++ b/WordPress/Tests/DB/RestrictedClassesUnitTest.2.inc
@@ -6,7 +6,7 @@ namespace My;
 
 class DBlayer {
 	const VERSION = '1.0';
-	
+
 	public static $property = true;
 
 	public static function connect() {

--- a/WordPress/Tests/DB/RestrictedClassesUnitTest.3.inc
+++ b/WordPress/Tests/DB/RestrictedClassesUnitTest.3.inc
@@ -6,42 +6,42 @@ namespace My {
 
 	class DBlayer {
 		const VERSION = '1.0';
-	
+
 		public static $property = true;
-	
+
 		public static function connect() {
 		}
 	}
-	
+
 	class DBextended extends DBlayer { // Bad.
 	}
-	
+
 	class DBextender implements PDO { // Ok -> resolves to \My\PDO.
 	}
-	
+
 	class DBextendes implements \PDO { // Bad -> fully qualified as \PDO.
 	}
-	
+
 	$db0 = new \DBlayer; // Ok - fully qualified as \DBlayer.
 	$db1 = new DBlayer; // Bad - resolves to \My\DBlayer.
 	$db2 = new DBlayer(); // Bad - resolves to \My\DBlayer.
-	
+
 	echo DBlayer::VERSION; // Bad - resolves to \My\DBlayer.
 	echo DBlayer::$property; // Bad - resolves to \My\DBlayer.
 	echo DBlayer::connect(); // Bad - resolves to \My\DBlayer.
-	
+
 	$db3 = new Yours\DBlayer; // Ok - resolves to \My\Yours\DBlayer.
-	
+
 	echo Yours\DBlayer::VERSION; // Ok - resolves to \My\Yours\DBlayer.
 	echo Yours\DBlayer::$property; // Ok - resolves to \My\Yours\DBlayer.
 	echo Yours\DBlayer::connect(); // Ok - resolves to \My\Yours\DBlayer.
-	
+
 	$db4 = new \My\DBlayer; // Bad - fully qualified as \My\DBlayer.
-	
+
 	echo \My\DBlayer::VERSION; // Bad - fully qualified as \My\DBlayer.
 	echo \My\DBlayer::$property; // Bad - fully qualified as \My\DBlayer.
 	echo \My\DBlayer::connect(); // Bad - fully qualified as \My\DBlayer.
-	
+
 	echo namespace\DBlayer::VERSION; // Bad - resolves to \My\DBlayer.
 	echo namespace\DBlayer::$property; // Bad - resolves to \My\DBlayer.
 	echo namespace\DBlayer::connect(); // Bad - resolves to \My\DBlayer.
@@ -82,7 +82,7 @@ namespace AdoDb {
 	class Tester {}
 
 	class TestAgain extends Test {} // Bad.
-	
+
 	class TestYetAgain extends Tester {} // Bad.
 
 	$db5 = new Test; // Bad.

--- a/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.9.inc
+++ b/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.9.inc
@@ -11,7 +11,7 @@
 
 function acronym_unfinished_global_statement($param) {
 	global $var1, $var2 // Deliberately missing semi-colon.
-	
+
 	foreach ($param as $var2) {}
 }
 

--- a/WordPress/Tests/Security/NonceVerificationUnitTest.1.inc
+++ b/WordPress/Tests/Security/NonceVerificationUnitTest.1.inc
@@ -466,7 +466,7 @@ function function_containing_nested_enum_with_nonce_check() {
 			wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['my_nonce'] ) ), 'the_nonce' );
 		}
 	}
-	
+
 	echo $_POST['foo']; // Bad.
 }
 

--- a/WordPress/Tests/Security/NonceVerificationUnitTest.5.inc
+++ b/WordPress/Tests/Security/NonceVerificationUnitTest.5.inc
@@ -5,7 +5,7 @@
  */
 
 if ( isset ( $_POST['prefix_myfield'] ) { // OK.
-	
+
 	do_something();
 	do_something();
 	do_something();

--- a/WordPress/Tests/WP/CapitalPDangitUnitTest.1.inc
+++ b/WordPress/Tests/WP/CapitalPDangitUnitTest.1.inc
@@ -102,7 +102,7 @@ if ( $counts['wordpress'] ) { // OK.
  *
  * @link OK: http://justintadlock.com/archives/2011/07/01/captions-in-wordpress
  */
- 
+
 if ( file_exists( ABSPATH . 'wp-content/plugins/wordpress-importer/wordpress-importer.php' ) ) { // OK.
 	include_once( ABSPATH . 'wp-admin/includes/plugin.php' );
 
@@ -129,8 +129,8 @@ $default_editor_settings = [
 				'label' 		=> __( 'Arouse Documentation', 'arouse' ),
 				'content' 		=> __( '<a class="button" href="https://themezhut.com/arouse-wordpress-theme-documentation/" target="_blank">Read the documentation.</a>', 'arouse' ), // OK.
 			)
-		) 
-	);	
+		)
+	);
 
 ?>
 

--- a/WordPress/Tests/WP/CapitalPDangitUnitTest.1.inc.fixed
+++ b/WordPress/Tests/WP/CapitalPDangitUnitTest.1.inc.fixed
@@ -102,7 +102,7 @@ if ( $counts['wordpress'] ) { // OK.
  *
  * @link OK: http://justintadlock.com/archives/2011/07/01/captions-in-wordpress
  */
- 
+
 if ( file_exists( ABSPATH . 'wp-content/plugins/wordpress-importer/wordpress-importer.php' ) ) { // OK.
 	include_once( ABSPATH . 'wp-admin/includes/plugin.php' );
 
@@ -129,8 +129,8 @@ $default_editor_settings = [
 				'label' 		=> __( 'Arouse Documentation', 'arouse' ),
 				'content' 		=> __( '<a class="button" href="https://themezhut.com/arouse-wordpress-theme-documentation/" target="_blank">Read the documentation.</a>', 'arouse' ), // OK.
 			)
-		) 
-	);	
+		)
+	);
 
 ?>
 


### PR DESCRIPTION
While adding a new test to CapitalPDangitUnitTest.1.inc in an unrelated commit, I noticed unnecessary trailing spaces in this file. Instead of removing them just for this one test, I opted to create this PR removing unnecessary trailing spaces from all test files using `Squiz.WhiteSpace.SuperfluousWhitespace`. I'm including only the files where it was easy to check that the spaces were not added intentionally.