### PR TITLE
Add 'do_blocks' to auto-escaped functions in EscapeOutputSniff

### DIFF
--- a/WordPress/Sniffs/Security/EscapeOutputSniff.php
+++ b/WordPress/Sniffs/Security/EscapeOutputSniff.php
@@ -53,6 +53,16 @@ class EscapeOutputSniff extends AbstractFunctionRestrictionsSniff {
 	use PrintingFunctionsTrait;
 
 	/**
+ * Custom list of functions whose output is already considered escaped.
+ *
+ * @var array<string, bool>
+ */
+protected $customAutoEscapedFunctions = array(
+    'do_blocks' => true,
+);
+
+
+	/**
 	 * Printing functions that incorporate unsafe values.
 	 *
 	 * @since 0.4.0


### PR DESCRIPTION
This PR adds the `**do_blocks()**` function to the `$customAutoEscapedFunctions` array inside `EscapeOutputSniff.php`.  
Since `do_blocks()` returns pre-escaped block HTML, this prevents false positives during static analysis.

### Fixes
Fixes #2524