### PR TITLE
PHP 8.4 asymmetric visibility properties: add tests to four sniffs

### DIFF
--- a/WordPress/Sniffs/WP/GlobalVariablesOverrideSniff.php
+++ b/WordPress/Sniffs/WP/GlobalVariablesOverrideSniff.php
@@ -174,7 +174,7 @@ final class GlobalVariablesOverrideSniff extends Sniff {
 	protected function process_list_assignment( $stackPtr ) {
 		$list_open_close = Lists::getOpenClose( $this->phpcsFile, $stackPtr );
 		if ( false === $list_open_close ) {
-			// Short array, not short list.
+			// Live coding or short array, not short list.
 			return;
 		}
 

--- a/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.1.inc
+++ b/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.1.inc
@@ -673,4 +673,14 @@ class WP_Atom_Server {
 	}
 }
 
+/*
+ * Safeguard that PHP 8.4+ asymmetric visibility properties don't lead to false positives.
+ * Including those defined using constructor property promotion.
+ */
+class Acronym_AsymmetricVisibilityProperties {
+    public private(set) string $bar = 'bar'; // Ok.
+
+    public function __construct(public protected(set) int $foo = 0) {} // Ok.
+}
+
 // phpcs:set WordPress.NamingConventions.PrefixAllGlobals prefixes[]

--- a/WordPress/Tests/NamingConventions/ValidVariableNameUnitTest.inc
+++ b/WordPress/Tests/NamingConventions/ValidVariableNameUnitTest.inc
@@ -237,3 +237,11 @@ class Has_Mixed_Case_Property {
 $lähtöaika = true; // OK.
 $lÄhtÖaika = true; // Bad, but only handled by the sniff if Mbstring is available.
 $lÄhtOaika = true; // Bad, handled via transliteration of non-ASCII chars if Mbstring is not available.
+
+/*
+ * Safeguard that the sniff handles PHP 8.4+ asymmetric visibility properties correctly.
+ */
+class Acronym_AsymmetricVisibilityProperties {
+    public private(set) string $valid_name = 'bar'; // Ok.
+    public(set) string $invalidName = 'bar'; // Bad.
+}

--- a/WordPress/Tests/NamingConventions/ValidVariableNameUnitTest.php
+++ b/WordPress/Tests/NamingConventions/ValidVariableNameUnitTest.php
@@ -98,6 +98,7 @@ final class ValidVariableNameUnitTest extends AbstractSniffUnitTest {
 			227 => 1,
 			238 => function_exists( 'mb_strtolower' ) ? 1 : 0,
 			239 => 1,
+			246 => 1,
 		);
 	}
 

--- a/WordPress/Tests/Security/NonceVerificationUnitTest.8.inc
+++ b/WordPress/Tests/Security/NonceVerificationUnitTest.8.inc
@@ -3,4 +3,5 @@
 class IgnoreProperties {
 	public $_GET = array( 'key' => 'something' ); // OK.
 	public $_POST; // OK.
+	public private(set) string $_REQUEST; // Ok.
 }

--- a/WordPress/Tests/WP/GlobalVariablesOverrideUnitTest.1.inc
+++ b/WordPress/Tests/WP/GlobalVariablesOverrideUnitTest.1.inc
@@ -310,3 +310,13 @@ list(
 	array( $tab, $tabs ) => $not_a_wp_global,
 	get($year, $day) => &$not_a_wp_global[$year]
 ] = $array;
+
+/*
+ * Safeguard that PHP 8.4+ asymmetric visibility properties don't lead to false positives.
+ * Including those defined using constructor property promotion.
+ */
+class AsymmetricVisibilityProperties {
+    public private(set) string $pagenow = 'bar'; // Ok.
+
+    public function __construct(public protected(set) int $page = 0) {} // Ok.
+}

--- a/WordPress/Tests/WP/GlobalVariablesOverrideUnitTest.1.inc
+++ b/WordPress/Tests/WP/GlobalVariablesOverrideUnitTest.1.inc
@@ -310,7 +310,3 @@ list(
 	array( $tab, $tabs ) => $not_a_wp_global,
 	get($year, $day) => &$not_a_wp_global[$year]
 ] = $array;
-
-// Live coding/parse error.
-// This has to be the last test in the file!
-list( $tab, $tabs

--- a/WordPress/Tests/WP/GlobalVariablesOverrideUnitTest.8.inc
+++ b/WordPress/Tests/WP/GlobalVariablesOverrideUnitTest.8.inc
@@ -1,0 +1,8 @@
+<?php
+
+/*
+ * Intentional parse error (missing closing parenthesis).
+ * This should be the only test in this file.
+ */
+
+list( $tab, $tabs


### PR DESCRIPTION
Asymmetric visibility properties were introduced in PHP 8.4 (https://wiki.php.net/rfc/asymmetric-visibility-v2). PHPCS started supporting it in version 3.13.0 (https://github.com/PHPCSStandards/PHP_CodeSniffer/pull/871). Since WPCS requires PHPCS 3.13.x, with @jrfnl's help, I investigated what needed to be updated in the WPCS repository to accommodate this new syntax.

In this PR, I'm adding tests to `WordPress.NamingConventions.PrefixAllGlobals`, `WordPress.NamingConventions.ValidVariableName`, `WordPress.Security.NonceVerification`, and `WordPress.WP.GlobalVariablesOverride` to safeguard that those four sniffs continue to handle asymmetric visibility properties correctly, as those sniffs have code related to class properties or parameters passed to the class constructor (in the case of asymmetric visibility combined with constructor promoted properties). No changes were required to the code of those sniffs.

As far as I could check, no further changes are required in the WPCS codebase to accommodate the new asymmetric visibility properties syntax.

To be able to add tests to `WordPress.WP.GlobalVariablesOverride`, I had to move a test with an intentional syntax error to a separate file. While doing that, I made a small improvement to the code comment in the sniff related to the moved test.