### PR TITLE
Update the `minimum_wp_version` to WP 6.5

### DIFF
--- a/WordPress/Helpers/MinimumWPVersionTrait.php
+++ b/WordPress/Helpers/MinimumWPVersionTrait.php
@@ -79,7 +79,7 @@ trait MinimumWPVersionTrait {
 	 *
 	 * @var string WordPress version.
 	 */
-	private $default_minimum_wp_version = '6.2';
+	private $default_minimum_wp_version = '6.5';
 
 	/**
 	 * Overrule the minimum supported WordPress version with a command-line/config value.

--- a/WordPress/Tests/WP/DeprecatedClassesUnitTest.inc
+++ b/WordPress/Tests/WP/DeprecatedClassesUnitTest.inc
@@ -23,10 +23,10 @@ $json = new Services_JSON;
 $json = new Services_JSON_Error;
 class Prefix_Menu_section extends WP_Privacy_Data_Export_Requests_Table {}
 WP_Privacy_Data_Removal_Requests_Table::foo();
+/* ============ WP 6.4 ============ */
+WP_Http_Curl::do_something();
+$streams = new WP_Http_Streams();
 
 /*
  * Warning
  */
-/* ============ WP 6.4 ============ */
-WP_Http_Curl::do_something();
-$streams = new WP_Http_Streams();

--- a/WordPress/Tests/WP/DeprecatedClassesUnitTest.php
+++ b/WordPress/Tests/WP/DeprecatedClassesUnitTest.php
@@ -28,11 +28,11 @@ final class DeprecatedClassesUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getErrorList() {
 		$start_line = 9;
-		$end_line   = 25;
+		$end_line   = 28;
 		$errors     = array_fill( $start_line, ( ( $end_line - $start_line ) + 1 ), 1 );
 
 		// Unset the lines related to version comments.
-		unset( $errors[16], $errors[18], $errors[21] );
+		unset( $errors[16], $errors[18], $errors[21], $errors[26] );
 
 		return $errors;
 	}
@@ -43,9 +43,6 @@ final class DeprecatedClassesUnitTest extends AbstractSniffUnitTest {
 	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList() {
-		return array(
-			31 => 1,
-			32 => 1,
-		);
+		return array();
 	}
 }

--- a/WordPress/Tests/WP/DeprecatedFunctionsUnitTest.inc
+++ b/WordPress/Tests/WP/DeprecatedFunctionsUnitTest.inc
@@ -380,10 +380,6 @@ install_global_terms();
 sync_category_tag_slugs();
 wp_get_attachment_thumb_file();
 wp_typography_get_css_variable_inline_style();
-
-/*
- * Warning.
- */
 /* ============ WP 6.2 ============ */
 _resolve_home_block_template();
 get_page_by_title();
@@ -422,6 +418,10 @@ the_block_template_skip_link();
 wp_admin_bar_header();
 wp_img_tag_add_decoding_attr();
 wp_update_https_detection_errors();
+
+/*
+ * Warning.
+ */
 /* ============ WP 6.5 ============ */
 block_core_file_ensure_interactivity_dependency();
 block_core_image_ensure_interactivity_dependency();

--- a/WordPress/Tests/WP/DeprecatedFunctionsUnitTest.php
+++ b/WordPress/Tests/WP/DeprecatedFunctionsUnitTest.php
@@ -28,7 +28,7 @@ final class DeprecatedFunctionsUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getErrorList() {
 		$start_line = 8;
-		$end_line   = 382;
+		$end_line   = 420;
 		$errors     = array_fill( $start_line, ( ( $end_line - $start_line ) + 1 ), 1 );
 
 		// Unset the lines related to version comments.
@@ -77,7 +77,10 @@ final class DeprecatedFunctionsUnitTest extends AbstractSniffUnitTest {
 			$errors[363],
 			$errors[369],
 			$errors[371],
-			$errors[373]
+			$errors[373],
+			$errors[383],
+			$errors[386],
+			$errors[410]
 		);
 
 		return $errors;
@@ -89,15 +92,12 @@ final class DeprecatedFunctionsUnitTest extends AbstractSniffUnitTest {
 	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList() {
-		$start_line = 388;
+		$start_line = 426;
 		$end_line   = 443;
 		$warnings   = array_fill( $start_line, ( ( $end_line - $start_line ) + 1 ), 1 );
 
 		// Unset the lines related to version comments.
 		unset(
-			$warnings[390],
-			$warnings[414],
-			$warnings[425],
 			$warnings[429],
 			$warnings[432],
 			$warnings[442]

--- a/WordPress/Tests/WP/DeprecatedParametersUnitTest.inc
+++ b/WordPress/Tests/WP/DeprecatedParametersUnitTest.inc
@@ -96,6 +96,6 @@ wp_upload_bits( '', 'deprecated' );
 xfn_check( '', '', 'deprecated' );
 global_terms( $foo, 'deprecated' );
 
-// All will give an WARNING as they have been deprecated after WP 6.2.
+// All will give an WARNING as they have been deprecated after WP 6.5.
 inject_ignored_hooked_blocks_metadata_attributes('', 'deprecated');
 wp_render_elements_support_styles('deprecated');


### PR DESCRIPTION
The minimum version should be three versions behind the latest WP release, so what with 6.8.2 being the latest release, it should now become 6.5.

Includes updating the tests to match.

Previous: #2121, #2321. #2436