### PR TITLE
docs: XML documentation guidelines for sniffs (#2462)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,22 @@
+### 📘 Writing XML Documentation for Sniffs
+
+When adding XML docs inside sniff files:
+
+- Use `<em>Valid:</em>` and `<em>Invalid:</em>` to highlight examples.
+- Code blocks should follow the WordPress Coding Standards.
+- Example:
+
+  ```php
+  /**
+   * This sniff checks for X.
+   *
+   * <em>Valid:</em>
+   * ```php
+   * do_something();
+   * ```
+   *
+   * <em>Invalid:</em>
+   * ```php
+   * bad_sniff();
+   * ```
+   */


### PR DESCRIPTION
This PR addresses issue #2462 by adding clear guidelines and examples for writing XML-style documentation in code sniff files:

- Usage of <em> tags to highlight valid/invalid code
- Required indentation and line length
