### PR TITLE
AbstractClassRestrictions: improve how anonymous classes are handled

### DIFF
--- a/WordPress/AbstractClassRestrictionsSniff.php
+++ b/WordPress/AbstractClassRestrictionsSniff.php
@@ -123,6 +123,15 @@ abstract class AbstractClassRestrictionsSniff extends AbstractFunctionRestrictio
 
 		if ( \in_array( $token['code'], array( \T_NEW, \T_EXTENDS, \T_IMPLEMENTS ), true ) ) {
 			if ( \T_NEW === $token['code'] ) {
+				$nextNonEmpty = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true );
+
+				if ( false === $nextNonEmpty
+					|| \in_array( $this->tokens[ $nextNonEmpty ]['code'], array( \T_READONLY, \T_ANON_CLASS, \T_ATTRIBUTE ), true )
+				) {
+					// Live coding or anonymous class (bow out for anonymous classes as they don't have a name).
+					return false;
+				}
+
 				$nameEnd = ( $this->phpcsFile->findNext( array( \T_OPEN_PARENTHESIS, \T_WHITESPACE, \T_SEMICOLON, \T_CLOSE_PARENTHESIS, \T_CLOSE_TAG ), ( $stackPtr + 2 ) ) - 1 );
 			} else {
 				$nameEnd = ( $this->phpcsFile->findNext( array( \T_CLOSE_CURLY_BRACKET, \T_WHITESPACE ), ( $stackPtr + 2 ) ) - 1 );

--- a/WordPress/Tests/DB/RestrictedClassesUnitTest.1.inc
+++ b/WordPress/Tests/DB/RestrictedClassesUnitTest.1.inc
@@ -104,3 +104,14 @@ $anon = new class extends PDOStatement {}; // Error.
 
 // PHP 8.1: enums can implement.
 enum MysqliEnum implements mysqli {} // Error.
+
+/*
+ * Safeguard handling of PHP 8.3+ readonly anonymous classes.
+ */
+$anon = new readonly class {
+    public function PDO() {} // OK.
+};
+
+$anon = new readonly class extends PDOStatement {}; // Error.
+
+$anon = new #[MyAttribute] readonly class {};

--- a/WordPress/Tests/DB/RestrictedClassesUnitTest.4.inc
+++ b/WordPress/Tests/DB/RestrictedClassesUnitTest.4.inc
@@ -1,0 +1,8 @@
+<?php
+
+/*
+ * Intentional parse error (nothing after T_NEW).
+ * This should be the only test in this file.
+ */
+
+$annon = new

--- a/WordPress/Tests/DB/RestrictedClassesUnitTest.php
+++ b/WordPress/Tests/DB/RestrictedClassesUnitTest.php
@@ -106,6 +106,7 @@ final class RestrictedClassesUnitTest extends AbstractSniffUnitTest {
 					91  => 1,
 					103 => 1,
 					106 => 1,
+					115 => 1,
 				);
 
 			case 'RestrictedClassesUnitTest.2.inc':


### PR DESCRIPTION
Before this PR, `AbstractClassRestrictionsSniff::is_targetted_token()` would name an anonymous class as "\class" or "\readonly" (in the case of readonly anonymous classes). While this would not cause false positives as it is not possible for a class to be named "class" or "readonly", it is not the correct behavior.

This commit improves how this method handles anonymous classes by returning `false` early, as those classes don't have a name.

Includes tests for readonly anonymous classes. It was not necessary to include more tests for normal anonymous classes, as the existing tests are already enough.