### PR TITLE
Release WordPressCS 3.2.0

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -31,7 +31,7 @@ Alternatively, if you have push access to this repo, create a feature branch pre
 ## Public properties
 
 When writing sniffs, always remember that any `public` sniff property can be overruled via a custom ruleset by the end-user.
-Only make a property `public` if that is the intended behaviour.
+Only make a property `public` if that is the intended behavior.
 
 When you introduce new `public` sniff properties, or your sniff extends a class from which you inherit a `public` property, please don't forget to update the [public properties wiki page](https://github.com/WordPress/WordPress-Coding-Standards/wiki/Customizable-sniff-properties) with the relevant details once your PR has been merged into the `develop` branch.
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -39,9 +39,9 @@ When you introduce new `public` sniff properties, or your sniff extends a class 
 
 ## Pre-requisites
 * WordPress-Coding-Standards
-* PHP_CodeSniffer 3.9.0 or higher
-* PHPCSUtils 1.0.10 or higher
-* PHPCSExtra 1.2.1 or higher
+* PHP_CodeSniffer 3.13.0 or higher
+* PHPCSUtils 1.1.0 or higher
+* PHPCSExtra 1.4.0 or higher
 * PHPUnit 4.x - 9.x
 
 The WordPress Coding Standards use the `PHP_CodeSniffer` native unit test framework for unit testing the sniffs.

--- a/.github/release-checklist.md
+++ b/.github/release-checklist.md
@@ -32,6 +32,7 @@ PR for tracking changes for the x.x.x release. Target release date: **DOW MONTH 
     - [ ] `$wp_time_constants` in `WordPress.WP.CronInterval` - PR #xxx
     - [ ] `$known_test_classes` in `IsUnitTestTrait` - PR #xxx
     - [ ] ...etc...
+- [ ] Verify there there has been no vandalism on the wiki (and if so, remove/fix it).
 
 ### Release prep
 

--- a/.github/workflows/basic-qa.yml
+++ b/.github/workflows/basic-qa.yml
@@ -56,10 +56,15 @@ jobs:
           # Bust the cache at least once a month - output format: YYYY-MM.
           custom-cache-suffix: $(date -u "+%Y-%m")
 
+      # Updating the lists can fail intermittently, typically after Microsoft has released a new package.
+      # This should not be blocking for this job, so ignore any errors from this step.
+      # Ref: https://github.com/dotnet/core/issues/4167
+      - name: Update the available packages list
+        continue-on-error: true
+        run: sudo apt-get update
+
       - name: Install xmllint
-        run: |
-          sudo apt-get update
-          sudo apt-get install --no-install-recommends -y libxml2-utils
+        run: sudo apt-get install --no-install-recommends -y libxml2-utils
 
       # Show XML violations inline in the file diff.
       # @link https://github.com/marketplace/actions/xmllint-problem-matcher

--- a/.github/workflows/basic-qa.yml
+++ b/.github/workflows/basic-qa.yml
@@ -137,6 +137,10 @@ jobs:
           phpcsstandards/phpcsutils:"${{ env.UTILS_DEV }}"
           phpcsstandards/phpcsextra:"${{ env.EXTRA_DEV }}"
 
+      - name: Enable creation of `composer.lock` file
+        if: ${{ matrix.dependencies == 'lowest' }}
+        run: composer config --unset lock
+
       - name: Install Composer dependencies
         uses: ramsey/composer-install@v3
         with:

--- a/.github/workflows/basic-qa.yml
+++ b/.github/workflows/basic-qa.yml
@@ -254,3 +254,15 @@ jobs:
 
       - name: Run PHPStan
         run: phpstan analyse
+
+  typos-check:
+    name: "Find typos"
+
+    runs-on: "ubuntu-latest"
+
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@v4"
+
+      - name: "Search for misspellings"
+        uses: "crate-ci/typos@v1"

--- a/.github/workflows/basic-qa.yml
+++ b/.github/workflows/basic-qa.yml
@@ -24,9 +24,6 @@ jobs:
     name: Run code sniffs
     runs-on: ubuntu-latest
 
-    env:
-      XMLLINT_INDENT: '	'
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -56,21 +53,6 @@ jobs:
           # Bust the cache at least once a month - output format: YYYY-MM.
           custom-cache-suffix: $(date -u "+%Y-%m")
 
-      # Updating the lists can fail intermittently, typically after Microsoft has released a new package.
-      # This should not be blocking for this job, so ignore any errors from this step.
-      # Ref: https://github.com/dotnet/core/issues/4167
-      - name: Update the available packages list
-        continue-on-error: true
-        run: sudo apt-get update
-
-      - name: Install xmllint
-        run: sudo apt-get install --no-install-recommends -y libxml2-utils
-
-      # Show XML violations inline in the file diff.
-      # @link https://github.com/marketplace/actions/xmllint-problem-matcher
-      - name: Enable showing XML issues inline
-        uses: korelstar/xmllint-problem-matcher@v1
-
       - name: Check the code style of the PHP files
         id: phpcs
         run: vendor/bin/phpcs --report-full --report-checkstyle=./phpcs-report.xml
@@ -82,14 +64,72 @@ jobs:
       # Validate the Ruleset XML files.
       # @link http://xmlsoft.org/xmllint.html
       - name: Validate the WordPress rulesets
-        run: xmllint --noout --schema vendor/squizlabs/php_codesniffer/phpcs.xsd ./*/ruleset.xml
+        uses: phpcsstandards/xmllint-validate@v1
+        with:
+          pattern: "./*/ruleset.xml"
+          xsd-file: "vendor/squizlabs/php_codesniffer/phpcs.xsd"
 
       - name: Validate the sample ruleset
-        run: xmllint --noout --schema vendor/squizlabs/php_codesniffer/phpcs.xsd ./phpcs.xml.dist.sample
+        uses: phpcsstandards/xmllint-validate@v1
+        with:
+          pattern: "phpcs.xml.dist.sample"
+          xsd-file: "vendor/squizlabs/php_codesniffer/phpcs.xsd"
 
       # Validate the Documentation XML files.
       - name: Validate documentation against schema
-        run: xmllint --noout --schema vendor/phpcsstandards/phpcsdevtools/DocsXsd/phpcsdocs.xsd ./WordPress/Docs/*/*Standard.xml
+        uses: phpcsstandards/xmllint-validate@v1
+        with:
+          pattern: "./WordPress/Docs/*/*Standard.xml"
+          xsd-file: "vendor/phpcsstandards/phpcsdevtools/DocsXsd/phpcsdocs.xsd"
+
+      - name: Validate Project PHPCS ruleset against schema
+        uses: phpcsstandards/xmllint-validate@v1
+        with:
+          pattern: ".phpcs.xml.dist"
+          xsd-file: "vendor/squizlabs/php_codesniffer/phpcs.xsd"
+
+      - name: "Validate PHPUnit config for use with PHPUnit 8"
+        uses: phpcsstandards/xmllint-validate@v1
+        with:
+          pattern: "phpunit.xml.dist"
+          xsd-file: "vendor/phpunit/phpunit/schema/8.5.xsd"
+
+      - name: "Validate PHPUnit config for use with PHPUnit 9"
+        uses: phpcsstandards/xmllint-validate@v1
+        with:
+          pattern: "phpunit.xml.dist"
+          xsd-file: "vendor/phpunit/phpunit/schema/9.2.xsd"
+
+      # Check that the sniffs available are feature complete.
+      # For now, just check that all sniffs have unit tests.
+      # At a later stage the documentation check can be activated.
+      - name: Check sniff feature completeness
+        run: composer check-complete
+
+  xml-cs:
+    name: 'XML Code style'
+    runs-on: ubuntu-latest
+
+    env:
+      XMLLINT_INDENT: '	'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # Updating the lists can fail intermittently, typically after Microsoft has released a new package.
+      # This should not be blocking for this job, so ignore any errors from this step.
+      # Ref: https://github.com/dotnet/core/issues/4167
+      - name: Update the available packages list
+        continue-on-error: true
+        run: sudo apt-get update
+
+      - name: Install xmllint
+        run: sudo apt-get install --no-install-recommends -y libxml2-utils
+
+      # Show XML violations inline in the file diff.
+      - name: Enable showing XML issues inline
+        uses: korelstar/xmllint-problem-matcher@v1
 
       - name: Check the code-style consistency of the xml files
         run: |
@@ -98,12 +138,6 @@ jobs:
           diff -B --tabsize=4 ./WordPress-Docs/ruleset.xml <(xmllint --format "./WordPress-Docs/ruleset.xml")
           diff -B --tabsize=4 ./WordPress-Extra/ruleset.xml <(xmllint --format "./WordPress-Extra/ruleset.xml")
           diff -B --tabsize=4 ./phpcs.xml.dist.sample <(xmllint --format "./phpcs.xml.dist.sample")
-
-      # Check that the sniffs available are feature complete.
-      # For now, just check that all sniffs have unit tests.
-      # At a later stage the documentation check can be activated.
-      - name: Check sniff feature completeness
-        run: composer check-complete
 
   # Makes sure the rulesets don't throw unexpected errors or warnings.
   # This workflow needs to be run against a high PHP version to prevent triggering the syntax error check.

--- a/.github/workflows/basic-qa.yml
+++ b/.github/workflows/basic-qa.yml
@@ -207,7 +207,7 @@ jobs:
         with:
           php-version: 'latest'
           coverage: none
-          tools: phpstan
+          tools: phpstan:1.x
 
       # Install dependencies and handle caching in one go.
       # Dependencies need to be installed to make sure the PHPCS and PHPUnit classes are recognized.

--- a/.github/workflows/basic-qa.yml
+++ b/.github/workflows/basic-qa.yml
@@ -186,7 +186,7 @@ jobs:
           set +e
           $(pwd)/vendor/bin/phpcbf -pq ./WordPress/Tests/ --standard=WordPress --extensions=inc --exclude=Generic.PHP.Syntax --report=summary --ignore=/WordPress/Tests/WP/GlobalVariablesOverrideUnitTest.7.inc
           exitcode="$?"
-          echo "EXITCODE=$exitcode" >> $GITHUB_OUTPUT
+          echo "EXITCODE=$exitcode" >> "$GITHUB_OUTPUT"
           exit "$exitcode"
 
       - name: Fail the build on fixer conflicts and other errors

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -73,7 +73,7 @@ jobs:
 
       - name: Send coverage report to Codecov
         if: ${{ success() && github.ref_name == 'develop' }}
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           files: ./build/logs/clover.xml
           fail_ci_if_error: true

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -41,6 +41,10 @@ jobs:
           ini-values: error_reporting=-1, display_errors=On
           coverage:  ${{ github.ref_name == 'develop' && 'xdebug' || 'none' }}
 
+      - name: Enable creation of `composer.lock` file
+        if: ${{ matrix.dependencies == 'lowest' }}
+        run: composer config --unset lock
+
       - name: Install Composer dependencies
         uses: ramsey/composer-install@v3
         with:

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -69,8 +69,10 @@ jobs:
 
       - name: Send coverage report to Codecov
         if: ${{ success() && github.ref_name == 'develop' }}
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           files: ./build/logs/clover.xml
           fail_ci_if_error: true
           verbose: true
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -64,15 +64,15 @@ jobs:
         run: composer lint
 
       - name: Run the unit tests without code coverage
-        if: ${{ github.ref_name != 'develop' }}
+        if: ${{ github.repository_owner != 'WordPress' || github.ref_name != 'develop' }}
         run: composer run-tests
 
       - name: Run the unit tests with code coverage
-        if: ${{ github.ref_name == 'develop' }}
+        if: ${{ github.repository_owner == 'WordPress' && github.ref_name == 'develop' }}
         run: composer coverage
 
       - name: Send coverage report to Codecov
-        if: ${{ success() && github.ref_name == 'develop' }}
+        if: ${{ success() && github.repository_owner == 'WordPress' && github.ref_name == 'develop' }}
         uses: codecov/codecov-action@v5
         with:
           files: ./build/logs/clover.xml

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -112,6 +112,10 @@ jobs:
           phpcsstandards/phpcsutils:"${{ env.UTILS_DEV }}"
           phpcsstandards/phpcsextra:"${{ env.EXTRA_DEV }}"
 
+      - name: Enable creation of `composer.lock` file
+        if: ${{ matrix.dependencies == 'lowest' }}
+        run: composer config --unset lock
+
       - name: Install Composer dependencies
         uses: ramsey/composer-install@v3
         with:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -140,8 +140,10 @@ jobs:
 
       - name: Send coverage report to Codecov
         if: ${{ success() && matrix.coverage == true }}
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           files: ./build/logs/clover.xml
           fail_ci_if_error: true
           verbose: true
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -144,7 +144,7 @@ jobs:
 
       - name: Send coverage report to Codecov
         if: ${{ success() && matrix.coverage == true }}
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           files: ./build/logs/clover.xml
           fail_ci_if_error: true

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [ '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.4' ]
+        php: [ '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.5' ]
         dependencies: [ 'lowest', 'stable' ]
         extensions: [ '' ]
         coverage: [false]
@@ -46,11 +46,11 @@ jobs:
             dependencies: 'lowest'
             extensions: ''
             coverage: true
-          - php: '8.3'
+          - php: '8.4'
             dependencies: 'stable'
             extensions: ''
             coverage: true
-          - php: '8.3'
+          - php: '8.4'
             dependencies: 'lowest'
             extensions: ''
             coverage: true
@@ -68,7 +68,7 @@ jobs:
             dependencies: 'dev'
             extensions: ''
             coverage: false
-          - php: '8.3'
+          - php: '8.4'
             dependencies: 'dev'
             extensions: ''
             coverage: false
@@ -79,7 +79,7 @@ jobs:
 
     name: PHP ${{ matrix.php }} on PHPCS ${{ matrix.dependencies }}
 
-    continue-on-error: ${{ matrix.php == '8.4' }}
+    continue-on-error: ${{ matrix.php == '8.5' }}
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -91,9 +91,9 @@ jobs:
         id: set_ini
         run: |
           if [ "${{ matrix.dependencies }}" != "dev" ]; then
-            echo 'PHP_INI=error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On' >> $GITHUB_OUTPUT
+            echo 'PHP_INI=error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On' >> "$GITHUB_OUTPUT"
           else
-            echo 'PHP_INI=error_reporting=-1, display_errors=On' >> $GITHUB_OUTPUT
+            echo 'PHP_INI=error_reporting=-1, display_errors=On' >> "$GITHUB_OUTPUT"
           fi
 
       - name: Set up PHP

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -75,7 +75,7 @@ jobs:
 
           # Add extra build to test against PHPCS 4.
           #- php: '7.4'
-          #  dependencies: '4.0.x-dev as 3.9.99'
+          #  dependencies: '4.0.x-dev as 3.99.99'
 
     name: PHP ${{ matrix.php }} on PHPCS ${{ matrix.dependencies }}
 

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="WordPress Coding Standards" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="WordPress Coding Standards" xsi:noNamespaceSchemaLocation="https://schema.phpcodesniffer.com/phpcs.xsd">
 
 	<description>The Coding standard for the WordPress Coding Standards itself.</description>
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -337,7 +337,7 @@ More information is available in the [Upgrade Guide to WordPressCS 3.0.0 for Dev
     This fix has a positive impact on all sniffs which are based on this abstract (3 sniffs).
 - `AbstractFunctionRestrictionsSniff`: false positives on function declarations when the function returns by reference.
     This fix has a positive impact on all sniffs which are based on this abstract (nearly half of the WordPressCS sniffs).
-- `AbstractFunctionRestrictionsSniff`: false positives on instantiation of a class with the same name as a targetted function.
+- `AbstractFunctionRestrictionsSniff`: false positives on instantiation of a class with the same name as a targeted function.
     This fix has a positive impact on all sniffs which are based on this abstract (nearly half of the WordPressCS sniffs).
 - `AbstractFunctionRestrictionsSniff` now respects that function names in PHP are case-insensitive in more places.
     This fix has a positive impact on all sniffs which are based on this abstract (nearly half of the WordPressCS sniffs).
@@ -388,8 +388,8 @@ More information is available in the [Upgrade Guide to WordPressCS 3.0.0 for Dev
 - `WordPress.Security.EscapeOutput` could previously get confused when it encountered comments in the `$file` parameter for `_deprecated_file()`.
 - `WordPress.Security.EscapeOutput` now ignores significantly more operators which should yield more accurate results.
 - `WordPress.Security.EscapeOutput` now respects that function names in PHP are case-insensitive when checking whether a printing function is being used.
-- `WordPress.Security.EscapeOutput` no longer throws an `Internal.Exception` when it encounters a constant or property mirroring the name of one of the printing functions being targetted, nor will it throw false positives for those.
-- `WordPress.Security.EscapeOutput` no longer incorrectly handles method calls or calls to namespaced functions mirroring the name of one of the printing functions being targetted.
+- `WordPress.Security.EscapeOutput` no longer throws an `Internal.Exception` when it encounters a constant or property mirroring the name of one of the printing functions being targeted, nor will it throw false positives for those.
+- `WordPress.Security.EscapeOutput` no longer incorrectly handles method calls or calls to namespaced functions mirroring the name of one of the printing functions being targeted.
 - `WordPress.Security.EscapeOutput` now ignores `exit`/`die` statements without a status being passed, preventing false positives on code after the statement.
 - `WordPress.Security.EscapeOutput` now has improved recognition that `print` can also be used as an expression, not only as a statement.
 - `WordPress.Security.EscapeOutput` now has much, much, much more accurate handling of code involving ternary expressions and should now correctly ignore the ternary condition in all long ternaries being examined.
@@ -854,7 +854,7 @@ Note: This will be the last release supporting PHP_CodeSniffer 2.x.
 ### Added
 - New `WordPress.PHP.NoSilencedErrors` sniff. This sniff replaces the `Generic.PHP.NoSilencedErrors` sniff which was previously used and included in the `WordPress-Core` ruleset.
     The WordPress specific version of the sniff differs from the PHPCS version in that it:
-    * Allows the error control operator `@` if it preceeds a function call to a limited list of PHP functions for which no amount of error checking can prevent a PHP warning from being thrown.
+    * Allows the error control operator `@` if it precedes a function call to a limited list of PHP functions for which no amount of error checking can prevent a PHP warning from being thrown.
     * Allows for a used-defined list of (additional) function names to be passed to the sniff via the `custom_whitelist` property in a custom ruleset, for which - if the error control operator is detected in front of a function call to one of the functions in this whitelist - no warnings will be thrown.
     * Displays a brief snippet of code in the `warning` message text to show the context in which the error control operator is being used. The length of the snippet (in tokens) can be customized via the `context_length` property.
     * Contains a public `use_default_whitelist` property which can be set from a custom ruleset which regulates whether or not the standard whitelist of PHP functions should be used by the sniff.
@@ -942,7 +942,7 @@ If you are a maintainer of an external standard based on WPCS and any of your cu
     - `ValidatedSanitizedInput` from the `VIP` category to the `Security` category.
 - The `WordPress.VIP.PostsPerPage` sniff has been split into two distinct sniffs:
     - `WordPress.WP.PostsPerPage` which will check for the use of a high pagination limit and will throw a `warning` when this is encountered. For the `VIP` ruleset, the error level remains `error`.
-    - `WordPress.VIP.PostsPerPage` wich will check for disabling of pagination.
+    - `WordPress.VIP.PostsPerPage` which will check for disabling of pagination.
 - The default value for `minimum_supported_wp_version`, as used by a [number of sniffs detecting usage of deprecated WP features](https://github.com/WordPress/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#minimum-wp-version-to-check-for-usage-of-deprecated-functions-classes-and-function-parameters), has been updated to `4.6`.
 - The `WordPress.WP.AlternativeFunctions` sniff will now only throw a warning if/when the recommended alternative function is available in the minimum supported WP version of a project.
     In addition to this, certain alternatives are only valid alternatives in certain circumstances, like when the WP version only supports the first parameter of the PHP function it is trying to replace.
@@ -1009,7 +1009,7 @@ If you are a maintainer of an external standard based on WPCS and any of your cu
 - The `Sniff::has_html_open_tag()` utility method has been deprecated as it is now only used by deprecated sniffs. The method will be removed in WPCS 2.0.0.
 
 ### Removed
-- `cancel_comment_reply_link()`, `get_bookmark()`, `get_comment_date()`, `get_comment_time()`, `get_template_part()`, `has_post_thumbnail()`, `is_attachement()`, `post_password_required()` and `wp_attachment_is_image()` from the list of auto-escaped functions `Sniff::$autoEscapedFunctions`. This affects the `WordPress.Security.EscapeOutput` sniff.
+- `cancel_comment_reply_link()`, `get_bookmark()`, `get_comment_date()`, `get_comment_time()`, `get_template_part()`, `has_post_thumbnail()`, `is_attachment()`, `post_password_required()` and `wp_attachment_is_image()` from the list of auto-escaped functions `Sniff::$autoEscapedFunctions`. This affects the `WordPress.Security.EscapeOutput` sniff.
 - WPCS no longer explicitly supports HHVM and builds are no longer tested against HHVM.
     For now, running WPCS on HHVM to test PHP code may still work for a little while, but HHVM has announced they are [dropping PHP support](https://hhvm.com/blog/2017/09/18/the-future-of-hhvm.html).
 
@@ -1138,11 +1138,11 @@ If you are a maintainer of an external standard based on WPCS and any of your cu
 - The `WordPress.Classes.ClassInstantiation` sniff will now correctly handle detection when using `new $array['key']` or `new $array[0]`.
 - The `WordPress.NamingConventions.PrefixAllGlobals` sniff did not allow for arbitrary word separators in hook names.
 - The `WordPress.NamingConventions.PrefixAllGlobals` sniff did not correctly recognize namespaced constants as prefixed.
-- The `WordPress.PHP.StrictInArray` sniff would erronously trigger if the `true` for `$strict` was passed in uppercase.
+- The `WordPress.PHP.StrictInArray` sniff would erroneously trigger if the `true` for `$strict` was passed in uppercase.
 - The `WordPress.PHP.YodaConditions` sniff could get confused over complex ternaries containing assignments. This has been remedied.
-- The `WordPress.WP.PreparedSQL` sniff would erronously throw errors about comments found within a DB function call.
-- The `WordPress.WP.PreparedSQL` sniff would erronously throw errors about `(int)`, `(float)` and `(bool)` casts and would also flag the subsequent variable which had been safe casted.
-- The `WordPress.XSS.EscapeOutput` sniff would erronously trigger when using a fully qualified function call - including the global namespace `\` indicator - to one of the escaping functions.
+- The `WordPress.WP.PreparedSQL` sniff would erroneously throw errors about comments found within a DB function call.
+- The `WordPress.WP.PreparedSQL` sniff would erroneously throw errors about `(int)`, `(float)` and `(bool)` casts and would also flag the subsequent variable which had been safe casted.
+- The `WordPress.XSS.EscapeOutput` sniff would erroneously trigger when using a fully qualified function call - including the global namespace `\` indicator - to one of the escaping functions.
 - The lists of WP global variables and WP mixed case variables have been synchronized, which fixes some false positives.
 
 
@@ -1185,7 +1185,7 @@ If you are a maintainer of an external standard based on WPCS and any of your cu
 - `Squiz.Classes.SelfMemberReference` whitespace related checks to the `WordPress-Core` ruleset and the additional check for using `self` rather than a FQN to the `WordPress-Extra` ruleset.
 - `Squiz.PHP.EmbeddedPhp` sniff to the `WordPress-Core` ruleset to check PHP code embedded within HTML blocks.
 - `PSR2.ControlStructures.SwitchDeclaration` to the `WordPress-Core` ruleset to check for the correct layout of `switch` control structures.
-- `WordPress.Classes.ClassInstantion` sniff to the `WordPress-Extra` ruleset to detect - and auto-fix - missing parentheses on object instantiation and superfluous whitespace in PHP and JS files. The sniff will also detect `new` being assigned by reference.
+- `WordPress.Classes.ClassInstantiation` sniff to the `WordPress-Extra` ruleset to detect - and auto-fix - missing parentheses on object instantiation and superfluous whitespace in PHP and JS files. The sniff will also detect `new` being assigned by reference.
 - `WordPress.CodeAnalysis.EmptyStatement` sniff to the `WordPress-Extra` ruleset to detect - and auto-fix - superfluous semi-colons and empty PHP open-close tag combinations.
 - `WordPress.NamingConventions.PrefixAllGlobals` sniff to the `WordPress-Extra` ruleset to verify that all functions, classes, interfaces, traits, variables, constants and hook names which are declared/defined in the global namespace are prefixed with one of the prefixes provided via a custom property or via the command line.
     To activate this sniff, [one or more allowed prefixes should be provided to the sniff](https://github.com/WordPress/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#naming-conventions-prefix-everything-in-the-global-namespace). This can be done using a custom ruleset or via the command line.
@@ -1239,7 +1239,7 @@ If you are a maintainer of an external standard based on WPCS and any of your cu
 - The `WordPress.XSS.EscapeOutput` sniff will no now longer report issues when it encounters a `__DIR__`, `(unset)` cast or a floating point number, and will correctly disregard more arithmetic operators when deciding whether to report an issue or not.
 - The [whitelisting of errors using flags](https://github.com/WordPress/WordPress-Coding-Standards/wiki/Whitelisting-code-which-flags-errors) was sometimes a bit too eager and could accidentally whitelist code which was not intended to be whitelisted.
 - Various (potential) `Undefined variable`, `Undefined index` and `Undefined offset` notices.
-- Grammer in one of the `WordPress.WP.I18n` error messages.
+- Grammar in one of the `WordPress.WP.I18n` error messages.
 
 
 ## [0.11.0] - 2017-03-20
@@ -1514,7 +1514,7 @@ from the `WordPress-VIP` standard, since they are just parents for other sniffs.
 - `WordPress.CSRF.NonceVerification` sniff to flag form processing without nonce verification.
 - `in_array()` and `is_array()` to the list of sanitizing functions.
 - Support for automatic error fixing to the `WordPress.Arrays.ArrayDeclaration` sniff.
-- `WordPress.PHP.StrictComparisions` to the `WordPress-VIP` and `WordPress-Extra` rulesets.
+- `WordPress.PHP.StrictComparisons` to the `WordPress-VIP` and `WordPress-Extra` rulesets.
 - `WordPress-Docs` ruleset to sniff for proper commenting.
 - `Generic.PHP.LowerCaseKeyword`, `Generic.Files.EndFileNewline`, `Generic.Files.LowercasedFilename`, 
 `Generic.Formatting.SpaceAfterCast`, and `Generic.Functions.OpeningFunctionBraceKernighanRitchie` to the `WordPress-Core` ruleset.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -768,7 +768,7 @@ If you are a maintainer of an external standard based on WordPressCS and any of 
 - The `vip_powered_wpcom` function from the `Sniff::$autoEscapedFunctions` list which is used by the `WordPress.Security.EscapeOutput` sniff.
 - The `AbstractVariableRestrictionsSniff` class, which was deprecated since WordPressCS 1.0.0.
 - The `Sniff::has_html_open_tag()` utility method, which was deprecated since WordPressCS 1.0.0.
-- The internal `$php_reserved_vars` property from the `WordPress.NamingConventions.ValidVariableName` sniff in favour of using a PHPCS native property which is now available.
+- The internal `$php_reserved_vars` property from the `WordPress.NamingConventions.ValidVariableName` sniff in favor of using a PHPCS native property which is now available.
 - The class aliases and WPCS native autoloader used for PHPCS cross-version support.
 - The unit test framework workarounds for PHPCS cross-version unit testing.
 - Support for the `@codingStandardsChangeSetting` annotation, which is generally only used in unit tests.
@@ -865,8 +865,8 @@ Note: This will be the last release supporting PHP_CodeSniffer 2.x.
 
 ### Changed
 - The `PEAR.Functions.FunctionCallSignature` sniff, which is part of the `WordPress-Core` ruleset, used to allow multiple function call parameters per line in multi-line function calls. This will no longer be allowed.
-    As of this release, if a function call is multi-line, each parameter should start on a new line and an `error` will be thrown if the code being analysed does not comply with that rule.
-    The sniff behaviour for single-line function calls is not affected by this change.
+    As of this release, if a function call is multi-line, each parameter should start on a new line and an `error` will be thrown if the code being analyzed does not comply with that rule.
+    The sniff behavior for single-line function calls is not affected by this change.
 - Moved the `WordPress.CodeAnalysis.EmptyStatement` sniff from the `WordPress-Extra` to the `WordPress-Core` ruleset.
 - Moved the `Squiz.PHP.CommentedOutCode` sniff from the `WordPress-Docs` to the `WordPress-Extra` ruleset and lowered the threshold for determining whether or not a comment is commented out code from 45% to 40%.
 - The `WordPress.NamingConventions.PrefixAllGlobals` sniff now has improved support for recognizing whether or not (non-prefixed) globals are declared in the context of unit tests.
@@ -881,7 +881,7 @@ Note: This will be the last release supporting PHP_CodeSniffer 2.x.
 ### Fixed
 - The `WordPress.Security.ValidatedSanitizedInput` sniff will now recognize array keys in superglobals independently of the string quote-style used for the array key.
 - The `WordPress.WhiteSpace.PrecisionAlignment` sniff will no longer throw false positives for DocBlocks for JavaScript functions within inline HTML.
-- `WordPress.WP.DeprecatedClasses`: The error codes for this sniff were unstable as they were based on the code being analysed instead of on fixed values.
+- `WordPress.WP.DeprecatedClasses`: The error codes for this sniff were unstable as they were based on the code being analyzed instead of on fixed values.
 - Various bugfixes for the `WordPress.WP.GlobalVariablesOverride` sniff:
     - Previously, the sniff only checked variables in the global namespace when a `global` statement would be encountered. As of now, all variable assignments in the global namespace will be checked.
     - Nested functions/closures/classes which don't import the global variable will now be skipped over when encountered within another function, preventing false positives.
@@ -1089,8 +1089,8 @@ If you are a maintainer of an external standard based on WPCS and any of your cu
 
 ### Added
 - `WordPress.Arrays.MultipleStatementAlignment` sniff to the `WordPress-Core` ruleset which will align the array assignment operator for multi-item, multi-line associative arrays.
-    This new sniff offers four custom properties to customize its behaviour: [`ignoreNewlines`](https://github.com/WordPress/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#array-alignment-allow-for-new-lines), [`exact`](https://github.com/WordPress/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#array-alignment-allow-non-exact-alignment), [`maxColumn`](https://github.com/WordPress/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#array-alignment-maximum-column) and [`alignMultilineItems`](https://github.com/WordPress/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#array-alignment-dealing-with-multi-line-items).
-- `WordPress.DB.PreparedSQLPlaceholders` sniff to the `WordPress-Core` ruleset which will analyse the placeholders passed to `$wpdb->prepare()` for their validity, check whether queries using `IN ()` and `LIKE` statements are created correctly and will check whether a correct number of replacements are passed.
+    This new sniff offers four custom properties to customize its behavior: [`ignoreNewlines`](https://github.com/WordPress/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#array-alignment-allow-for-new-lines), [`exact`](https://github.com/WordPress/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#array-alignment-allow-non-exact-alignment), [`maxColumn`](https://github.com/WordPress/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#array-alignment-maximum-column) and [`alignMultilineItems`](https://github.com/WordPress/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#array-alignment-dealing-with-multi-line-items).
+- `WordPress.DB.PreparedSQLPlaceholders` sniff to the `WordPress-Core` ruleset which will analyze the placeholders passed to `$wpdb->prepare()` for their validity, check whether queries using `IN ()` and `LIKE` statements are created correctly and will check whether a correct number of replacements are passed.
     This sniff should help detect queries which are impacted by the security fixes to `$wpdb->prepare()` which shipped with WP 4.8.2 and 4.8.3.
     The sniff also adds a new ["PreparedSQLPlaceholders replacement count" whitelist comment](https://github.com/WordPress/WordPress-Coding-Standards/wiki/Whitelisting-code-which-flags-errors#preparedsql-placeholders-vs-replacements) for pertinent replacement count vs placeholder mismatches. Please consider carefully whether something could be a bug when you are tempted to use the whitelist comment and if so, [report it](https://github.com/WordPress/WordPress-Coding-Standards/issues/new).
 - `WordPress.PHP.DiscourageGoto` sniff to the `WordPress-Core` ruleset.
@@ -1110,7 +1110,7 @@ If you are a maintainer of an external standard based on WPCS and any of your cu
 - When passing an array property via a custom ruleset to PHP_CodeSniffer, spaces around the key/value are taken as intentional and parsed as part of the array key/value. In practice, this leads to confusion and WPCS does not expect any values which could be preceded/followed by a space, so for the WordPress Coding Standard native array properties, like `customAutoEscapedFunction`, `text_domain`, `prefixes`, WPCS will now trim whitespace from the keys/values received before use.
 - The WPCS native whitelist comments used to only work when they were put on the _end of the line_ of the code they applied to. As of now, they will also be recognized when they are be put at the _end of the statement_ they apply to.
 - The `WordPress.Arrays.ArrayDeclarationSpacing` sniff used to enforce all associative arrays to be multi-line. The handbook has been updated to only require this for multi-item associative arrays and the sniff has been updated accordingly.
-    [The original behaviour can still be enforced](https://github.com/WordPress/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#arrays-forcing-single-item-associative-arrays-to-be-multi-line) by setting the new `allow_single_item_single_line_associative_arrays` property to `false` in a custom ruleset.
+    [The original behavior can still be enforced](https://github.com/WordPress/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#arrays-forcing-single-item-associative-arrays-to-be-multi-line) by setting the new `allow_single_item_single_line_associative_arrays` property to `false` in a custom ruleset.
 - The `WordPress.NamingConventions.PrefixAllGlobals` sniff will now allow for a limited list of WP core hooks which are intended to be called by plugins and themes.
 - The `WordPress.PHP.DiscouragedFunctions` sniff used to include `create_function`. This check has been moved to the new `WordPress.PHP.RestrictedFunctions` sniff.
 - The `WordPress.PHP.StrictInArray` sniff now has a separate error code `FoundNonStrictFalse` for when the `$strict` parameter has been set to `false`. This allows for excluding the warnings for that particular situation, which will normally be intentional, via a custom ruleset.
@@ -1329,7 +1329,7 @@ You are also encouraged to check the file history of any WPCS classes you extend
 ### Removed
 - Warnings thrown by individual sniffs about parse errors they encounter. This is left up to the `Generic.PHP.Syntax` sniff which is included in the `WordPress-Extra` ruleset.
 - The `post_class()` function from the `autoEscapedFunctions` list used by the `WordPress.XSS.EscapeOutput` sniff.
-- The `Generic.Files.LowercasedFilename` sniff from the `WordPress-Core` ruleset in favour of the improved `WordPress.Files.FileName` sniff to prevent duplicate messages being thrown.
+- The `Generic.Files.LowercasedFilename` sniff from the `WordPress-Core` ruleset in favor of the improved `WordPress.Files.FileName` sniff to prevent duplicate messages being thrown.
 - Some temporary work-arounds for changes which were pulled and merged into PHPCS upstream.
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![codecov.io](https://codecov.io/gh/WordPress/WordPress-Coding-Standards/graph/badge.svg?token=UzFYn0RzVG&branch=develop)](https://codecov.io/gh/WordPress/WordPress-Coding-Standards?branch=develop)
 
 [![Minimum PHP Version](https://img.shields.io/packagist/php-v/wp-coding-standards/wpcs.svg?maxAge=3600)](https://packagist.org/packages/wp-coding-standards/wpcs)
-[![Tested on PHP 5.4 to 8.3](https://img.shields.io/badge/tested%20on-PHP%205.4%20|%205.5%20|%205.6%20|%207.0%20|%207.1%20|%207.2%20|%207.3%20|%207.4%20|%208.0%20|%208.1%20|%208.2%20|%208.3-green.svg?maxAge=2419200)](https://github.com/WordPress/WordPress-Coding-Standards/actions/workflows/unit-tests.yml)
+[![Tested on PHP 5.4 to 8.4](https://img.shields.io/badge/tested%20on-PHP%205.4%20|%205.5%20|%205.6%20|%207.0%20|%207.1%20|%207.2%20|%207.3%20|%207.4%20|%208.0%20|%208.1%20|%208.2%20|%208.3%20|%208.4-green.svg?maxAge=2419200)](https://github.com/WordPress/WordPress-Coding-Standards/actions/workflows/unit-tests.yml)
 
 [![License: MIT](https://poser.pugx.org/wp-coding-standards/wpcs/license)](https://github.com/WordPress/WordPress-Coding-Standards/blob/develop/LICENSE)
 [![Total Downloads](https://poser.pugx.org/wp-coding-standards/wpcs/downloads)](https://packagist.org/packages/wp-coding-standards/wpcs/stats)

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 * [Rulesets](#rulesets)
     + [Standards subsets](#standards-subsets)
     + [Using a custom ruleset](#using-a-custom-ruleset)
-    + [Customizing sniff behaviour](#customizing-sniff-behaviour)
+    + [Customizing sniff behavior](#customizing-sniff-behavior)
     + [Recommended additional rulesets](#recommended-additional-rulesets)
 * [How to use](#how-to-use)
     + [Command line](#command-line)
@@ -135,9 +135,9 @@ When you name this file either `.phpcs.xml`, `phpcs.xml`, `.phpcs.xml.dist` or `
 
 For more info, read about [using a default configuration file](https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Advanced-Usage#using-a-default-configuration-file). See also the provided WordPressCS [`phpcs.xml.dist.sample`](phpcs.xml.dist.sample) file and the [fully annotated example ruleset](https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Annotated-ruleset.xml) in the PHP_CodeSniffer documentation.
 
-### Customizing sniff behaviour
+### Customizing sniff behavior
 
-The WordPress Coding Standard contains a number of sniffs which are configurable. This means that you can turn parts of the sniff on or off, or change the behaviour by setting a property for the sniff in your custom `[.]phpcs.xml[.dist]` file.
+The WordPress Coding Standard contains a number of sniffs which are configurable. This means that you can turn parts of the sniff on or off, or change the behavior by setting a property for the sniff in your custom `[.]phpcs.xml[.dist]` file.
 
 You can find a complete list of all the properties you can change for the WordPressCS sniffs in the [wiki](https://github.com/WordPress/WordPress-Coding-Standards/wiki/Customizable-sniff-properties).
 
@@ -151,7 +151,7 @@ Information on custom properties which can be set for sniffs from PHP_CodeSniffe
 #### PHPCompatibility
 
 The [PHPCompatibility](https://github.com/PHPCompatibility/PHPCompatibility) ruleset and its subset [PHPCompatibilityWP](https://github.com/PHPCompatibility/PHPCompatibilityWP) come highly recommended.
-The [PHPCompatibility](https://github.com/PHPCompatibility/PHPCompatibility) sniffs are designed to analyse your code for cross-version PHP compatibility.
+The [PHPCompatibility](https://github.com/PHPCompatibility/PHPCompatibility) sniffs are designed to analyze your code for cross-version PHP compatibility.
 
 The [PHPCompatibilityWP](https://github.com/PHPCompatibility/PHPCompatibilityWP) ruleset is based on PHPCompatibility, but specifically crafted to prevent false positives for projects which expect to run within the context of WordPress, i.e. core, plugins and themes.
 

--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -718,7 +718,7 @@
 	Ref: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#increment-decrement-operators
 	#############################################################################
 	-->
-	<!-- Covers rule: Pre-increment/decrement should be favoured over post-increment/decrement
+	<!-- Covers rule: Pre-increment/decrement should be favored over post-increment/decrement
 		 for stand-alone statements. -->
 	<rule ref="Universal.Operators.DisallowStandalonePostIncrementDecrement">
 		<type>warning</type>
@@ -778,7 +778,7 @@
 	<rule ref="Generic.Formatting.DisallowMultipleStatements"/>
 
 	<!-- Covers rule: Unless absolutely necessary, loose comparisons should not be used,
-		 as their behaviour can be misleading. -->
+		 as their behavior can be misleading. -->
 	<rule phpcs-only="true" ref="Universal.Operators.StrictComparisons">
 		<type>warning</type>
 	</rule>
@@ -940,8 +940,8 @@
 	<!-- Check that class name references use the correct case. -->
 	<rule ref="WordPress.WP.ClassNameCase"/>
 
-	<!-- Check that __DIR__ is favoured over dirname(__FILE__)
-		 and that dirname( __DIR__, $levels ) is favoured over nested calls to dirname().
+	<!-- Check that __DIR__ is favored over dirname(__FILE__)
+		 and that dirname( __DIR__, $levels ) is favored over nested calls to dirname().
 		 See: https://core.trac.wordpress.org/ticket/48082 -->
 	<rule ref="Modernize.FunctionCalls.Dirname"/>
 

--- a/WordPress-Core/ruleset.xml
+++ b/WordPress-Core/ruleset.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="WordPress Core" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="WordPress-Core" xsi:noNamespaceSchemaLocation="https://schema.phpcodesniffer.com/phpcs.xsd">
 
 	<description>Non-controversial generally-agreed upon WordPress Coding Standards</description>
 

--- a/WordPress-Docs/ruleset.xml
+++ b/WordPress-Docs/ruleset.xml
@@ -41,13 +41,13 @@
 		<exclude name="Squiz.Commenting.FileComment.MissingSubpackageTag"/>
 		<!-- WP doesn't require @copyright tags -->
 		<exclude name="Squiz.Commenting.FileComment.MissingCopyrightTag"/>
-		<!-- WP has a different prefered order of tags -->
+		<!-- WP has a different preferred order of tags -->
 		<exclude name="Squiz.Commenting.FileComment.PackageTagOrder"/>
-		<!-- WP has a different prefered order of tags -->
+		<!-- WP has a different preferred order of tags -->
 		<exclude name="Squiz.Commenting.FileComment.SubpackageTagOrder"/>
-		<!-- WP has a different prefered order of tags -->
+		<!-- WP has a different preferred order of tags -->
 		<exclude name="Squiz.Commenting.FileComment.AuthorTagOrder"/>
-		<!-- WP has a different prefered order of tags -->
+		<!-- WP has a different preferred order of tags -->
 		<exclude name="Squiz.Commenting.FileComment.CopyrightTagOrder"/>
 
 		<!-- WP prefers int and bool instead of integer and boolean -->
@@ -91,7 +91,7 @@
 	<rule ref="Generic.Commenting.DocComment">
 		<!-- WP has different alignment of tag values -->
 		<exclude name="Generic.Commenting.DocComment.TagValueIndent"/>
-		<!-- WP has a different prefered order of tags -->
+		<!-- WP has a different preferred order of tags -->
 		<exclude name="Generic.Commenting.DocComment.ParamNotFirst"/>
 		<!-- Excluded to allow param documentation for arrays  -->
 		<exclude name="Generic.Commenting.DocComment.ParamGroup"/>

--- a/WordPress-Docs/ruleset.xml
+++ b/WordPress-Docs/ruleset.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="WordPress Docs" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="WordPress-Docs" xsi:noNamespaceSchemaLocation="https://schema.phpcodesniffer.com/phpcs.xsd">
 
 	<description>WordPress Coding Standards for Inline Documentation and Comments</description>
 

--- a/WordPress-Extra/ruleset.xml
+++ b/WordPress-Extra/ruleset.xml
@@ -15,7 +15,6 @@
 		 https://github.com/WordPress/WordPress-Coding-Standards/pull/382 -->
 	<rule ref="Generic.PHP.DeprecatedFunctions"/>
 	<rule ref="Generic.PHP.ForbiddenFunctions"/>
-	<rule ref="Generic.Functions.CallTimePassByReference"/>
 	<rule ref="Generic.CodeAnalysis.EmptyStatement"/>
 	<rule ref="Generic.CodeAnalysis.ForLoopShouldBeWhileLoop"/>
 	<rule ref="Generic.CodeAnalysis.ForLoopWithTestFunctionCall"/>

--- a/WordPress-Extra/ruleset.xml
+++ b/WordPress-Extra/ruleset.xml
@@ -187,6 +187,11 @@
 	<!-- Detect use of double negative `!!`. -->
 	<rule ref="Universal.CodeAnalysis.NoDoubleNegative"/>
 
+	<!-- Flags calls to get_*_meta() and get_metadata*() functions
+		 that include the $[meta_]key parameter but omit the $single parameter.
+		 https://github.com/WordPress/WordPress-Coding-Standards/issues/2459 -->
+	<rule ref="WordPress.WP.GetMetaSingle"/>
+
 	<!--
 	#############################################################################
 	Code style sniffs for more recent PHP features and syntaxes.

--- a/WordPress-Extra/ruleset.xml
+++ b/WordPress-Extra/ruleset.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="WordPress Extra" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="WordPress-Extra" xsi:noNamespaceSchemaLocation="https://schema.phpcodesniffer.com/phpcs.xsd">
 
 	<description>Best practices beyond core WordPress Coding Standards</description>
 

--- a/WordPress-Extra/ruleset.xml
+++ b/WordPress-Extra/ruleset.xml
@@ -29,6 +29,8 @@
 			<property name="allowMultiline" value="true"/>
 		</properties>
 	</rule>
+	<rule ref="Generic.Strings.UnnecessaryHeredoc"/>
+	<rule ref="Generic.WhiteSpace.HereNowdocIdentifierSpacing"/>
 
 	<!-- More generic PHP best practices.
 		 https://github.com/WordPress/WordPress-Coding-Standards/issues/607 -->

--- a/WordPress/AbstractArrayAssignmentRestrictionsSniff.php
+++ b/WordPress/AbstractArrayAssignmentRestrictionsSniff.php
@@ -21,7 +21,7 @@ use WordPressCS\WordPress\Sniff;
  * Restricts array assignment of certain keys.
  *
  * @since 0.3.0
- * @since 0.10.0 Class became a proper abstract class. This was already the behaviour.
+ * @since 0.10.0 Class became a proper abstract class. This was already the behavior.
  *               Moved the file and renamed the class from
  *               `\WordPressCS\WordPress\Sniffs\Arrays\ArrayAssignmentRestrictionsSniff` to
  *               `\WordPressCS\WordPress\AbstractArrayAssignmentRestrictionsSniff`.

--- a/WordPress/AbstractClassRestrictionsSniff.php
+++ b/WordPress/AbstractClassRestrictionsSniff.php
@@ -128,8 +128,10 @@ abstract class AbstractClassRestrictionsSniff extends AbstractFunctionRestrictio
 				$nameEnd = ( $this->phpcsFile->findNext( array( \T_CLOSE_CURLY_BRACKET, \T_WHITESPACE ), ( $stackPtr + 2 ) ) - 1 );
 			}
 
-			$classname = GetTokensAsString::noEmpties( $this->phpcsFile, ( $stackPtr + 2 ), $nameEnd );
-			$classname = $this->get_namespaced_classname( $classname, ( $stackPtr - 1 ) );
+			if ( isset( $this->tokens[ $stackPtr + 2 ] ) && false !== $nameEnd ) {
+				$classname = GetTokensAsString::noEmpties( $this->phpcsFile, ( $stackPtr + 2 ), $nameEnd );
+				$classname = $this->get_namespaced_classname( $classname, ( $stackPtr - 1 ) );
+			}
 		}
 
 		if ( \T_DOUBLE_COLON === $token['code'] ) {

--- a/WordPress/AbstractClassRestrictionsSniff.php
+++ b/WordPress/AbstractClassRestrictionsSniff.php
@@ -159,7 +159,7 @@ abstract class AbstractClassRestrictionsSniff extends AbstractFunctionRestrictio
 	}
 
 	/**
-	 * Verify if the current token is one of the targetted classes.
+	 * Verify if the current token is one of the targeted classes.
 	 *
 	 * @since 0.11.0 Split out from the `process()` method.
 	 *

--- a/WordPress/AbstractClassRestrictionsSniff.php
+++ b/WordPress/AbstractClassRestrictionsSniff.php
@@ -123,6 +123,15 @@ abstract class AbstractClassRestrictionsSniff extends AbstractFunctionRestrictio
 
 		if ( \in_array( $token['code'], array( \T_NEW, \T_EXTENDS, \T_IMPLEMENTS ), true ) ) {
 			if ( \T_NEW === $token['code'] ) {
+				$nextNonEmpty = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true );
+
+				if ( false === $nextNonEmpty
+					|| \in_array( $this->tokens[ $nextNonEmpty ]['code'], array( \T_READONLY, \T_ANON_CLASS, \T_ATTRIBUTE ), true )
+				) {
+					// Live coding or anonymous class. Bow out.
+					return false;
+				}
+
 				$nameEnd = ( $this->phpcsFile->findNext( array( \T_OPEN_PARENTHESIS, \T_WHITESPACE, \T_SEMICOLON, \T_CLOSE_PARENTHESIS, \T_CLOSE_TAG ), ( $stackPtr + 2 ) ) - 1 );
 			} else {
 				$nameEnd = ( $this->phpcsFile->findNext( array( \T_CLOSE_CURLY_BRACKET, \T_WHITESPACE ), ( $stackPtr + 2 ) ) - 1 );

--- a/WordPress/AbstractFunctionParameterSniff.php
+++ b/WordPress/AbstractFunctionParameterSniff.php
@@ -9,6 +9,7 @@
 
 namespace WordPressCS\WordPress;
 
+use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\Utils\PassedParameters;
 use WordPressCS\WordPress\AbstractFunctionRestrictionsSniff;
 
@@ -75,6 +76,44 @@ abstract class AbstractFunctionParameterSniff extends AbstractFunctionRestrictio
 		} else {
 			return $this->process_parameters( $stackPtr, $group_name, $matched_content, $parameters );
 		}
+	}
+
+	/**
+	 * Verify if the current token is a function call. Behaves like the parent method, except that
+	 * it returns false if there is no opening parenthesis after the function name (likely a
+	 * function import) or if it is a first class callable.
+	 *
+	 * @param int $stackPtr The position of the current token in the stack.
+	 *
+	 * @return bool
+	 */
+	public function is_targetted_token( $stackPtr ) {
+		if ( ! parent::is_targetted_token( $stackPtr ) ) {
+			return false;
+		}
+
+		$next = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true );
+
+		if ( \T_OPEN_PARENTHESIS !== $this->tokens[ $next ]['code'] ) {
+			// Not a function call (likely a function import).
+			return false;
+		}
+
+		if ( isset( $this->tokens[ $next ]['parenthesis_closer'] ) === false ) {
+			// Syntax error or live coding: missing closing parenthesis.
+			return false;
+		}
+
+		// First class callable.
+		$firstNonEmpty = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $next + 1 ), null, true );
+		if ( \T_ELLIPSIS === $this->tokens[ $firstNonEmpty ]['code'] ) {
+			$secondNonEmpty = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $firstNonEmpty + 1 ), null, true );
+			if ( \T_CLOSE_PARENTHESIS === $this->tokens[ $secondNonEmpty ]['code'] ) {
+				return false;
+			}
+		}
+
+		return true;
 	}
 
 	/**

--- a/WordPress/AbstractFunctionParameterSniff.php
+++ b/WordPress/AbstractFunctionParameterSniff.php
@@ -32,17 +32,17 @@ abstract class AbstractFunctionParameterSniff extends AbstractFunctionRestrictio
 	/**
 	 * Functions this sniff is looking for. Should be defined in the child class.
 	 *
-	 * @var array The only requirement for this array is that the top level
-	 *            array keys are the names of the functions you're looking for.
-	 *            Other than that, the array can have arbitrary content
-	 *            depending on your needs.
+	 * @var array<string, mixed> The only requirement for this array is that the top level
+	 *                           array keys are the names of the functions you're looking for.
+	 *                           Other than that, the array can have arbitrary content
+	 *                           depending on your needs.
 	 */
 	protected $target_functions = array();
 
 	/**
 	 * Groups of functions to restrict.
 	 *
-	 * @return array
+	 * @return array<string, array<string, array<string>>>
 	 */
 	public function getGroups() {
 		if ( empty( $this->target_functions ) ) {

--- a/WordPress/AbstractFunctionRestrictionsSniff.php
+++ b/WordPress/AbstractFunctionRestrictionsSniff.php
@@ -276,7 +276,7 @@ abstract class AbstractFunctionRestrictionsSniff extends Sniff {
 	}
 
 	/**
-	 * Verify if the current token is one of the targetted functions.
+	 * Verify if the current token is one of the targeted functions.
 	 *
 	 * @since 0.11.0 Split out from the `process()` method.
 	 *

--- a/WordPress/AbstractFunctionRestrictionsSniff.php
+++ b/WordPress/AbstractFunctionRestrictionsSniff.php
@@ -214,7 +214,7 @@ abstract class AbstractFunctionRestrictionsSniff extends Sniff {
 	}
 
 	/**
-	 * Verify is the current token is a function call.
+	 * Verify if the current token is a function call.
 	 *
 	 * @since 0.11.0 Split out from the `process()` method.
 	 *

--- a/WordPress/AbstractFunctionRestrictionsSniff.php
+++ b/WordPress/AbstractFunctionRestrictionsSniff.php
@@ -20,7 +20,7 @@ use WordPressCS\WordPress\Sniff;
  * Restricts usage of some functions.
  *
  * @since 0.3.0
- * @since 0.10.0 Class became a proper abstract class. This was already the behaviour.
+ * @since 0.10.0 Class became a proper abstract class. This was already the behavior.
  *               Moved the file and renamed the class from
  *               `\WordPressCS\WordPress\Sniffs\Functions\FunctionRestrictionsSniff` to
  *               `\WordPressCS\WordPress\AbstractFunctionRestrictionsSniff`.

--- a/WordPress/Docs/Arrays/ArrayIndentationStandard.xml
+++ b/WordPress/Docs/Arrays/ArrayIndentationStandard.xml
@@ -72,7 +72,7 @@ For heredocs/nowdocs, this does not apply to the content of the heredoc/nowdoc o
         <![CDATA[
 $args = array(
     'phrase' => 'start of phrase'
-        . 'concatented additional phrase'
+        . 'concatenated additional phrase'
         . 'more text',
 );
         ]]>
@@ -81,7 +81,7 @@ $args = array(
         <![CDATA[
 $args = array(
     'phrase' => 'start of phrase'
-. 'concatented additional phrase'
+. 'concatenated additional phrase'
 . 'more text',
 );
         ]]>
@@ -93,7 +93,7 @@ $args = array(
 $text = array(
     <<<EOD
     start of phrase
-    concatented additional phrase
+    concatenated additional phrase
     more text
 EOD
     ,
@@ -105,7 +105,7 @@ EOD
 $text = array(
 <em><<<EOD</em>
     start of phrase
-    concatented additional phrase
+    concatenated additional phrase
     more text
 EOD
 <em>,</em>

--- a/WordPress/Docs/Arrays/ArrayIndentationStandard.xml
+++ b/WordPress/Docs/Arrays/ArrayIndentationStandard.xml
@@ -5,18 +5,18 @@
     >
     <standard>
     <![CDATA[
-      The array closing bracket indentation should line up with the start of the content on the line containing the array opener.
+    The array closing bracket indentation should line up with the start of the content on the line containing the array opener.
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: Closing bracket lined up correctly">
+        <code title="Valid: Closing bracket lined up correctly.">
         <![CDATA[
 $args = array(
     'post_id' => 22,
 <em>);</em>
         ]]>
         </code>
-        <code title="Invalid: Closing bracket lined up incorrectly">
+        <code title="Invalid: Closing bracket lined up incorrectly.">
         <![CDATA[
 $args = array(
     'post_id' => 22,
@@ -26,11 +26,11 @@ $args = array(
     </code_comparison>
     <standard>
     <![CDATA[
-      In multi-line arrays, array items should be indented by a 4-space tab for each level of nested array, so that the array visually matches its structure.
+    In multi-line arrays, array items should be indented by a 4-space tab for each level of nested array, so that the array visually matches its structure.
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: Correctly indented array">
+        <code title="Valid: Correctly indented array.">
         <![CDATA[
 $args = array(
     'post_id'       => 22,
@@ -88,7 +88,7 @@ $args = array(
         </code>
     </code_comparison>
     <code_comparison>
-        <code title="Valid: Opener and comma after closer are indented correctly">
+        <code title="Valid: Opener and comma after closer are indented correctly.">
         <![CDATA[
 $text = array(
     <<<EOD

--- a/WordPress/Docs/Arrays/ArrayKeySpacingRestrictionsStandard.xml
+++ b/WordPress/Docs/Arrays/ArrayKeySpacingRestrictionsStandard.xml
@@ -5,11 +5,11 @@
     >
     <standard>
     <![CDATA[
-      When referring to array items, only include a space around the index if it is a variable or the key is concatenated.
+    When referring to array items, only include a space around the index if it is a variable or the key is concatenated.
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: Correct spacing around the index keys">
+        <code title="Valid: Correct spacing around the index keys.">
         <![CDATA[
 $post       = $posts<em>[ </em>$post_id<em> ]</em>;
 $post_title = $post<em>[ </em>'concatenated' . $title<em> ]</em>;
@@ -18,7 +18,7 @@ $post       = $posts<em>[</em>123<em>]</em>;
 $post_title = $post<em>[</em>'post_title'<em>]</em>;
         ]]>
         </code>
-        <code title="Invalid: Incorrect spacing around the index keys">
+        <code title="Invalid: Incorrect spacing around the index keys.">
         <![CDATA[
 $post       = $posts<em>[</em>$post_id<em>]</em>;
 $post_title = $post<em>[</em>'concatenated' . $title<em> ]</em>;

--- a/WordPress/Docs/Arrays/MultipleStatementAlignmentStandard.xml
+++ b/WordPress/Docs/Arrays/MultipleStatementAlignmentStandard.xml
@@ -9,7 +9,7 @@
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: correct spacing between the key and value.">
+        <code title="Valid: Correct spacing between the key and value.">
         <![CDATA[
 $foo = array( 'cat'<em> => </em>22 );
 $bar = array( 'year'<em> => </em>$current_year );

--- a/WordPress/Docs/Arrays/MultipleStatementAlignmentStandard.xml
+++ b/WordPress/Docs/Arrays/MultipleStatementAlignmentStandard.xml
@@ -5,7 +5,7 @@
     >
     <standard>
     <![CDATA[
-        When declaring arrays, there should be one space on either side of a double arrow operator used to assign a value to a key.
+    When declaring arrays, there should be one space on either side of a double arrow operator used to assign a value to a key.
     ]]>
     </standard>
     <code_comparison>
@@ -24,7 +24,7 @@ $bar = array( 'year'<em>=>   </em>$current_year );
     </code_comparison>
     <standard>
     <![CDATA[
-        In the case of a block of related assignments, it is recommended to align the arrows to promote readability.
+    In the case of a block of related assignments, it is recommended to align the arrows to promote readability.
     ]]>
     </standard>
     <code_comparison>

--- a/WordPress/Docs/DB/PreparedSQLStandard.xml
+++ b/WordPress/Docs/DB/PreparedSQLStandard.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Prepared SQL"
+    >
+    <standard>
+    <![CDATA[
+    When querying the database, you should use $wpdb->prepare() to escape and quote the contents of variables. This prevents SQL injection.
+    Use placeholders for all variables used in the query. You should not use variable interpolation or concatenation.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: Placeholders with $wpdb->prepare() used for all variables in query.">
+        <![CDATA[
+$wpdb->prepare(
+    'SELECT * from table
+        WHERE field = <em>%s</em>',
+    <em>$_GET['foo']</em>
+);
+        ]]>
+        </code>
+        <code title="Invalid: Interpolated variables used in $wpdb->query().">
+        <![CDATA[
+$wpdb->query(
+    "SELECT * from table
+    WHERE field = <em>{$_GET['foo']}</em>"
+);
+        ]]>
+        </code>
+    </code_comparison>
+
+    <code_comparison>
+        <code title="Valid: Placeholders with $wpdb->prepare() used for all variables in query.">
+        <![CDATA[
+$wpdb->prepare(
+    'SELECT * from table
+        WHERE field = <em>%s</em>',
+    <em>$value</em>
+);
+        ]]>
+        </code>
+        <code title="Invalid: Concatenation of variables used in $wpdb->*().">
+        <![CDATA[
+$wpdb->get_results(
+    "SELECT * from table
+    WHERE field = <em>" . $value</em>
+);
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/WordPress/Docs/DateTime/CurrentTimeTimestampStandard.xml
+++ b/WordPress/Docs/DateTime/CurrentTimeTimestampStandard.xml
@@ -9,24 +9,24 @@
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: using time() to get a Unix (UTC) timestamp.">
+        <code title="Valid: Using time() to get a Unix (UTC) timestamp.">
         <![CDATA[
 $timestamp = <em>time()</em>;
         ]]>
         </code>
-        <code title="Invalid: using current_time() to get a Unix (UTC) timestamp.">
+        <code title="Invalid: Using current_time() to get a Unix (UTC) timestamp.">
         <![CDATA[
 $timestamp = <em>current_time( 'timestamp', true )</em>;
         ]]>
         </code>
     </code_comparison>
     <code_comparison>
-        <code title="Valid: using current_time() with a non-timestamp format.">
+        <code title="Valid: Using current_time() with a non-timestamp format.">
         <![CDATA[
 $timestamp = current_time( <em>'Y-m-d'</em> );
         ]]>
         </code>
-        <code title="Invalid: using current_time() to get a timezone corrected timestamp.">
+        <code title="Invalid: Using current_time() to get a timezone corrected timestamp.">
         <![CDATA[
 $timestamp = <em>current_time( 'U', false )</em>;
         ]]>

--- a/WordPress/Docs/NamingConventions/PrefixAllGlobalsStandard.xml
+++ b/WordPress/Docs/NamingConventions/PrefixAllGlobalsStandard.xml
@@ -15,7 +15,7 @@
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: Using the prefix ECPT_">
+        <code title="Valid: Using the prefix ECPT_.">
         <![CDATA[
 define( <em>'ECPT_VERSION'</em>, '1.0' );
 
@@ -29,7 +29,7 @@ apply_filter(
 );
         ]]>
         </code>
-        <code title="Invalid: non-prefixed code">
+        <code title="Invalid: non-prefixed code.">
         <![CDATA[
 define( <em>'PLUGIN_VERSION'</em>, '1.0' );
 
@@ -45,7 +45,7 @@ apply_filter(
         </code>
     </code_comparison>
     <code_comparison>
-        <code title="Valid: Using the prefix ECPT_ in namespaced code">
+        <code title="Valid: Using the prefix ECPT_ in namespaced code.">
         <![CDATA[
 namespace <em>ECPT_Plugin\Admin</em>;
 
@@ -68,7 +68,7 @@ apply_filter(
 );
         ]]>
         </code>
-        <code title="Invalid: using a non-prefixed namespace">
+        <code title="Invalid: using a non-prefixed namespace.">
         <![CDATA[
 namespace <em>Admin</em>;
 
@@ -88,12 +88,12 @@ class Admin_Page {}
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: Using the prefix mycoolplugin_">
+        <code title="Valid: Using the prefix mycoolplugin_.">
         <![CDATA[
 function <em>mycoolplugin_save_post()</em> {}
         ]]>
         </code>
-        <code title="Invalid: Using a WordPress reserved prefix wp_">
+        <code title="Invalid: Using a WordPress reserved prefix wp_.">
         <![CDATA[
 function <em>wp_save_post()</em> {}
         ]]>
@@ -105,12 +105,12 @@ function <em>wp_save_post()</em> {}
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: Using the distinct prefix MyPlugin">
+        <code title="Valid: Using the distinct prefix MyPlugin.">
         <![CDATA[
 interface <em>MyPluginIsCool</em> {}
         ]]>
         </code>
-        <code title="Invalid: Using a two-letter prefix My">
+        <code title="Invalid: Using a two-letter prefix My.">
         <![CDATA[
 interface <em>My</em> {}
         ]]>

--- a/WordPress/Docs/NamingConventions/PrefixAllGlobalsStandard.xml
+++ b/WordPress/Docs/NamingConventions/PrefixAllGlobalsStandard.xml
@@ -29,7 +29,7 @@ apply_filter(
 );
         ]]>
         </code>
-        <code title="Invalid: non-prefixed code.">
+        <code title="Invalid: Non-prefixed code.">
         <![CDATA[
 define( <em>'PLUGIN_VERSION'</em>, '1.0' );
 
@@ -68,7 +68,7 @@ apply_filter(
 );
         ]]>
         </code>
-        <code title="Invalid: using a non-prefixed namespace.">
+        <code title="Invalid: Using a non-prefixed namespace.">
         <![CDATA[
 namespace <em>Admin</em>;
 

--- a/WordPress/Docs/NamingConventions/PrefixAllGlobalsStandard.xml
+++ b/WordPress/Docs/NamingConventions/PrefixAllGlobalsStandard.xml
@@ -101,7 +101,7 @@ function <em>wp_save_post()</em> {}
     </code_comparison>
     <standard>
     <![CDATA[
-    Prefixes must have a minimum length of three character to be considered valid, as many plugins and themes share the same initials.
+    Prefixes must have a minimum length of four character to be considered valid, as many plugins and themes share the same initials.
     ]]>
     </standard>
     <code_comparison>

--- a/WordPress/Docs/NamingConventions/ValidFunctionNameStandard.xml
+++ b/WordPress/Docs/NamingConventions/ValidFunctionNameStandard.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Valid Function Name"
+>
+    <standard>
+    <![CDATA[
+    Use lowercase letters in function names. Separate words using underscores. Do not use double underscores as a prefix.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: lowercase function name.">
+        <![CDATA[
+function <em>prefix_function_name()</em> {}
+        ]]>
+        </code>
+        <code title="Invalid: mixed case function name.">
+        <![CDATA[
+function <em>Prefix_Function_NAME()</em> {}
+        ]]>
+        </code>
+    </code_comparison>
+    <code_comparison>
+        <code title="Valid: words separated by underscores.">
+        <![CDATA[
+class My_Class {
+    public static <em>method_name()</em> {}
+}
+        ]]>
+        </code>
+        <code title="Invalid: using camel case to separate words.">
+        <![CDATA[
+class My_Class {
+    public static <em>methodName()</em> {}
+}
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/WordPress/Docs/NamingConventions/ValidFunctionNameStandard.xml
+++ b/WordPress/Docs/NamingConventions/ValidFunctionNameStandard.xml
@@ -9,26 +9,26 @@
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: lowercase function name.">
+        <code title="Valid: Lowercase function name.">
         <![CDATA[
 function <em>prefix_function_name()</em> {}
         ]]>
         </code>
-        <code title="Invalid: mixed case function name.">
+        <code title="Invalid: Mixed case function name.">
         <![CDATA[
 function <em>Prefix_Function_NAME()</em> {}
         ]]>
         </code>
     </code_comparison>
     <code_comparison>
-        <code title="Valid: words separated by underscores.">
+        <code title="Valid: Words separated by underscores.">
         <![CDATA[
 class My_Class {
     public static <em>method_name()</em> {}
 }
         ]]>
         </code>
-        <code title="Invalid: using camel case to separate words.">
+        <code title="Invalid: Using camel case to separate words.">
         <![CDATA[
 class My_Class {
     public static <em>methodName()</em> {}

--- a/WordPress/Docs/NamingConventions/ValidFunctionNameStandard.xml
+++ b/WordPress/Docs/NamingConventions/ValidFunctionNameStandard.xml
@@ -24,15 +24,27 @@ function <em>Prefix_Function_NAME()</em> {}
         <code title="Valid: Words separated by underscores.">
         <![CDATA[
 class My_Class {
-    public static <em>method_name()</em> {}
+    public static function <em>method_name()</em> {}
 }
         ]]>
         </code>
         <code title="Invalid: Using camel case to separate words.">
         <![CDATA[
 class My_Class {
-    public static <em>methodName()</em> {}
+    public static function <em>methodName()</em> {}
 }
+        ]]>
+        </code>
+    </code_comparison>
+    <code_comparison>
+        <code title="Valid: Single underscore prefix is allowed.">
+        <![CDATA[
+function <em>_prefix_function_name()</em> {}
+        ]]>
+        </code>
+        <code title="Invalid: Double underscore prefix is not allowed.">
+        <![CDATA[
+function <em>__prefix_function_name()</em> {}
         ]]>
         </code>
     </code_comparison>

--- a/WordPress/Docs/NamingConventions/ValidHookNameStandard.xml
+++ b/WordPress/Docs/NamingConventions/ValidHookNameStandard.xml
@@ -9,24 +9,24 @@
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: lowercase hook name.">
+        <code title="Valid: Lowercase hook name.">
         <![CDATA[
 do_action( <em>'prefix_hook_name'</em>, $var );
         ]]>
         </code>
-        <code title="Invalid: mixed case hook name.">
+        <code title="Invalid: Mixed case hook name.">
         <![CDATA[
 do_action( <em>'Prefix_Hook_NAME'</em>, $var );
         ]]>
         </code>
     </code_comparison>
     <code_comparison>
-        <code title="Valid: words separated by underscores.">
+        <code title="Valid: Words separated by underscores.">
         <![CDATA[
 apply_filters( <em>'prefix_hook_name'</em>, $var );
         ]]>
         </code>
-        <code title="Invalid: using non-underscore characters to separate words.">
+        <code title="Invalid: Using non-underscore characters to separate words.">
         <![CDATA[
 apply_filters( <em>'prefix\hook-name'</em>, $var );
         ]]>

--- a/WordPress/Docs/NamingConventions/ValidPostTypeSlugStandard.xml
+++ b/WordPress/Docs/NamingConventions/ValidPostTypeSlugStandard.xml
@@ -9,7 +9,7 @@
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: short post type slug.">
+        <code title="Valid: Short post type slug.">
         <![CDATA[
 register_post_type( 
     <em>'my_short_slug'</em>, 
@@ -17,7 +17,7 @@ register_post_type(
 );
         ]]>
         </code>
-        <code title="Invalid: too long post type slug.">
+        <code title="Invalid: Too long post type slug.">
         <![CDATA[
 register_post_type( 
     <em>'my_own_post_type_too_long'</em>, 
@@ -32,7 +32,7 @@ register_post_type(
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: no special characters in post type slug.">
+        <code title="Valid: No special characters in post type slug.">
         <![CDATA[
 register_post_type( 
     <em>'my_post_type_slug'</em>, 
@@ -40,7 +40,7 @@ register_post_type(
 );
         ]]>
         </code>
-        <code title="Invalid: invalid characters in post type slug.">
+        <code title="Invalid: Invalid characters in post type slug.">
         <![CDATA[
 register_post_type( 
     <em>'my/post/type/slug'</em>, 
@@ -55,7 +55,7 @@ register_post_type(
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: static post type slug.">
+        <code title="Valid: Static post type slug.">
         <![CDATA[
 register_post_type( 
     <em>'my_post_active'</em>, 
@@ -63,7 +63,7 @@ register_post_type(
 );
         ]]>
         </code>
-        <code title="Invalid: dynamic post type slug.">
+        <code title="Invalid: Dynamic post type slug.">
         <![CDATA[
 register_post_type( 
     <em>"my_post_{$status}"</em>, 
@@ -78,7 +78,7 @@ register_post_type(
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: prefixed post slug.">
+        <code title="Valid: Prefixed post slug.">
         <![CDATA[
 register_post_type( 
     <em>'prefixed_author'</em>, 
@@ -86,7 +86,7 @@ register_post_type(
 );
         ]]>
         </code>
-        <code title="Invalid: using a reserved keyword as slug.">
+        <code title="Invalid: Using a reserved keyword as slug.">
         <![CDATA[
 register_post_type( 
     <em>'author'</em>, 
@@ -101,7 +101,7 @@ register_post_type(
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: custom prefix post slug.">
+        <code title="Valid: Custom prefix post slug.">
         <![CDATA[
 register_post_type( 
     <em>'prefixed_author'</em>, 
@@ -109,7 +109,7 @@ register_post_type(
 );
         ]]>
         </code>
-        <code title="Invalid: using a reserved prefix.">
+        <code title="Invalid: Using a reserved prefix.">
         <![CDATA[
 register_post_type( 
     <em>'wp_author'</em>, 

--- a/WordPress/Docs/NamingConventions/ValidVariableNameStandard.xml
+++ b/WordPress/Docs/NamingConventions/ValidVariableNameStandard.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Valid Variable Name"
+>
+    <standard>
+    <![CDATA[
+    Use lowercase letters in variable names. Separate words using underscores.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: Lowercase variable name.">
+        <![CDATA[
+<em>$prefix_variable_name</em> = 'value';
+
+echo <em>$prefix_variable_name</em>;
+        ]]>
+        </code>
+        <code title="Invalid: Mixed case function name.">
+        <![CDATA[
+<em>$Prefix_Variable_NAME</em> = 'value';
+
+echo <em>$Prefix_Variable_NAME</em>;
+        ]]>
+        </code>
+    </code_comparison>
+    <code_comparison>
+        <code title="Valid: Words separated by underscores.">
+        <![CDATA[
+class My_Class {
+    public <em>$property_name</em> = 'value';
+}
+        ]]>
+        </code>
+        <code title="Invalid: Using camel case to separate words.">
+        <![CDATA[
+class My_Class {
+    public <em>$propertyName</em> = 'value';
+}
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/WordPress/Docs/PHP/DontExtractStandard.xml
+++ b/WordPress/Docs/PHP/DontExtractStandard.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Detect Use Of `extract()`"
+    >
+    <standard>
+    <![CDATA[
+    Forbids the usage of the PHP native `extract()` function. Using `extract()` makes code harder to debug, harder to understand and may cause unexpected behaviour when variables names conflict.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: Accessing array elements directly.">
+        <![CDATA[
+$post_data = array(
+    'title'   => 'My title',
+    'content' => 'My content',
+    'ID'      => 123
+);
+<em>echo $post_data['title'];</em>
+        ]]>
+        </code>
+        <code title="Invalid: Using the `extract()` function.">
+        <![CDATA[
+$var_array = array(
+    'title'    => 'My title',
+    'content'  => 'My content',
+    'ID'       => 123
+);
+
+<em>extract( $var_array );</em>
+echo $title;
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/WordPress/Docs/PHP/DontExtractStandard.xml
+++ b/WordPress/Docs/PHP/DontExtractStandard.xml
@@ -5,7 +5,7 @@
     >
     <standard>
     <![CDATA[
-    Forbids the usage of the PHP native `extract()` function. Using `extract()` makes code harder to debug, harder to understand and may cause unexpected behaviour when variables names conflict.
+    Forbids the usage of the PHP native `extract()` function. Using `extract()` makes code harder to debug, harder to understand and may cause unexpected behavior when variables names conflict.
     ]]>
     </standard>
     <code_comparison>

--- a/WordPress/Docs/PHP/IniSetStandard.xml
+++ b/WordPress/Docs/PHP/IniSetStandard.xml
@@ -9,12 +9,12 @@
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: ini_set() for a possibly breaking setting.">
+        <code title="Valid: (Not) using ini_set() for a possibly breaking setting.">
         <![CDATA[
 // ini_set() should not be used.
         ]]>
         </code>
-        <code title="Invalid: ini_set() for a possibly breaking setting.">
+        <code title="Invalid: Using ini_set() for a possibly breaking setting.">
         <![CDATA[
 ini_set( <em>'short_open_tag'</em>, 'off' );
         ]]>
@@ -26,12 +26,12 @@ ini_set( <em>'short_open_tag'</em>, 'off' );
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: WordPress functional alternative.">
+        <code title="Valid: Using WordPress functional alternative.">
         <![CDATA[
 <em>wp_raise_memory_limit();</em>
         ]]>
         </code>
-        <code title="Invalid: ini_set() to alter memory limits.">
+        <code title="Invalid: Using ini_set() to alter memory limits.">
         <![CDATA[
 ini_set( <em>'memory_limit'</em>, '256M' );
         ]]>

--- a/WordPress/Docs/PHP/IniSetStandard.xml
+++ b/WordPress/Docs/PHP/IniSetStandard.xml
@@ -5,7 +5,7 @@
     >
     <standard>
     <![CDATA[
-      Using ini_set() and similar functions for altering PHP settings at runtime is discouraged. Changing runtime configuration might break other plugins and themes, and even WordPress itself.
+    Using ini_set() and similar functions for altering PHP settings at runtime is discouraged. Changing runtime configuration might break other plugins and themes, and even WordPress itself.
     ]]>
     </standard>
     <code_comparison>
@@ -22,7 +22,7 @@ ini_set( <em>'short_open_tag'</em>, 'off' );
     </code_comparison>
     <standard>
     <![CDATA[
-      For some configuration values there are alternative ways available - either via WordPress native functionality of via standard PHP - to achieve the same without the risk of breaking interoperability. These alternatives are preferred.
+    For some configuration values there are alternative ways available - either via WordPress native functionality of via standard PHP - to achieve the same without the risk of breaking interoperability. These alternatives are preferred.
     ]]>
     </standard>
     <code_comparison>

--- a/WordPress/Docs/PHP/StrictInArrayStandard.xml
+++ b/WordPress/Docs/PHP/StrictInArrayStandard.xml
@@ -11,13 +11,13 @@
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: calling in_array() with the $strict parameter set to `true`.">
+        <code title="Valid: Calling in_array() with the $strict parameter set to `true`.">
         <![CDATA[
 $array = array( '1', 1, true );
 if ( in_array( $value, $array, <em>true</em> ) ) {}
         ]]>
         </code>
-        <code title="Invalid: calling in_array() without passing the $strict parameter.">
+        <code title="Invalid: Calling in_array() without passing the $strict parameter.">
         <![CDATA[
 $array = array( '1', 1, true );
 if ( in_array( $value, $array<em> </em>) ) {}
@@ -26,12 +26,12 @@ if ( in_array( $value, $array<em> </em>) ) {}
     </code_comparison>
 
     <code_comparison>
-        <code title="Valid: calling array_search() with the $strict parameter set to `true`.">
+        <code title="Valid: Calling array_search() with the $strict parameter set to `true`.">
         <![CDATA[
 $key = array_search( 1, $array, <em>true</em> );
         ]]>
         </code>
-        <code title="Invalid: calling array_search() without passing the $strict parameter.">
+        <code title="Invalid: Calling array_search() without passing the $strict parameter.">
         <![CDATA[
 $key = array_search( 1, $array<em> </em>);
         ]]>
@@ -39,12 +39,12 @@ $key = array_search( 1, $array<em> </em>);
     </code_comparison>
 
     <code_comparison>
-        <code title="Valid: calling array_keys() with a $search_value and the $strict parameter set to `true`.">
+        <code title="Valid: Calling array_keys() with a $search_value and the $strict parameter set to `true`.">
         <![CDATA[
 $keys = array_keys( $array, $key, <em>true</em> );
         ]]>
         </code>
-        <code title="Invalid: calling array_keys() with a $search_value without passing the $strict parameter.">
+        <code title="Invalid: Calling array_keys() with a $search_value without passing the $strict parameter.">
         <![CDATA[
 $keys = array_keys( $array, $key<em> </em>);
         ]]>

--- a/WordPress/Docs/PHP/YodaConditionsStandard.xml
+++ b/WordPress/Docs/PHP/YodaConditionsStandard.xml
@@ -9,14 +9,14 @@
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: The variable is placed on the right">
+        <code title="Valid: The variable is placed on the right.">
         <![CDATA[
 if ( <em>true === $the_force</em> ) {
     $victorious = you_will( $be );
 }
         ]]>
         </code>
-        <code title="Invalid: The variable has been placed on the left">
+        <code title="Invalid: The variable has been placed on the left.">
         <![CDATA[
 if ( <em>$the_force === false</em> ) {
     $victorious = you_will_not( $be );

--- a/WordPress/Docs/WP/CapabilitiesStandard.xml
+++ b/WordPress/Docs/WP/CapabilitiesStandard.xml
@@ -9,12 +9,12 @@
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: a WP native or registered custom user capability is used.">
+        <code title="Valid: A WP native or registered custom user capability is used.">
         <![CDATA[
 if ( author_can( $post, <em>'manage_sites'</em> ) ) { }
         ]]>
         </code>
-        <code title="Invalid: unknown/unsupported user capability is used.">
+        <code title="Invalid: Unknown/unsupported user capability is used.">
         <![CDATA[
 map_meta_cap( <em>'manage_site'</em>, $user->ID );
         ]]>
@@ -26,7 +26,7 @@ map_meta_cap( <em>'manage_site'</em>, $user->ID );
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: user capability is used.">
+        <code title="Valid: User capability is used.">
         <![CDATA[
 add_options_page(
     esc_html__( 'Options', 'textdomain' ),
@@ -37,7 +37,7 @@ add_options_page(
 );
         ]]>
         </code>
-        <code title="Invalid: user role is used instead of a capability.">
+        <code title="Invalid: User role is used instead of a capability.">
         <![CDATA[
 add_options_page(
     esc_html__( 'Options', 'textdomain' ),
@@ -55,12 +55,12 @@ add_options_page(
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: a WP native or registered custom user capability is used.">
+        <code title="Valid: A WP native or registered custom user capability is used.">
         <![CDATA[
 if ( author_can( $post, <em>'read'</em> ) ) { }
         ]]>
         </code>
-        <code title="Invalid: deprecated user capability is used.">
+        <code title="Invalid: Deprecated user capability is used.">
         <![CDATA[
 if ( author_can( $post, <em>'level_6'</em> ) ) { }
         ]]>

--- a/WordPress/Docs/WP/CapabilitiesStandard.xml
+++ b/WordPress/Docs/WP/CapabilitiesStandard.xml
@@ -5,7 +5,7 @@
     >
     <standard>
     <![CDATA[
-Capabilities passed should be valid capabilities (custom capabilities can be added in the ruleset).
+    Capabilities passed should be valid capabilities (custom capabilities can be added in the ruleset).
     ]]>
     </standard>
     <code_comparison>
@@ -22,7 +22,7 @@ map_meta_cap( <em>'manage_site'</em>, $user->ID );
     </code_comparison>
     <standard>
     <![CDATA[
-Always use user capabilities instead of roles.
+    Always use user capabilities instead of roles.
     ]]>
     </standard>
     <code_comparison>
@@ -51,7 +51,7 @@ add_options_page(
     </code_comparison>
     <standard>
     <![CDATA[
-Don't use deprecated capabilities.
+    Don't use deprecated capabilities.
     ]]>
     </standard>
     <code_comparison>

--- a/WordPress/Docs/WP/CapitalPDangitStandard.xml
+++ b/WordPress/Docs/WP/CapitalPDangitStandard.xml
@@ -5,9 +5,9 @@
     >
     <standard>
     <![CDATA[
-The correct spelling of "WordPress" should be used in text strings, comments and object names.
+    The correct spelling of "WordPress" should be used in text strings, comments and object names.
 
-In select cases, when part of an identifier or a URL, WordPress does not have to be capitalized.
+    In select cases, when part of an identifier or a URL, WordPress does not have to be capitalized.
     ]]>
     </standard>
     <code_comparison>

--- a/WordPress/Docs/WP/ClassNameCaseStandard.xml
+++ b/WordPress/Docs/WP/ClassNameCaseStandard.xml
@@ -9,12 +9,12 @@
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: reference to a WordPress native class name using the correct case.">
+        <code title="Valid: Reference to a WordPress native class name using the correct case.">
         <![CDATA[
 $obj = new WP_Query;
         ]]>
         </code>
-        <code title="Invalid: reference to a WordPress native class name not using the correct case.">
+        <code title="Invalid: Reference to a WordPress native class name not using the correct case.">
         <![CDATA[
 $obj = new wp_query;
         ]]>

--- a/WordPress/Docs/WP/DeprecatedClassesStandard.xml
+++ b/WordPress/Docs/WP/DeprecatedClassesStandard.xml
@@ -9,12 +9,12 @@
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: use of a current (non-deprecated) class.">
+        <code title="Valid: Use of a current (non-deprecated) class.">
         <![CDATA[
 $a = new <em>WP_User_Query</em>();
         ]]>
         </code>
-        <code title="Invalid: use of a deprecated class.">
+        <code title="Invalid: Use of a deprecated class.">
         <![CDATA[
 $a = new <em>WP_User_Search</em>(); // Deprecated WP 3.1.
         ]]>

--- a/WordPress/Docs/WP/DeprecatedFunctionsStandard.xml
+++ b/WordPress/Docs/WP/DeprecatedFunctionsStandard.xml
@@ -9,12 +9,12 @@
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: use of a current (non-deprecated) function.">
+        <code title="Valid: Use of a current (non-deprecated) function.">
         <![CDATA[
 $sites = <em>get_sites</em>();
         ]]>
         </code>
-        <code title="Invalid: use of a deprecated function.">
+        <code title="Invalid: Use of a deprecated function.">
         <![CDATA[
 $sites = <em>wp_get_sites</em>(); // Deprecated WP 4.6.
         ]]>

--- a/WordPress/Docs/WP/DeprecatedParameterValuesStandard.xml
+++ b/WordPress/Docs/WP/DeprecatedParameterValuesStandard.xml
@@ -9,12 +9,12 @@
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: passing a valid function parameter value.">
+        <code title="Valid: Passing a valid function parameter value.">
         <![CDATA[
 bloginfo( <em>'url'</em> );
         ]]>
         </code>
-        <code title="Invalid: passing a deprecated function parameter value.">
+        <code title="Invalid: Passing a deprecated function parameter value.">
         <![CDATA[
 bloginfo ( <em>'home'</em> ); // Deprecated WP 2.2.0.
         ]]>

--- a/WordPress/Docs/WP/DeprecatedParametersStandard.xml
+++ b/WordPress/Docs/WP/DeprecatedParametersStandard.xml
@@ -6,7 +6,7 @@
     <standard>
     <![CDATA[
     Please refrain from passing deprecated WordPress function parameters.
-	In case, you need to pass an optional parameter positioned <em>after</em> the deprecated parameter, only ever pass the default value.
+    In case, you need to pass an optional parameter positioned <em>after</em> the deprecated parameter, only ever pass the default value.
     ]]>
     </standard>
     <code_comparison>

--- a/WordPress/Docs/WP/DeprecatedParametersStandard.xml
+++ b/WordPress/Docs/WP/DeprecatedParametersStandard.xml
@@ -10,13 +10,13 @@
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: not passing a deprecated parameter.">
+        <code title="Valid: Not passing a deprecated parameter.">
         <![CDATA[
 // First - and only - parameter deprecated.
 get_the_author();
         ]]>
         </code>
-        <code title="Invalid: passing a deprecated parameter.">
+        <code title="Invalid: Passing a deprecated parameter.">
         <![CDATA[
 // First - and only - parameter deprecated.
 get_the_author( <em>$string</em> );
@@ -24,13 +24,13 @@ get_the_author( <em>$string</em> );
         </code>
     </code_comparison>
     <code_comparison>
-        <code title="Valid: passing default value for a deprecated parameter.">
+        <code title="Valid: Passing default value for a deprecated parameter.">
         <![CDATA[
 // Third parameter deprecated in WP 2.3.0.
 add_option( 'option_name', 123, <em>''</em>, 'yes' );
         ]]>
         </code>
-        <code title="Invalid: not passing the default value for a deprecated parameter.">
+        <code title="Invalid: Not passing the default value for a deprecated parameter.">
         <![CDATA[
 // Third parameter deprecated in WP 2.3.0.
 add_option( 'my_name', 123, <em>'oops'</em>, 'yes' );

--- a/WordPress/Docs/WP/GetMetaSingleStandard.xml
+++ b/WordPress/Docs/WP/GetMetaSingleStandard.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Get Meta Function Single Parameter"
+    >
+    <standard>
+    <![CDATA[
+    When calling the `get_(comment|post|site|term|user)_meta()`, `get_metadata()`,
+    `get_metadata_default()`, and `get_metadata_raw()` functions, if the `$[meta_]key` parameter is
+    passed, the `$single` parameter should be passed as well to make it explicit whether the
+    functions should return a single value (the first value) or an array of values stored for the
+    meta key.
+
+    Note that these functions may still return `false` for an invalid ID. They may also return an
+    empty string if `$single` is `true` or an empty array if `$single` is `false` for a valid but
+    non-existing ID. This can be confusing as these might be valid values for a meta value.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: Get meta functions called either without the `$[meta_]key` parameter; or with both the `$[meta_]key` and the `$single` parameters.">
+        <![CDATA[
+$admin_color = get_user_meta(
+    $user_id,
+    <em>'admin_color'</em>,
+    <em>true</em>
+);
+$post_meta = get_metadata( 'post', $post_id<em></em> );
+        ]]>
+        </code>
+        <code title="Invalid: Get meta function called with the `$[meta_]key` parameter, but without the `$single` parameter.">
+        <![CDATA[
+$admin_color = get_user_meta(
+    $user_id,
+    <em>'admin_color'</em>
+);
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/WordPress/Docs/WP/PostsPerPageStandard.xml
+++ b/WordPress/Docs/WP/PostsPerPageStandard.xml
@@ -5,9 +5,9 @@
     >
     <standard>
     <![CDATA[
-Using "posts_per_page" or "numberposts" with the value set to an high number opens up the potential for making requests slow if the query ends up querying thousands of posts.
+    Using "posts_per_page" or "numberposts" with the value set to an high number opens up the potential for making requests slow if the query ends up querying thousands of posts.
 
-You should always fetch the lowest number possible that still gives you the number of results you find acceptable.
+    You should always fetch the lowest number possible that still gives you the number of results you find acceptable.
     ]]>
     </standard>
     <code_comparison>

--- a/WordPress/Docs/WhiteSpace/CastStructureSpacingStandard.xml
+++ b/WordPress/Docs/WhiteSpace/CastStructureSpacingStandard.xml
@@ -10,7 +10,7 @@
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: space before typecast.">
+        <code title="Valid: Space before typecast.">
         <![CDATA[
 $a =<em> </em>(int) '420';
 
@@ -18,7 +18,7 @@ $a =<em> </em>(int) '420';
 $a = function_call( <em>...(array)</em> $mixed );
         ]]>
         </code>
-        <code title="Invalid: no space before typecast.">
+        <code title="Invalid: No space before typecast.">
         <![CDATA[
 $a <em>=(</em>int) '420';
         ]]>

--- a/WordPress/Docs/WhiteSpace/ObjectOperatorSpacingStandard.xml
+++ b/WordPress/Docs/WhiteSpace/ObjectOperatorSpacingStandard.xml
@@ -1,4 +1,8 @@
-<documentation title="Object Operator Spacing">
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Object Operator Spacing"
+>
     <standard>
     <![CDATA[
     The object operators (->, ?->, ::) should not have any spaces around them, though new lines are allowed except for use with the `::class` constant.

--- a/WordPress/Docs/WhiteSpace/OperatorSpacingStandard.xml
+++ b/WordPress/Docs/WhiteSpace/OperatorSpacingStandard.xml
@@ -10,13 +10,13 @@
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: one space before and after an operator.">
+        <code title="Valid: One space before and after an operator.">
         <![CDATA[
 if ( $a<em> === </em>$b<em> && </em>$b<em> === </em>$c ) {}
 if (<em> ! </em>$var ) {}
         ]]>
         </code>
-        <code title="Invalid: too much/little space.">
+        <code title="Invalid: Too much/little space.">
         <![CDATA[
 // Too much space.
 if ( $a === $b<em>   &&   </em>$b<em> ===      </em>$c ) {}
@@ -29,14 +29,14 @@ if (<em> !</em>$var ) {}
         </code>
     </code_comparison>
     <code_comparison>
-        <code title="Valid: a new line instead of a space is okay too.">
+        <code title="Valid: A new line instead of a space is okay too.">
         <![CDATA[
 if ( $a === $b<em>
     && </em>$b === $c
 ) {}
         ]]>
         </code>
-        <code title="Invalid: too much space after operator on new line.">
+        <code title="Invalid: Too much space after operator on new line.">
         <![CDATA[
 if ( $a === $b<em>
     &&     </em>$b === $c
@@ -45,13 +45,13 @@ if ( $a === $b<em>
         </code>
     </code_comparison>
     <code_comparison>
-        <code title="Valid: one space after assignment operator.">
+        <code title="Valid: One space after assignment operator.">
         <![CDATA[
 $a   <em>= </em>'foo';
 $all <em>= </em>'foobar';
         ]]>
         </code>
-        <code title="Invalid: too much/little space after assignment operator.">
+        <code title="Invalid: Too much/little space after assignment operator.">
         <![CDATA[
 $a   <em>=     </em>'foo';
 $all <em>=</em>'foobar';

--- a/WordPress/Helpers/ConstantsHelper.php
+++ b/WordPress/Helpers/ConstantsHelper.php
@@ -42,7 +42,7 @@ final class ConstantsHelper {
 	 *              - The `$phpcsFile` parameter was added.
 	 *
 	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
-	 * @param int                         $stackPtr  The position of the function call token.
+	 * @param int                         $stackPtr  The position of the T_STRING token.
 	 *
 	 * @return bool
 	 */

--- a/WordPress/Helpers/ConstantsHelper.php
+++ b/WordPress/Helpers/ConstantsHelper.php
@@ -16,7 +16,7 @@ use PHPCSUtils\Utils\Scopes;
 use WordPressCS\WordPress\Helpers\ContextHelper;
 
 /**
- * Helper utilities for checking the context in which a token is used.
+ * Helper utilities for identifying the use of global constants in PHP code.
  *
  * ---------------------------------------------------------------------------------------------
  * This class is only intended for internal use by WordPressCS and is not part of the public API.

--- a/WordPress/Helpers/ContextHelper.php
+++ b/WordPress/Helpers/ContextHelper.php
@@ -31,7 +31,7 @@ use PHPCSUtils\Utils\PassedParameters;
 final class ContextHelper {
 
 	/**
-	 * Tokens which when they preceed code indicate the value is safely casted.
+	 * Tokens which when they precede code indicate the value is safely casted.
 	 *
 	 * @since 1.1.0
 	 * @since 3.0.0 - Moved from the Sniff class to this class.

--- a/WordPress/Helpers/ListHelper.php
+++ b/WordPress/Helpers/ListHelper.php
@@ -15,7 +15,7 @@ use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\Lists;
 
 /**
- * Helper utilities for checking the context in which a token is used.
+ * Helper utilities for working with lists.
  *
  * ---------------------------------------------------------------------------------------------
  * This class is only intended for internal use by WordPressCS and is not part of the public API.

--- a/WordPress/Helpers/MinimumWPVersionTrait.php
+++ b/WordPress/Helpers/MinimumWPVersionTrait.php
@@ -79,7 +79,7 @@ trait MinimumWPVersionTrait {
 	 *
 	 * @var string WordPress version.
 	 */
-	private $default_minimum_wp_version = '6.2';
+	private $default_minimum_wp_version = '6.5';
 
 	/**
 	 * Overrule the minimum supported WordPress version with a command-line/config value.

--- a/WordPress/Helpers/MinimumWPVersionTrait.php
+++ b/WordPress/Helpers/MinimumWPVersionTrait.php
@@ -35,7 +35,7 @@ trait MinimumWPVersionTrait {
 	 * `WordPress.WP.DeprecatedClasses`, `WordPress.WP.DeprecatedFunctions`,
 	 * `WordPress.WP.DeprecatedParameter` and the `WordPress.WP.DeprecatedParameterValues` sniff.
 	 *
-	 * These sniffs will adapt their behaviour based on the minimum supported WP version
+	 * These sniffs will adapt their behavior based on the minimum supported WP version
 	 * indicated.
 	 * By default, it is set to presume that a project will support the current
 	 * WP version and up to three releases before.
@@ -141,7 +141,7 @@ trait MinimumWPVersionTrait {
 	 * Ensures that a version number is comparable via the PHP version_compare() function
 	 * by making sure it complies with the minimum "PHP-standardized" version number requirements.
 	 *
-	 * Presumes the input is a numeric version number string. The behaviour with other input is undefined.
+	 * Presumes the input is a numeric version number string. The behavior with other input is undefined.
 	 *
 	 * @since 3.0.0
 	 *

--- a/WordPress/Helpers/SanitizationHelperTrait.php
+++ b/WordPress/Helpers/SanitizationHelperTrait.php
@@ -126,7 +126,7 @@ trait SanitizationHelperTrait {
 	 *
 	 * This list is complementary to the `$sanitizingFunctions` list.
 	 * Sanitizing functions should be added to this list if they also
-	 * implicitely unslash data and to the `$sanitizingFunctions` list
+	 * implicitly unslash data and to the `$sanitizingFunctions` list
 	 * if they don't.
 	 *
 	 * @since 0.5.0

--- a/WordPress/Helpers/SanitizationHelperTrait.php
+++ b/WordPress/Helpers/SanitizationHelperTrait.php
@@ -137,15 +137,16 @@ trait SanitizationHelperTrait {
 	 * @var array<string, bool>
 	 */
 	private $unslashingSanitizingFunctions = array(
-		'absint'               => true,
-		'boolval'              => true,
-		'count'                => true,
-		'doubleval'            => true,
-		'floatval'             => true,
-		'intval'               => true,
-		'sanitize_key'         => true,
-		'sanitize_locale_name' => true,
-		'sizeof'               => true,
+		'absint'                => true,
+		'boolval'               => true,
+		'count'                 => true,
+		'doubleval'             => true,
+		'floatval'              => true,
+		'intval'                => true,
+		'rest_sanitize_boolean' => true,
+		'sanitize_key'          => true,
+		'sanitize_locale_name'  => true,
+		'sizeof'                => true,
 	);
 
 	/**

--- a/WordPress/Helpers/WPDBTrait.php
+++ b/WordPress/Helpers/WPDBTrait.php
@@ -37,7 +37,7 @@ trait WPDBTrait {
 	 * @since 3.0.0  - Moved from the Sniff class to this dedicated Trait.
 	 *               - The `$phpcsFile` parameter was added.
 	 *
-	 * {@internal This method should be refactored to not exhibit "magic" behaviour
+	 * {@internal This method should be refactored to not exhibit "magic" behavior
 	 *            for properties in the sniff class(es) using it.}}
 	 *
 	 * @param \PHP_CodeSniffer\Files\File $phpcsFile      The file being scanned.

--- a/WordPress/Sniffs/Arrays/ArrayDeclarationSpacingSniff.php
+++ b/WordPress/Sniffs/Arrays/ArrayDeclarationSpacingSniff.php
@@ -34,9 +34,9 @@ use WordPressCS\WordPress\Sniff;
  *               The `WordPress.Arrays.ArrayDeclaration` sniff has now been deprecated.
  * @since 0.13.0 Class name changed: this class is now namespaced.
  * @since 0.14.0 Single item associative arrays are now by default exempt from the
- *               "must be multi-line" rule. This behaviour can be changed using the
+ *               "must be multi-line" rule. This behavior can be changed using the
  *               `allow_single_item_single_line_associative_arrays` property.
- * @since 3.0.0  Removed various whitespace related checks and fixers in favour of the PHPCSExtra
+ * @since 3.0.0  Removed various whitespace related checks and fixers in favor of the PHPCSExtra
  *               `NormalizedArrays.Arrays.ArrayBraceSpacing` sniff.
  */
 final class ArrayDeclarationSpacingSniff extends Sniff {

--- a/WordPress/Sniffs/Arrays/ArrayIndentationSniff.php
+++ b/WordPress/Sniffs/Arrays/ArrayIndentationSniff.php
@@ -243,7 +243,7 @@ final class ArrayIndentationSniff extends Sniff {
 			 * Multi-line array items.
 			 *
 			 * Verify & if needed, correct the indentation of subsequent lines.
-			 * Subsequent lines may be indented more or less than the mimimum expected indent,
+			 * Subsequent lines may be indented more or less than the minimum expected indent,
 			 * but the "first line after" should be indented - at least - as much as the very first line
 			 * of the array item.
 			 * Indentation correction for subsequent lines will be based on that diff.

--- a/WordPress/Sniffs/Arrays/MultipleStatementAlignmentSniff.php
+++ b/WordPress/Sniffs/Arrays/MultipleStatementAlignmentSniff.php
@@ -112,7 +112,7 @@ final class MultipleStatementAlignmentSniff extends Sniff {
 	 *               * Setting this to `=0` is useless as in that case there are
 	 *                 no multi-line items in the array anyway.
 	 *
-	 * This setting will respect the `ignoreNewlines` and `maxColumnn` settings.
+	 * This setting will respect the `ignoreNewlines` and `maxColumn` settings.
 	 *
 	 * @since 0.14.0
 	 *

--- a/WordPress/Sniffs/CodeAnalysis/AssignmentInTernaryConditionSniff.php
+++ b/WordPress/Sniffs/CodeAnalysis/AssignmentInTernaryConditionSniff.php
@@ -23,7 +23,7 @@ use WordPressCS\WordPress\Sniff;
  *
  * @since 0.14.0
  * @since 3.0.0  - The generic "assignment in condition" logic has been removed from the sniff
- *                 in favour of the upstream `Generic.CodeAnalysis.AssignmentInCondition` sniff.
+ *                 in favor of the upstream `Generic.CodeAnalysis.AssignmentInCondition` sniff.
  *               - The sniff has been renamed from `AssignmentInCondition` to `AssignmentInTernaryCondition`.
  *
  * @link https://github.com/squizlabs/PHP_CodeSniffer/pull/1594 Upstream sniff.

--- a/WordPress/Sniffs/DB/PreparedSQLPlaceholdersSniff.php
+++ b/WordPress/Sniffs/DB/PreparedSQLPlaceholdersSniff.php
@@ -232,7 +232,7 @@ final class PreparedSQLPlaceholdersSniff extends Sniff {
 						if ( ! empty( $sprintf_parameters ) ) {
 							/*
 							 * Check for named params. sprintf() does not support this due to its variadic nature,
-							 * and we cannot analyse the code correctly if it is used, so skip the whole sprintf()
+							 * and we cannot analyze the code correctly if it is used, so skip the whole sprintf()
 							 * in that case.
 							 */
 							$valid_sprintf = true;
@@ -347,7 +347,7 @@ final class PreparedSQLPlaceholdersSniff extends Sniff {
 			}
 
 			/*
-			 * Analyse the query for incorrect LIKE queries.
+			 * Analyze the query for incorrect LIKE queries.
 			 *
 			 * - `LIKE %s` is the only correct one.
 			 * - `LIKE '%s'` or `LIKE "%s"` will not be reported here, but in the quote check.
@@ -419,7 +419,7 @@ final class PreparedSQLPlaceholdersSniff extends Sniff {
 			}
 
 			/*
-			 * Analyse the query for unsupported placeholders.
+			 * Analyze the query for unsupported placeholders.
 			 */
 			if ( preg_match_all( self::UNSUPPORTED_PLACEHOLDER_REGEX, $content, $matches ) > 0 ) {
 				if ( ! empty( $matches[0] ) ) {
@@ -463,7 +463,7 @@ final class PreparedSQLPlaceholdersSniff extends Sniff {
 			}
 
 			/*
-			 * Analyse the query for single/double quoted simple value placeholders
+			 * Analyze the query for single/double quoted simple value placeholders
 			 * Identifiers are checked separately.
 			 */
 			$regex = '`(' . $regex_quote . ')%[dfFs]\1`';
@@ -482,7 +482,7 @@ final class PreparedSQLPlaceholdersSniff extends Sniff {
 			}
 
 			/*
-			 * Analyse the query for quoted identifier placeholders.
+			 * Analyze the query for quoted identifier placeholders.
 			 */
 			$regex = '/(' . $regex_quote . '|`)(?<placeholder>' . self::PREPARE_PLACEHOLDER_REGEX . ')\1/x';
 			if ( preg_match_all( $regex, $content, $matches ) > 0 ) {
@@ -502,7 +502,7 @@ final class PreparedSQLPlaceholdersSniff extends Sniff {
 			}
 
 			/*
-			 * Analyse the query for unquoted complex placeholders.
+			 * Analyze the query for unquoted complex placeholders.
 			 */
 			$regex = '`(?<!' . $regex_quote . ')' . self::PREPARE_PLACEHOLDER_REGEX . '(?!' . $regex_quote . ')`x';
 			if ( preg_match_all( $regex, $content, $matches ) > 0 ) {
@@ -650,7 +650,7 @@ final class PreparedSQLPlaceholdersSniff extends Sniff {
 	}
 
 	/**
-	 * Analyse a sprintf() query wrapper to see if it contains a specific code pattern
+	 * Analyze a sprintf() query wrapper to see if it contains a specific code pattern
 	 * to deal correctly with `IN` queries.
 	 *
 	 * The pattern we are searching for is:
@@ -687,7 +687,7 @@ final class PreparedSQLPlaceholdersSniff extends Sniff {
 	}
 
 	/**
-	 * Analyse an implode() function call to see if it contains a specific code pattern
+	 * Analyze an implode() function call to see if it contains a specific code pattern
 	 * to dynamically create placeholders.
 	 *
 	 * The pattern we are searching for is:

--- a/WordPress/Sniffs/Files/FileNameSniff.php
+++ b/WordPress/Sniffs/Files/FileNameSniff.php
@@ -154,7 +154,7 @@ final class FileNameSniff extends Sniff {
 		// Usage of `stripQuotes` is to ensure `stdin_path` passed by IDEs does not include quotes.
 		$file = TextStrings::stripQuotes( $this->phpcsFile->getFileName() );
 		if ( 'STDIN' === $file ) {
-			return;
+			return $this->phpcsFile->numTokens;
 		}
 
 		$class_ptr = $this->phpcsFile->findNext( \T_CLASS, $stackPtr );
@@ -163,7 +163,7 @@ final class FileNameSniff extends Sniff {
 			 * This rule should not be applied to test classes (at all).
 			 * @link https://github.com/WordPress/WordPress-Coding-Standards/issues/1995
 			 */
-			return;
+			return $this->phpcsFile->numTokens;
 		}
 
 		// Respect phpcs:disable comments as long as they are not accompanied by an enable.
@@ -184,7 +184,7 @@ final class FileNameSniff extends Sniff {
 
 				if ( false === $i ) {
 					// The entire (rest of the) file is disabled.
-					return;
+					return $this->phpcsFile->numTokens;
 				}
 			}
 		}
@@ -204,7 +204,7 @@ final class FileNameSniff extends Sniff {
 		}
 
 		// Only run this sniff once per file, no need to run it again.
-		return ( $this->phpcsFile->numTokens + 1 );
+		return $this->phpcsFile->numTokens;
 	}
 
 	/**

--- a/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
+++ b/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
@@ -861,7 +861,7 @@ final class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 	protected function process_variable_assignment( $stackPtr, $in_list = false ) {
 		/*
 		 * We're only concerned with variables which are being defined.
-		 * `is_assigment()` will not recognize property assignments, which is good in this case.
+		 * `is_assignment()` will not recognize property assignments, which is good in this case.
 		 * However it will also not recognize $b in `foreach( $a as $b )` as an assignment, so
 		 * we need a separate check for that.
 		 */
@@ -1138,7 +1138,7 @@ final class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 	 *
 	 * @since 0.12.0
 	 * @since 0.14.0 Allows for other non-word characters as well as underscores to better support hook names.
-	 * @since 1.0.0  Does not require a word seperator anymore after a prefix.
+	 * @since 1.0.0  Does not require a word separator anymore after a prefix.
 	 *               This allows for improved code style independent checking,
 	 *               i.e. allows for camelCase naming and the likes.
 	 * @since 1.0.1  - Added $stackPtr parameter.

--- a/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
+++ b/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
@@ -59,12 +59,14 @@ final class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 	 * Minimal number of characters the prefix needs in order to be valid.
 	 *
 	 * @since 2.2.0
+	 * @since 3.2.0 The minimum number of characters was raised from 3 to 4.
 	 *
 	 * @link https://github.com/WordPress/WordPress-Coding-Standards/issues/1733 Issue 1733.
+	 * @link https://github.com/WordPress/WordPress-Coding-Standards/issues/2467 Issue 2467.
 	 *
 	 * @var int
 	 */
-	const MIN_PREFIX_LENGTH = 3;
+	const MIN_PREFIX_LENGTH = 4;
 
 	/**
 	 * Target prefixes.

--- a/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
+++ b/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
@@ -1289,7 +1289,7 @@ final class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 	 */
 	private function record_potential_prefix_metric( $stackPtr, $construct_name ) {
 		if ( preg_match( '`^([A-Z]*[a-z0-9]*+)`', ltrim( $construct_name, '\$_' ), $matches ) > 0
-			&& isset( $matches[1] ) && '' !== $matches[1]
+			&& '' !== $matches[1]
 		) {
 			$this->phpcsFile->recordMetric( $stackPtr, 'Prefix all globals: potential prefixes - start of non-prefixed construct', strtolower( $matches[1] ) );
 		}

--- a/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
+++ b/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
@@ -617,7 +617,7 @@ final class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 					if ( DeprecationHelper::is_function_deprecated( $this->phpcsFile, $stackPtr ) === true ) {
 						/*
 						 * Deprecated functions don't have to comply with the naming conventions,
-						 * otherwise functions deprecated in favour of a function with a compliant
+						 * otherwise functions deprecated in favor of a function with a compliant
 						 * name would still trigger an error.
 						 */
 						return;

--- a/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
+++ b/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
@@ -147,7 +147,7 @@ final class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 	 * Only overrulable constants are listed, i.e. those defined within core within
 	 * a `if ( ! defined() ) {}` wrapper.
 	 *
-	 * {@internal To be updated after every major release. Last updated for WordPress 6.5-RC3.}
+	 * {@internal To be updated after every major release. Last updated for WordPress 6.8.1.}
 	 *
 	 * @since 1.0.0
 	 * @since 3.0.0 Renamed from `$whitelisted_core_constants` to `$allowed_core_constants`.
@@ -201,7 +201,7 @@ final class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 	 *
 	 * Note: deprecated functions should still be included in this list as plugins may support older WP versions.
 	 *
-	 * {@internal To be updated after every major release. Last updated for WordPress 6.5-RC3.}
+	 * {@internal To be updated after every major release. Last updated for WordPress 6.8.1.}
 	 *
 	 * @since 3.0.0.
 	 *
@@ -322,6 +322,13 @@ final class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 		'twentytwenty_get_customizer_css'                => true,
 		'twentytwenty_get_theme_svg'                     => true,
 		'twentytwenty_the_theme_svg'                     => true,
+		'twentytwentyfive_block_styles'                  => true,
+		'twentytwentyfive_editor_style'                  => true,
+		'twentytwentyfive_enqueue_styles'                => true,
+		'twentytwentyfive_format_binding'                => true,
+		'twentytwentyfive_pattern_categories'            => true,
+		'twentytwentyfive_post_format_setup'             => true,
+		'twentytwentyfive_register_block_bindings'       => true,
 		'twentytwentyfour_block_styles'                  => true,
 		'twentytwentyfour_block_stylesheets'             => true,
 		'twentytwentyfour_pattern_categories'            => true,
@@ -358,6 +365,7 @@ final class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 		'wp_notify_postauthor'                           => true,
 		'wp_parse_auth_cookie'                           => true,
 		'wp_password_change_notification'                => true,
+		'wp_password_needs_rehash'                       => true,
 		'wp_rand'                                        => true,
 		'wp_redirect'                                    => true,
 		'wp_safe_redirect'                               => true,
@@ -382,7 +390,7 @@ final class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
 	 *
 	 * Note: deprecated classes should still be included in this list as plugins may support older WP versions.
 	 *
-	 * {@internal To be updated after every major release. Last updated for WordPress 6.5-RC3.}
+	 * {@internal To be updated after every major release. Last updated for WordPress 6.8.1.}
 	 *
 	 * @since 3.0.0.
 	 *

--- a/WordPress/Sniffs/NamingConventions/ValidFunctionNameSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidFunctionNameSniff.php
@@ -59,7 +59,7 @@ final class ValidFunctionNameSniff extends Sniff {
 		if ( DeprecationHelper::is_function_deprecated( $this->phpcsFile, $stackPtr ) === true ) {
 			/*
 			 * Deprecated functions don't have to comply with the naming conventions,
-			 * otherwise functions deprecated in favour of a function with a compliant
+			 * otherwise functions deprecated in favor of a function with a compliant
 			 * name would still trigger an error.
 			 */
 			return;

--- a/WordPress/Sniffs/NamingConventions/ValidHookNameSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidHookNameSniff.php
@@ -69,7 +69,7 @@ class ValidHookNameSniff extends AbstractFunctionParameterSniff {
 	 *
 	 * @since 0.11.0
 	 *
-	 * @return array
+	 * @return array<string, array<string, array<string>>>
 	 */
 	public function getGroups() {
 		// Only retrieve functions which are not used for deprecated hooks.

--- a/WordPress/Sniffs/NamingConventions/ValidPostTypeSlugSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidPostTypeSlugSniff.php
@@ -63,7 +63,7 @@ final class ValidPostTypeSlugSniff extends AbstractFunctionParameterSniff {
 	 *
 	 * Source: {@link https://developer.wordpress.org/reference/functions/register_post_type/#reserved-post-types}
 	 *
-	 * {@internal To be updated after every major release. Last updated for WordPress 6.5-RC3.}
+	 * {@internal To be updated after every major release. Last updated for WordPress 6.8.1.}
 	 *
 	 * @since 2.2.0
 	 *

--- a/WordPress/Sniffs/PHP/IniSetSniff.php
+++ b/WordPress/Sniffs/PHP/IniSetSniff.php
@@ -30,10 +30,7 @@ final class IniSetSniff extends AbstractFunctionParameterSniff {
 	 *
 	 * @since 2.1.0
 	 *
-	 * @var array Multidimensional array with parameter details.
-	 *     $target_functions = array(
-	 *         (string) Function name.
-	 *     );
+	 * @var array<string, true> Key is function name, value irrelevant.
 	 */
 	protected $target_functions = array(
 		'ini_set'   => true,
@@ -47,7 +44,7 @@ final class IniSetSniff extends AbstractFunctionParameterSniff {
 	 * @since 2.1.0
 	 * @since 3.0.0 Renamed from `$whitelisted_options` to `$safe_options`.
 	 *
-	 * @var array Multidimensional array with parameter details.
+	 * @var array<string, array<string, array<string>>> Multidimensional array with parameter details.
 	 *     $safe_options = array(
 	 *         (string) option name. = array(
 	 *             (string[]) 'valid_values' = array()
@@ -74,7 +71,7 @@ final class IniSetSniff extends AbstractFunctionParameterSniff {
 	 * @since 2.1.0
 	 * @since 3.0.0 Renamed from `$blacklisted_options` to `$disallowed_options`.
 	 *
-	 * @var array Multidimensional array with parameter details.
+	 * @var array<string, array<string, string|array<string>>> Multidimensional array with parameter details.
 	 *     $disallowed_options = array(
 	 *         (string) option name. = array(
 	 *             (string[]) 'invalid_values' = array()

--- a/WordPress/Sniffs/PHP/NoSilencedErrorsSniff.php
+++ b/WordPress/Sniffs/PHP/NoSilencedErrorsSniff.php
@@ -69,7 +69,7 @@ final class NoSilencedErrorsSniff extends Sniff {
 	 *
 	 * Errors caused by calls to any of these native PHP functions
 	 * are allowed to be silenced as file system permissions and such
-	 * can cause E_WARNINGs to be thrown which cannot be prevented via
+	 * can cause `E_WARNING`s to be thrown which cannot be prevented via
 	 * error checking.
 	 *
 	 * Note: only calls to global functions - in contrast to class methods -

--- a/WordPress/Sniffs/Security/EscapeOutputSniff.php
+++ b/WordPress/Sniffs/Security/EscapeOutputSniff.php
@@ -185,7 +185,6 @@ class EscapeOutputSniff extends AbstractFunctionRestrictionsSniff {
 	 */
 	public function process_token( $stackPtr ) {
 		$start = ( $stackPtr + 1 );
-		$end   = $start;
 
 		switch ( $this->tokens[ $stackPtr ]['code'] ) {
 			case \T_STRING:

--- a/WordPress/Sniffs/Security/PluginMenuSlugSniff.php
+++ b/WordPress/Sniffs/Security/PluginMenuSlugSniff.php
@@ -44,7 +44,7 @@ final class PluginMenuSlugSniff extends AbstractFunctionParameterSniff {
 	 *               array containing parameter positions to an array with the parameter
 	 *               position as the index and the parameter name as value.
 	 *
-	 * @var array<string, array<int, string|array>> Key is the name of the functions being targetted.
+	 * @var array<string, array<int, string|array>> Key is the name of the functions being targeted.
 	 *                                              Value is an array with parameter positions as the
 	 *                                              keys and parameter names as the values
 	 */

--- a/WordPress/Sniffs/Utils/I18nTextDomainFixerSniff.php
+++ b/WordPress/Sniffs/Utils/I18nTextDomainFixerSniff.php
@@ -536,7 +536,7 @@ final class I18nTextDomainFixerSniff extends AbstractFunctionParameterSniff {
 				$error_msg .= ' and preceding argument(s)';
 				$error_code = 'MissingArgs';
 
-				// Expected preceeding param also missing, just throw the warning.
+				// Expected preceding param also missing, just throw the warning.
 				$this->phpcsFile->addWarning( $error_msg, $stackPtr, $error_code );
 			}
 
@@ -570,7 +570,7 @@ final class I18nTextDomainFixerSniff extends AbstractFunctionParameterSniff {
 		$old_domain = TextStrings::stripQuotes( $this->tokens[ $domain_token ]['content'] );
 
 		if ( ! \in_array( $old_domain, $this->old_text_domain, true ) ) {
-			// Not a text domain targetted for replacement, ignore.
+			// Not a text domain targeted for replacement, ignore.
 			return;
 		}
 

--- a/WordPress/Sniffs/Utils/I18nTextDomainFixerSniff.php
+++ b/WordPress/Sniffs/Utils/I18nTextDomainFixerSniff.php
@@ -674,7 +674,6 @@ final class I18nTextDomainFixerSniff extends AbstractFunctionParameterSniff {
 		$regex   = $this->plugin_header_regex;
 		$headers = $this->plugin_headers;
 		$type    = 'plugin';
-		$skip_to = $stackPtr;
 
 		$file = TextStrings::stripQuotes( $this->phpcsFile->getFileName() );
 		if ( 'STDIN' === $file ) {

--- a/WordPress/Sniffs/Utils/I18nTextDomainFixerSniff.php
+++ b/WordPress/Sniffs/Utils/I18nTextDomainFixerSniff.php
@@ -394,7 +394,7 @@ final class I18nTextDomainFixerSniff extends AbstractFunctionParameterSniff {
 		if ( ! is_string( $this->new_text_domain )
 			|| '' === $this->new_text_domain
 		) {
-			return ( $this->phpcsFile->numTokens + 1 );
+			return $this->phpcsFile->numTokens;
 		}
 
 		if ( isset( $this->old_text_domain ) ) {
@@ -403,7 +403,7 @@ final class I18nTextDomainFixerSniff extends AbstractFunctionParameterSniff {
 			if ( ! is_array( $this->old_text_domain )
 				|| array() === $this->old_text_domain
 			) {
-				return ( $this->phpcsFile->numTokens + 1 );
+				return $this->phpcsFile->numTokens;
 			}
 		}
 
@@ -421,7 +421,7 @@ final class I18nTextDomainFixerSniff extends AbstractFunctionParameterSniff {
 					array( $this->new_text_domain )
 				);
 
-				return ( $this->phpcsFile->numTokens + 1 );
+				return $this->phpcsFile->numTokens;
 			}
 
 			if ( preg_match( '`^[a-z0-9-]+$`', $this->new_text_domain ) !== 1 ) {
@@ -432,14 +432,14 @@ final class I18nTextDomainFixerSniff extends AbstractFunctionParameterSniff {
 					array( $this->new_text_domain )
 				);
 
-				return ( $this->phpcsFile->numTokens + 1 );
+				return $this->phpcsFile->numTokens;
 			}
 
 			// If the text domain passed both validations, it should be considered valid.
 			$this->is_valid = true;
 
 		} elseif ( false === $this->is_valid ) {
-			return ( $this->phpcsFile->numTokens + 1 );
+			return $this->phpcsFile->numTokens;
 		}
 
 		if ( isset( $this->tab_width ) === false ) {
@@ -685,7 +685,7 @@ final class I18nTextDomainFixerSniff extends AbstractFunctionParameterSniff {
 		if ( isset( $this->phpcsFile->tokenizerType ) && 'CSS' === $this->phpcsFile->tokenizerType ) {
 			if ( 'style.css' !== $file_name && ! defined( 'PHP_CODESNIFFER_IN_TESTS' ) ) {
 				// CSS files only need to be examined for the file header.
-				return ( $this->phpcsFile->numTokens + 1 );
+				return $this->phpcsFile->numTokens;
 			}
 
 			$regex   = $this->theme_header_regex;

--- a/WordPress/Sniffs/WP/CapabilitiesSniff.php
+++ b/WordPress/Sniffs/WP/CapabilitiesSniff.php
@@ -57,7 +57,7 @@ final class CapabilitiesSniff extends AbstractFunctionParameterSniff {
 	 *
 	 * @since 3.0.0
 	 *
-	 * @var array<string, array> The key is the name of a function we're targetting,
+	 * @var array<string, array> The key is the name of a function we're targeting,
 	 *                           the value is an array containing the 1-based parameter position
 	 *                           of the "capability" parameter within the function, as well as
 	 *                           the name of the parameter as declared in the function.

--- a/WordPress/Sniffs/WP/CapabilitiesSniff.php
+++ b/WordPress/Sniffs/WP/CapabilitiesSniff.php
@@ -173,7 +173,7 @@ final class CapabilitiesSniff extends AbstractFunctionParameterSniff {
 	 *
 	 * List is sorted alphabetically.
 	 *
-	 * {@internal To be updated after every major release. Last updated for WordPress 6.1.0.}
+	 * {@internal To be updated after every major release. Last updated for WordPress 6.8.1.}
 	 *
 	 * @since 3.0.0
 	 *
@@ -229,6 +229,7 @@ final class CapabilitiesSniff extends AbstractFunctionParameterSniff {
 		'edit_app_password'           => true,
 		'edit_categories'             => true,
 		'edit_block'                  => true, // Only seen in tests.
+		'edit_block_binding'          => true,
 		'edit_blocks'                 => true, // Alias for 'edit_posts', but supported.
 		'edit_comment'                => true, // Alias, but supported.
 		'edit_comment_meta'           => true,

--- a/WordPress/Sniffs/WP/ClassNameCaseSniff.php
+++ b/WordPress/Sniffs/WP/ClassNameCaseSniff.php
@@ -25,7 +25,7 @@ final class ClassNameCaseSniff extends AbstractClassRestrictionsSniff {
 	 *
 	 * Note: this list will be enhanced in the class constructor.
 	 *
-	 * {@internal To be updated after every major release. Last updated for WordPress 6.5-RC3.}
+	 * {@internal To be updated after every major release. Last updated for WordPress 6.8.1.}
 	 *
 	 * @since 3.0.0
 	 *
@@ -97,6 +97,7 @@ final class ClassNameCaseSniff extends AbstractClassRestrictionsSniff {
 		'Text_Diff_Op_delete',
 		'Text_Diff_Renderer',
 		'Text_Diff_Renderer_inline',
+		'Text_Exception',
 		'Text_MappedDiff',
 		'Theme_Installer_Skin',
 		'Theme_Upgrader',
@@ -125,6 +126,7 @@ final class ClassNameCaseSniff extends AbstractClassRestrictionsSniff {
 		'WP_Block_Bindings_Source',
 		'WP_Block_Editor_Context',
 		'WP_Block_List',
+		'WP_Block_Metadata_Registry',
 		'WP_Block_Parser',
 		'WP_Block_Parser_Block',
 		'WP_Block_Parser_Frame',
@@ -133,6 +135,7 @@ final class ClassNameCaseSniff extends AbstractClassRestrictionsSniff {
 		'WP_Block_Styles_Registry',
 		'WP_Block_Supports',
 		'WP_Block_Template',
+		'WP_Block_Templates_Registry',
 		'WP_Block_Type',
 		'WP_Block_Type_Registry',
 		'WP_Classic_To_Block_Menu_Converter',
@@ -186,6 +189,7 @@ final class ClassNameCaseSniff extends AbstractClassRestrictionsSniff {
 		'WP_Duotone',
 		'WP_Embed',
 		'WP_Error',
+		'WP_Exception',
 		'WP_Fatal_Error_Handler',
 		'WP_Feed_Cache',
 		'WP_Feed_Cache_Transient',
@@ -201,10 +205,13 @@ final class ClassNameCaseSniff extends AbstractClassRestrictionsSniff {
 		'WP_Font_Utils',
 		'WP_HTML_Active_Formatting_Elements',
 		'WP_HTML_Attribute_Token',
+		'WP_HTML_Decoder',
+		'WP_HTML_Doctype_Info',
 		'WP_HTML_Open_Elements',
 		'WP_HTML_Processor',
 		'WP_HTML_Processor_State',
 		'WP_HTML_Span',
+		'WP_HTML_Stack_Event',
 		'WP_HTML_Tag_Processor',
 		'WP_HTML_Text_Replacement',
 		'WP_HTML_Token',
@@ -246,6 +253,7 @@ final class ClassNameCaseSniff extends AbstractClassRestrictionsSniff {
 		'WP_Network',
 		'WP_Network_Query',
 		'WP_Object_Cache',
+		'WP_PHPMailer',
 		'WP_Paused_Extensions_Storage',
 		'WP_Plugin_Dependencies',
 		'WP_Plugin_Install_List_Table',
@@ -343,6 +351,7 @@ final class ClassNameCaseSniff extends AbstractClassRestrictionsSniff {
 		'WP_Sitemaps_Stylesheet',
 		'WP_Sitemaps_Taxonomies',
 		'WP_Sitemaps_Users',
+		'WP_Speculation_Rules',
 		'WP_Style_Engine',
 		'WP_Style_Engine_CSS_Declarations',
 		'WP_Style_Engine_CSS_Rule',
@@ -364,11 +373,13 @@ final class ClassNameCaseSniff extends AbstractClassRestrictionsSniff {
 		'WP_Theme_JSON_Resolver',
 		'WP_Theme_JSON_Schema',
 		'WP_Themes_List_Table',
+		'WP_Token_Map',
 		'WP_Translation_Controller',
 		'WP_Translation_File',
 		'WP_Translation_File_MO',
 		'WP_Translation_File_PHP',
 		'WP_Translations',
+		'WP_URL_Pattern_Prefixer',
 		'WP_Upgrader',
 		'WP_Upgrader_Skin',
 		'WP_User',
@@ -412,7 +423,7 @@ final class ClassNameCaseSniff extends AbstractClassRestrictionsSniff {
 	 *
 	 * Note: this list will be enhanced in the class constructor.
 	 *
-	 * {@internal To be updated after every major release. Last updated for WordPress 6.5-RC3.}
+	 * {@internal To be updated after every major release. Last updated for WordPress 6.8.1.}
 	 *
 	 * @since 3.0.0
 	 *
@@ -444,7 +455,7 @@ final class ClassNameCaseSniff extends AbstractClassRestrictionsSniff {
 	 *
 	 * Note: this list will be enhanced in the class constructor.
 	 *
-	 * {@internal To be updated after every major release. Last updated for WordPress 6.5-RC3.}
+	 * {@internal To be updated after every major release. Last updated for WordPress 6.8.1.}
 	 *
 	 * @since 3.1.0
 	 *
@@ -466,7 +477,7 @@ final class ClassNameCaseSniff extends AbstractClassRestrictionsSniff {
 	 *
 	 * Note: this list will be enhanced in the class constructor.
 	 *
-	 * {@internal To be updated after every major release. Last updated for WordPress 6.5-RC3.}
+	 * {@internal To be updated after every major release. Last updated for WordPress 6.8.1.}
 	 *
 	 * @since 3.0.0
 	 *
@@ -502,7 +513,7 @@ final class ClassNameCaseSniff extends AbstractClassRestrictionsSniff {
 	 *
 	 * Note: this list will be enhanced in the class constructor.
 	 *
-	 * {@internal To be updated after every major release. Last updated for WordPress 6.5-RC3.}
+	 * {@internal To be updated after every major release. Last updated for WordPress 6.8.1.}
 	 *
 	 * @since 3.0.0
 	 *
@@ -520,7 +531,7 @@ final class ClassNameCaseSniff extends AbstractClassRestrictionsSniff {
 	 *
 	 * Note: this list will be enhanced in the class constructor.
 	 *
-	 * {@internal To be updated after every major release. Last updated for WordPress 6.5-RC3.}
+	 * {@internal To be updated after every major release. Last updated for WordPress 6.8.1.}
 	 *
 	 * @since 3.0.0
 	 *
@@ -664,7 +675,7 @@ final class ClassNameCaseSniff extends AbstractClassRestrictionsSniff {
 	 *
 	 * Note: this list will be enhanced in the class constructor.
 	 *
-	 * {@internal To be updated after every major release. Last updated for WordPress 6.5-RC3.}
+	 * {@internal To be updated after every major release. Last updated for WordPress 6.8.1.}
 	 *
 	 * @since 3.0.0
 	 *
@@ -672,11 +683,18 @@ final class ClassNameCaseSniff extends AbstractClassRestrictionsSniff {
 	 *               The constructor will add the lowercased class name as a key to each entry.
 	 */
 	private $simplepie_classes = array(
-		// Interfaces.
+		// Interfaces, SimplePie v1.
 		'SimplePie_Cache_Base',
 
-		// Classes.
+		// Interfaces, SimplePie v2 (with BC layer in v1).
+		'SimplePie\Cache\Base',
+		'SimplePie\Cache\DataCache',
+		'SimplePie\Cache\NameFilter',
+		'SimplePie\RegistryAware',
+
+		// Classes, SimplePie v1.
 		'SimplePie',
+		'SimplePie_Autoloader',
 		'SimplePie_Author',
 		'SimplePie_Cache',
 		'SimplePie_Cache_DB',
@@ -710,6 +728,43 @@ final class ClassNameCaseSniff extends AbstractClassRestrictionsSniff {
 		'SimplePie_Source',
 		'SimplePie_XML_Declaration_Parser',
 		'SimplePie_gzdecode',
+
+		// Classes, SimplePie v2 (with BC layer in v1).
+		'SimplePie\Author',
+		'SimplePie\Cache',
+		'SimplePie\Cache\BaseDataCache',
+		'SimplePie\Cache\CallableNameFilter',
+		'SimplePie\Cache\DB',
+		'SimplePie\Cache\File',
+		'SimplePie\Cache\Memcache',
+		'SimplePie\Cache\Memcached',
+		'SimplePie\Cache\MySQL',
+		'SimplePie\Cache\Psr16',
+		'SimplePie\Cache\Redis',
+		'SimplePie\Caption',
+		'SimplePie\Category',
+		'SimplePie\Content\Type\Sniffer',
+		'SimplePie\Copyright',
+		'SimplePie\Credit',
+		'SimplePie\Enclosure',
+		'SimplePie\Exception',
+		'SimplePie\File',
+		'SimplePie\Gzdecode',
+		'SimplePie\HTTP\Parser',
+		'SimplePie\IRI',
+		'SimplePie\Item',
+		'SimplePie\Locator',
+		'SimplePie\Misc',
+		'SimplePie\Net\IPv6',
+		'SimplePie\Parse\Date',
+		'SimplePie\Parser',
+		'SimplePie\Rating',
+		'SimplePie\Registry',
+		'SimplePie\Restriction',
+		'SimplePie\Sanitize',
+		'SimplePie\SimplePie',
+		'SimplePie\Source',
+		'SimplePie\XML\Declaration\Parser',
 	);
 
 	/**

--- a/WordPress/Sniffs/WP/DeprecatedClassesSniff.php
+++ b/WordPress/Sniffs/WP/DeprecatedClassesSniff.php
@@ -41,7 +41,7 @@ final class DeprecatedClassesSniff extends AbstractClassRestrictionsSniff {
 	 *
 	 * Version numbers should be fully qualified.
 	 *
-	 * {@internal To be updated after every major release. Last updated for WordPress 6.5-RC3.}
+	 * {@internal To be updated after every major release. Last updated for WordPress 6.8.1.}
 	 *
 	 * @var array
 	 */

--- a/WordPress/Sniffs/WP/DeprecatedFunctionsSniff.php
+++ b/WordPress/Sniffs/WP/DeprecatedFunctionsSniff.php
@@ -43,7 +43,7 @@ final class DeprecatedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 	 * To retrieve a function list for comparison, the following tool is available:
 	 * https://github.com/JDGrimes/wp-deprecated-code-scanner
 	 *
-	 * {@internal To be updated after every major release. Last updated for WordPress 6.5-RC3.}
+	 * {@internal To be updated after every major release. Last updated for WordPress 6.8.1.}
 	 *
 	 * @var array
 	 */
@@ -1529,6 +1529,7 @@ final class DeprecatedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 			'version' => '6.3.0',
 		),
 		'block_core_navigation_submenu_build_css_colors' => array(
+			// Verified correct alternative.
 			'alt'     => 'wp_apply_colors_support()',
 			'version' => '6.3.0',
 		),
@@ -1545,7 +1546,7 @@ final class DeprecatedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 			'version' => '6.3.0',
 		),
 		'wp_get_duotone_filter_svg' => array(
-			'alt'     => '',
+			'alt'     => 'WP_Duotone::get_filter_svg_from_preset()',
 			'version' => '6.3.0',
 		),
 		'wp_get_global_styles_svg_filters' => array(
@@ -1603,11 +1604,11 @@ final class DeprecatedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 			'version' => '6.4.0',
 		),
 		'_inject_theme_attribute_in_block_template_content' => array(
-			'alt'     => 'traverse_and_serialize_blocks( parse_blocks( $template_content ), \'_inject_theme_attribute_in_template_part_block\' )',
+			'alt'     => 'traverse_and_serialize_blocks( parse_blocks( $template_content ), "_inject_theme_attribute_in_template_part_block" )',
 			'version' => '6.4.0',
 		),
 		'_remove_theme_attribute_in_block_template_content' => array(
-			'alt'     => 'traverse_and_serialize_blocks( parse_blocks( $template_content ), \'_remove_theme_attribute_from_template_part_block\' )',
+			'alt'     => 'traverse_and_serialize_blocks( parse_blocks( $template_content ), "_remove_theme_attribute_from_template_part_block" )',
 			'version' => '6.4.0',
 		),
 		'_wp_theme_json_webfonts_handler' => array(
@@ -1635,6 +1636,7 @@ final class DeprecatedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 			'version' => '6.4.0',
 		),
 		'wp_update_https_detection_errors' => array(
+			// Verified correct alternative.
 			'alt'     => 'wp_get_https_detection_errors()',
 			'version' => '6.4.0',
 		),
@@ -1651,6 +1653,60 @@ final class DeprecatedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
 		'block_core_query_ensure_interactivity_dependency' => array(
 			'alt'     => 'wp_register_script_module()',
 			'version' => '6.5.0',
+		),
+
+		// WP 6.6.0.
+		'wp_interactivity_process_directives_of_interactive_blocks' => array(
+			'alt'     => '',
+			'version' => '6.6.0',
+		),
+		'wp_render_elements_support' => array(
+			'alt'     => 'wp_render_elements_class_name()',
+			'version' => '6.6.0',
+		),
+
+		// WP 6.7.0.
+		'current_user_can_for_blog' => array(
+			'alt'     => 'current_user_can_for_site()',
+			'version' => '6.7.0',
+		),
+		'wp_create_block_style_variation_instance_name' => array(
+			'alt'     => 'wp_unique_id( $variation . \'--\' )',
+			'version' => '6.7.0',
+		),
+		'wp_enqueue_global_styles_custom_css' => array(
+			'alt'     => 'wp_enqueue_global_styles()',
+			'version' => '6.7.0',
+		),
+		'wp_get_global_styles_custom_css' => array(
+			'alt'     => 'wp_get_global_stylesheet() or WP_Theme_JSON::get_styles_for_block()',
+			'version' => '6.7.0',
+		),
+		'wp_init_targeted_link_rel_filters' => array(
+			'alt'     => '',
+			'version' => '6.7.0',
+		),
+		'wp_remove_targeted_link_rel_filters' => array(
+			'alt'     => '',
+			'version' => '6.7.0',
+		),
+		'wp_simplepie_autoload' => array(
+			'alt'     => 'SimplePie_Autoloader',
+			'version' => '6.7.0',
+		),
+		'wp_targeted_link_rel' => array(
+			'alt'     => '',
+			'version' => '6.7.0',
+		),
+		'wp_targeted_link_rel_callback' => array(
+			'alt'     => '',
+			'version' => '6.7.0',
+		),
+
+		// WP 6.8.0.
+		'wp_add_editor_classic_theme_styles' => array(
+			'alt'     => 'wp_enqueue_classic_theme_styles()',
+			'version' => '6.8.0',
 		),
 	);
 

--- a/WordPress/Sniffs/WP/DeprecatedParameterValuesSniff.php
+++ b/WordPress/Sniffs/WP/DeprecatedParameterValuesSniff.php
@@ -244,7 +244,7 @@ final class DeprecatedParameterValuesSniff extends AbstractFunctionParameterSnif
 	 *
 	 * @param string $matched_content The token content (function name) which was matched
 	 *                                in lowercase.
-	 * @param array  $parameter       Array with start and end token positon of the parameter.
+	 * @param array  $parameter       Array with start and end token position of the parameter.
 	 * @param array  $parameter_args  Array with alternative and WordPress deprecation version of the parameter.
 	 *
 	 * @return void

--- a/WordPress/Sniffs/WP/DeprecatedParameterValuesSniff.php
+++ b/WordPress/Sniffs/WP/DeprecatedParameterValuesSniff.php
@@ -48,7 +48,7 @@ final class DeprecatedParameterValuesSniff extends AbstractFunctionParameterSnif
 	 * @since 3.0.0 The format of the value has changed to support function calls
 	 *              using named parameters.
 	 *
-	 * @var array Multidimensional array with parameter details.
+	 * @var array<string, array<int, array<string, mixed>>> Multidimensional array with parameter details.
 	 *     $target_functions = array(
 	 *         (string) Function name. => array(
 	 *             (int) Target parameter position, 1-based. => array(

--- a/WordPress/Sniffs/WP/DeprecatedParameterValuesSniff.php
+++ b/WordPress/Sniffs/WP/DeprecatedParameterValuesSniff.php
@@ -42,7 +42,8 @@ final class DeprecatedParameterValuesSniff extends AbstractFunctionParameterSnif
 	 * The list of deprecated parameter values can be found by
 	 * looking for `_deprecated_argument()`.
 	 * The list is sorted alphabetically by function name.
-	 * Last updated for WordPress 4.9.6.
+	 *
+	 * {@internal To be updated after every major release. Last updated for WordPress 6.8.1.}
 	 *
 	 * @since 1.0.0
 	 * @since 3.0.0 The format of the value has changed to support function calls
@@ -203,6 +204,21 @@ final class DeprecatedParameterValuesSniff extends AbstractFunctionParameterSnif
 					'comment_whitelist' => array(
 						'alt'     => 'comment_previously_approved',
 						'version' => '5.5.0',
+					),
+				),
+			),
+		),
+		'wp_get_typography_font_size_value' => array(
+			2 => array(
+				'name'   => 'settings',
+				'values' => array(
+					'true' => array(
+						'alt'     => 'an array',
+						'version' => '6.6.0',
+					),
+					'false' => array(
+						'alt'     => 'an array',
+						'version' => '6.6.0',
 					),
 				),
 			),

--- a/WordPress/Sniffs/WP/DeprecatedParametersSniff.php
+++ b/WordPress/Sniffs/WP/DeprecatedParametersSniff.php
@@ -53,7 +53,7 @@ final class DeprecatedParametersSniff extends AbstractFunctionParameterSniff {
 	 *
 	 * @since 0.12.0
 	 *
-	 * @var array Multidimensional array with parameter details.
+	 * @var array<string, array<int, array<string, mixed>>> Multidimensional array with parameter details.
 	 *    $target_functions = array(
 	 *        (string) Function name. => array(
 	 *            (int) Target parameter position, 1-based. => array(

--- a/WordPress/Sniffs/WP/DeprecatedParametersSniff.php
+++ b/WordPress/Sniffs/WP/DeprecatedParametersSniff.php
@@ -49,7 +49,8 @@ final class DeprecatedParametersSniff extends AbstractFunctionParameterSniff {
 	 * Array of function, argument, and default value for deprecated argument.
 	 *
 	 * The functions are ordered alphabetically.
-	 * Last updated for WordPress 6.3.
+	 *
+	 * {@internal To be updated after every major release. Last updated for WordPress 6.8.1.}
 	 *
 	 * @since 0.12.0
 	 *
@@ -207,6 +208,13 @@ final class DeprecatedParametersSniff extends AbstractFunctionParameterSniff {
 				'name'    => 'deprecated',
 				'value'   => false,
 				'version' => '4.2.0',
+			),
+		),
+		'inject_ignored_hooked_blocks_metadata_attributes' => array(
+			2 => array(
+				'name'    => 'deprecated',
+				'value'   => null,
+				'version' => '6.5.3',
 			),
 		),
 		'install_search_form' => array(
@@ -408,6 +416,13 @@ final class DeprecatedParametersSniff extends AbstractFunctionParameterSniff {
 				'name'    => 'deprecated',
 				'value'   => null,
 				'version' => '3.8.0',
+			),
+		),
+		'wp_render_elements_support_styles' => array(
+			1 => array(
+				'name'    => 'parsed_block',
+				'value'   => null,
+				'version' => '6.6.0',
 			),
 		),
 		'wp_title_rss' => array(

--- a/WordPress/Sniffs/WP/GetMetaSingleSniff.php
+++ b/WordPress/Sniffs/WP/GetMetaSingleSniff.php
@@ -1,0 +1,195 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPressCS\WordPress\Sniffs\WP;
+
+use PHPCSUtils\Utils\PassedParameters;
+use WordPressCS\WordPress\AbstractFunctionParameterSniff;
+
+/**
+ * Warns when calls to get meta functions use the $[meta_]key param without the $single param.
+ *
+ * Flags calls to get_(comment|post|site|term|user)_meta(), get_metadata(), get_metadata_default()
+ * and get_metadata_raw() functions that include the $key/$meta_key parameter, but omit the $single
+ * parameter. Omitting $single in this situation can result in unexpected return types and lead to
+ * bugs.
+ *
+ * @link https://github.com/WordPress/WordPress-Coding-Standards/issues/2459
+ *
+ * @since 3.2.0
+ */
+final class GetMetaSingleSniff extends AbstractFunctionParameterSniff {
+
+	/**
+	 * The phrase to use for the metric recorded by this sniff.
+	 *
+	 * @var string
+	 */
+	const METRIC_NAME = 'get_*meta() function called with $single parameter';
+
+	/**
+	 * The group name for this group of functions.
+	 *
+	 * @since 3.2.0
+	 *
+	 * @var string
+	 */
+	protected $group_name = 'get_meta';
+
+	/**
+	 * List of functions this sniff should examine.
+	 *
+	 * {@internal Once support for PHP < 5.6 is dropped, it is possible to create two class constants
+	 * representing the two different signatures of get meta functions to remove the duplication
+	 * of the name and position of the parameters.}
+	 *
+	 * @link https://developer.wordpress.org/reference/functions/get_comment_meta/
+	 * @link https://developer.wordpress.org/reference/functions/get_metadata/
+	 * @link https://developer.wordpress.org/reference/functions/get_metadata_default/
+	 * @link https://developer.wordpress.org/reference/functions/get_metadata_raw/
+	 * @link https://developer.wordpress.org/reference/functions/get_post_meta/
+	 * @link https://developer.wordpress.org/reference/functions/get_site_meta/
+	 * @link https://developer.wordpress.org/reference/functions/get_term_meta/
+	 * @link https://developer.wordpress.org/reference/functions/get_user_meta/
+	 *
+	 * @since 3.2.0
+	 *
+	 * @var array<string, array<string, array<string, int|string>>> Key is function name, value is
+	 *                                                              an array containing information
+	 *                                                              about the name and position of
+	 *                                                              the relevant parameters.
+	 */
+	protected $target_functions = array(
+		'get_comment_meta'     => array(
+			'condition'   => array(
+				'param_name' => 'key',
+				'position'   => 2,
+			),
+			'recommended' => array(
+				'param_name' => 'single',
+				'position'   => 3,
+			),
+		),
+		'get_metadata'         => array(
+			'condition'   => array(
+				'param_name' => 'meta_key',
+				'position'   => 3,
+			),
+			'recommended' => array(
+				'param_name' => 'single',
+				'position'   => 4,
+			),
+		),
+		'get_metadata_default' => array(
+			'condition'   => array(
+				'param_name' => 'meta_key',
+				'position'   => 3,
+			),
+			'recommended' => array(
+				'param_name' => 'single',
+				'position'   => 4,
+			),
+		),
+		'get_metadata_raw'     => array(
+			'condition'   => array(
+				'param_name' => 'meta_key',
+				'position'   => 3,
+			),
+			'recommended' => array(
+				'param_name' => 'single',
+				'position'   => 4,
+			),
+		),
+		'get_post_meta'        => array(
+			'condition'   => array(
+				'param_name' => 'key',
+				'position'   => 2,
+			),
+			'recommended' => array(
+				'param_name' => 'single',
+				'position'   => 3,
+			),
+		),
+		'get_site_meta'        => array(
+			'condition'   => array(
+				'param_name' => 'key',
+				'position'   => 2,
+			),
+			'recommended' => array(
+				'param_name' => 'single',
+				'position'   => 3,
+			),
+		),
+		'get_term_meta'        => array(
+			'condition'   => array(
+				'param_name' => 'key',
+				'position'   => 2,
+			),
+			'recommended' => array(
+				'param_name' => 'single',
+				'position'   => 3,
+			),
+		),
+		'get_user_meta'        => array(
+			'condition'   => array(
+				'param_name' => 'key',
+				'position'   => 2,
+			),
+			'recommended' => array(
+				'param_name' => 'single',
+				'position'   => 3,
+			),
+		),
+	);
+
+	/**
+	 * Process the parameters of a matched function.
+	 *
+	 * @since 3.2.0
+	 *
+	 * @param int    $stackPtr        The position of the current token in the stack.
+	 * @param string $group_name      The name of the group which was matched.
+	 * @param string $matched_content The token content (function name) which was matched
+	 *                                in lowercase.
+	 * @param array  $parameters      Array with information about the parameters.
+	 *
+	 * @return void
+	 */
+	public function process_parameters( $stackPtr, $group_name, $matched_content, $parameters ) {
+		$condition   = $this->target_functions[ $matched_content ]['condition'];
+		$recommended = $this->target_functions[ $matched_content ]['recommended'];
+
+		$meta_key = PassedParameters::getParameterFromStack( $parameters, $condition['position'], $condition['param_name'] );
+		if ( ! is_array( $meta_key ) ) {
+			return;
+		}
+
+		$single = PassedParameters::getParameterFromStack( $parameters, $recommended['position'], $recommended['param_name'] );
+		if ( is_array( $single ) ) {
+			$this->phpcsFile->recordMetric( $stackPtr, self::METRIC_NAME, 'yes' );
+			return;
+		}
+
+		$this->phpcsFile->recordMetric( $stackPtr, self::METRIC_NAME, 'no' );
+
+		$tokens       = $this->phpcsFile->getTokens();
+		$message_data = array(
+			$condition['param_name'],
+			$tokens[ $stackPtr ]['content'],
+			$recommended['param_name'],
+		);
+
+		$this->phpcsFile->addWarning(
+			'When passing the $%s parameter to %s(), it is recommended to also pass the $%s parameter to explicitly indicate whether a single value or multiple values are expected to be returned.',
+			$stackPtr,
+			'Missing',
+			$message_data
+		);
+	}
+}

--- a/WordPress/Sniffs/WP/GlobalVariablesOverrideSniff.php
+++ b/WordPress/Sniffs/WP/GlobalVariablesOverrideSniff.php
@@ -33,7 +33,7 @@ use WordPressCS\WordPress\Sniff;
  * @since 0.13.0 Class name changed: this class is now namespaced.
  * @since 1.0.0  This sniff has been moved from the `Variables` category to the `WP`
  *               category and renamed from `GlobalVariables` to `GlobalVariablesOverride`.
- * @since 1.1.0  The sniff now also detects variables being overriden in the global namespace.
+ * @since 1.1.0  The sniff now also detects variables being overridden in the global namespace.
  * @since 2.2.0  The sniff now also detects variable assignments via the list() construct.
  *
  * @uses \WordPressCS\WordPress\Helpers\IsUnitTestTrait::$custom_test_classes

--- a/WordPress/Sniffs/WP/I18nSniff.php
+++ b/WordPress/Sniffs/WP/I18nSniff.php
@@ -449,7 +449,7 @@ final class I18nSniff extends AbstractFunctionParameterSniff {
 	 *                                     in lowercase.
 	 * @param string      $param_name      The name of the parameter being examined.
 	 * @param array|false $param_info      Parameter info array for an individual parameter,
-	 *                                     as received from the PassedParemeters class.
+	 *                                     as received from the PassedParameters class.
 	 *
 	 * @return bool Whether or not the argument is a string literal.
 	 */
@@ -550,7 +550,7 @@ final class I18nSniff extends AbstractFunctionParameterSniff {
 	 *                                     in lowercase.
 	 * @param string      $param_name      The name of the parameter being examined.
 	 * @param array|false $param_info      Parameter info array for an individual parameter,
-	 *                                     as received from the PassedParemeters class.
+	 *                                     as received from the PassedParameters class.
 	 *
 	 * @return void
 	 */
@@ -642,7 +642,7 @@ final class I18nSniff extends AbstractFunctionParameterSniff {
 	 *                                     in lowercase.
 	 * @param string      $param_name      The name of the parameter being examined.
 	 * @param array|false $param_info      Parameter info array for an individual parameter,
-	 *                                     as received from the PassedParemeters class.
+	 *                                     as received from the PassedParameters class.
 	 *
 	 * @return void
 	 */
@@ -724,7 +724,7 @@ final class I18nSniff extends AbstractFunctionParameterSniff {
 	 *                                     in lowercase.
 	 * @param string      $param_name      The name of the parameter being examined.
 	 * @param array|false $param_info      Parameter info array for an individual parameter,
-	 *                                     as received from the PassedParemeters class.
+	 *                                     as received from the PassedParameters class.
 	 *
 	 * @return bool Whether or not the text string has translatable content.
 	 */
@@ -759,7 +759,7 @@ final class I18nSniff extends AbstractFunctionParameterSniff {
 	 *                                     in lowercase.
 	 * @param string      $param_name      The name of the parameter being examined.
 	 * @param array|false $param_info      Parameter info array for an individual parameter,
-	 *                                     as received from the PassedParemeters class.
+	 *                                     as received from the PassedParameters class.
 	 *
 	 * @return void
 	 */
@@ -813,9 +813,9 @@ final class I18nSniff extends AbstractFunctionParameterSniff {
 	 *
 	 * @param int   $stackPtr          The position of the function call token in the stack.
 	 * @param array $param_info_single Parameter info array for the `$single` parameter,
-	 *                                 as received from the PassedParemeters class.
+	 *                                 as received from the PassedParameters class.
 	 * @param array $param_info_plural Parameter info array for the `$plural` parameter,
-	 *                                 as received from the PassedParemeters class.
+	 *                                 as received from the PassedParameters class.
 	 *
 	 * @return void
 	 */

--- a/WordPress/Sniffs/WP/I18nSniff.php
+++ b/WordPress/Sniffs/WP/I18nSniff.php
@@ -873,7 +873,7 @@ final class I18nSniff extends AbstractFunctionParameterSniff {
 				continue;
 			}
 
-			if ( preg_match( self::SPRINTF_PLACEHOLDER_REGEX, $param_info['clean'], $placeholders ) === 1 ) {
+			if ( preg_match( self::SPRINTF_PLACEHOLDER_REGEX, $param_info['clean'] ) === 1 ) {
 				$needs_translators_comment = true;
 				break;
 			}
@@ -969,7 +969,7 @@ final class I18nSniff extends AbstractFunctionParameterSniff {
 	 * @return bool
 	 */
 	private function is_translators_comment( $content ) {
-		if ( preg_match( '`^(?:(?://|/\*{1,2}) )?translators:`i', $content, $matches ) === 1 ) {
+		if ( preg_match( '`^(?:(?://|/\*{1,2}) )?translators:`i', $content ) === 1 ) {
 			return true;
 		}
 		return false;

--- a/WordPress/Sniffs/WhiteSpace/CastStructureSpacingSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/CastStructureSpacingSniff.php
@@ -22,7 +22,7 @@ use WordPressCS\WordPress\Sniff;
  * @since 0.11.0 The error level for all errors thrown by this sniff has been raised from warning to error.
  * @since 0.12.0 This class now extends the WordPressCS native `Sniff` class.
  * @since 0.13.0 Class name changed: this class is now namespaced.
- * @since 1.2.0  Removed the `NoSpaceAfterCloseParenthesis` error code in favour of the
+ * @since 1.2.0  Removed the `NoSpaceAfterCloseParenthesis` error code in favor of the
  *               upstream `Generic.Formatting.SpaceAfterCast.NoSpace` error.
  * @since 2.2.0  Added exception for whitespace between spread operator and cast.
  */

--- a/WordPress/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
+++ b/WordPress/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
@@ -410,7 +410,7 @@ final class ControlStructureSpacingSniff extends Sniff {
 
 			// Move past end comments.
 			if ( $this->tokens[ $trailingContent ]['line'] === $this->tokens[ $scopeCloser ]['line'] ) {
-				if ( preg_match( '`^//[ ]?end`i', $this->tokens[ $trailingContent ]['content'], $matches ) > 0 ) {
+				if ( preg_match( '`^//[ ]?end`i', $this->tokens[ $trailingContent ]['content'] ) > 0 ) {
 					$scopeCloser     = $trailingContent;
 					$trailingContent = $this->phpcsFile->findNext( \T_WHITESPACE, ( $trailingContent + 1 ), null, true );
 				}

--- a/WordPress/Tests/DB/DirectDatabaseQueryUnitTest.inc
+++ b/WordPress/Tests/DB/DirectDatabaseQueryUnitTest.inc
@@ -290,7 +290,7 @@ function nullsafe_object_operator() {
 
 function stabilize_token_walking($other_db) {
 	global $wpdb;
-	// Overwritting $wpdb is bad, of course, but that's not the concern of this sniff.
+	// Overwriting $wpdb is bad, of course, but that's not the concern of this sniff.
 	// This test is making sure that the `$other_db->query` code is not flagged as if it were a call to a `$wpdb` method.
 	$wpdb = $other_db->query;
 }

--- a/WordPress/Tests/DB/PreparedSQLPlaceholdersUnitTest.inc
+++ b/WordPress/Tests/DB/PreparedSQLPlaceholdersUnitTest.inc
@@ -154,7 +154,7 @@ $where = $wpdb->prepare(
 ); // Bad x 2 - quotes between the () for the IN.
 
 /*
- * Test distinguising wildcard _ and %'s in LIKE statements.
+ * Test distinguishing wildcard _ and %'s in LIKE statements.
  */
 $sql = $wpdb->prepare( "SELECT * FROM $wpdb->posts WHERE post_content LIKE %s", $like ); // OK.
 $sql = $wpdb->prepare( 'SELECT * FROM ' . $wpdb->posts . ' WHERE post_content LIKE \'a string\'' ); // Warning x 2. Like without wildcard, no need for prepare.

--- a/WordPress/Tests/DB/PreparedSQLUnitTest.1.inc
+++ b/WordPress/Tests/DB/PreparedSQLUnitTest.1.inc
@@ -140,7 +140,7 @@ $wpdb = new WPDB();
 $foo = $wpdb->propertyAccess;
 echo $wpdb::CONSTANT_NAME;
 
-// Not an identifyable method call.
+// Not an identifiable method call.
 $wpdb->{$methodName}('query');
 
 // Don't throw an error during live coding.

--- a/WordPress/Tests/DB/RestrictedClassesUnitTest.1.inc
+++ b/WordPress/Tests/DB/RestrictedClassesUnitTest.1.inc
@@ -104,3 +104,14 @@ $anon = new class extends PDOStatement {}; // Error.
 
 // PHP 8.1: enums can implement.
 enum MysqliEnum implements mysqli {} // Error.
+
+/*
+ * Safeguard handling of PHP 8.3+ readonly anonymous classes.
+ */
+$anon = new readonly class {
+    public function PDO() {} // OK.
+};
+
+$anon = new readonly class() extends PDOStatement {}; // Error.
+
+$anon = new #[MyAttribute] readonly class {};

--- a/WordPress/Tests/DB/RestrictedClassesUnitTest.2.inc
+++ b/WordPress/Tests/DB/RestrictedClassesUnitTest.2.inc
@@ -6,7 +6,7 @@ namespace My;
 
 class DBlayer {
 	const VERSION = '1.0';
-	
+
 	public static $property = true;
 
 	public static function connect() {

--- a/WordPress/Tests/DB/RestrictedClassesUnitTest.3.inc
+++ b/WordPress/Tests/DB/RestrictedClassesUnitTest.3.inc
@@ -6,42 +6,42 @@ namespace My {
 
 	class DBlayer {
 		const VERSION = '1.0';
-	
+
 		public static $property = true;
-	
+
 		public static function connect() {
 		}
 	}
-	
+
 	class DBextended extends DBlayer { // Bad.
 	}
-	
+
 	class DBextender implements PDO { // Ok -> resolves to \My\PDO.
 	}
-	
+
 	class DBextendes implements \PDO { // Bad -> fully qualified as \PDO.
 	}
-	
+
 	$db0 = new \DBlayer; // Ok - fully qualified as \DBlayer.
 	$db1 = new DBlayer; // Bad - resolves to \My\DBlayer.
 	$db2 = new DBlayer(); // Bad - resolves to \My\DBlayer.
-	
+
 	echo DBlayer::VERSION; // Bad - resolves to \My\DBlayer.
 	echo DBlayer::$property; // Bad - resolves to \My\DBlayer.
 	echo DBlayer::connect(); // Bad - resolves to \My\DBlayer.
-	
+
 	$db3 = new Yours\DBlayer; // Ok - resolves to \My\Yours\DBlayer.
-	
+
 	echo Yours\DBlayer::VERSION; // Ok - resolves to \My\Yours\DBlayer.
 	echo Yours\DBlayer::$property; // Ok - resolves to \My\Yours\DBlayer.
 	echo Yours\DBlayer::connect(); // Ok - resolves to \My\Yours\DBlayer.
-	
+
 	$db4 = new \My\DBlayer; // Bad - fully qualified as \My\DBlayer.
-	
+
 	echo \My\DBlayer::VERSION; // Bad - fully qualified as \My\DBlayer.
 	echo \My\DBlayer::$property; // Bad - fully qualified as \My\DBlayer.
 	echo \My\DBlayer::connect(); // Bad - fully qualified as \My\DBlayer.
-	
+
 	echo namespace\DBlayer::VERSION; // Bad - resolves to \My\DBlayer.
 	echo namespace\DBlayer::$property; // Bad - resolves to \My\DBlayer.
 	echo namespace\DBlayer::connect(); // Bad - resolves to \My\DBlayer.
@@ -82,7 +82,7 @@ namespace AdoDb {
 	class Tester {}
 
 	class TestAgain extends Test {} // Bad.
-	
+
 	class TestYetAgain extends Tester {} // Bad.
 
 	$db5 = new Test; // Bad.

--- a/WordPress/Tests/DB/RestrictedClassesUnitTest.4.inc
+++ b/WordPress/Tests/DB/RestrictedClassesUnitTest.4.inc
@@ -1,0 +1,8 @@
+<?php
+
+/*
+ * Intentional parse error (nothing after T_NEW).
+ * This should be the only test in this file.
+ */
+
+$annon = new

--- a/WordPress/Tests/DB/RestrictedClassesUnitTest.php
+++ b/WordPress/Tests/DB/RestrictedClassesUnitTest.php
@@ -106,6 +106,7 @@ final class RestrictedClassesUnitTest extends AbstractSniffUnitTest {
 					91  => 1,
 					103 => 1,
 					106 => 1,
+					115 => 1,
 				);
 
 			case 'RestrictedClassesUnitTest.2.inc':

--- a/WordPress/Tests/DB/RestrictedFunctionsUnitTest.php
+++ b/WordPress/Tests/DB/RestrictedFunctionsUnitTest.php
@@ -35,7 +35,7 @@ final class RestrictedFunctionsUnitTest extends AbstractSniffUnitTest {
 		parent::setUp();
 
 		AbstractFunctionRestrictionsSniff::$unittest_groups = array(
-			'test-empty-funtions-array' => array(
+			'test-empty-functions-array' => array(
 				'type'      => 'error',
 				'message'   => 'Detected usage of %s.',
 				'functions' => array(),

--- a/WordPress/Tests/Files/FileNameUnitTest.php
+++ b/WordPress/Tests/Files/FileNameUnitTest.php
@@ -9,7 +9,11 @@
 
 namespace WordPressCS\WordPress\Tests\Files;
 
+use PHP_CodeSniffer\Files\DummyFile;
+use PHP_CodeSniffer\Ruleset;
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHPCSUtils\BackCompat\Helper;
+use PHPCSUtils\TestUtils\ConfigDouble;
 
 /**
  * Unit test class for the FileName sniff.
@@ -171,5 +175,27 @@ final class FileNameUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getWarningList() {
 		return array();
+	}
+
+	/**
+	 * Test the sniff bails early when handling STDIN.
+	 *
+	 * @return void
+	 */
+	public function testStdIn() {
+		$config = new ConfigDouble();
+		Helper::setConfigData( 'installed_paths', dirname( dirname( __DIR__ ) ), true, $config );
+		$config->standards = array( 'WordPress' );
+		$config->sniffs    = array( 'WordPress.Files.FileName' );
+
+		$ruleset = new Ruleset( $config );
+
+		$content = '<?php ';
+		$file    = new DummyFile( $content, $ruleset, $config );
+		$file->process();
+
+		$this->assertSame( 0, $file->getErrorCount() );
+		$this->assertSame( 0, $file->getWarningCount() );
+		$this->assertCount( 0, $file->getErrors() );
 	}
 }

--- a/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.1.inc
+++ b/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.1.inc
@@ -509,7 +509,7 @@ function a_do_something(){}
 // phpcs:set WordPress.NamingConventions.PrefixAllGlobals prefixes[] aa
 function aa_do_something(){}
 
-// The following line mimicks an empty prefix value.
+// The following line mimics an empty prefix value.
 // phpcs:set WordPress.NamingConventions.PrefixAllGlobals prefixes[] ,
 function aaa_do_something(){}
 

--- a/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.1.inc
+++ b/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.1.inc
@@ -276,7 +276,7 @@ apply_filters( $_REQUEST['else'] ); // Warning.
 
 class Acronym_Dynamic_Hooks {
 	const FILTER = 'acronym';
-	const FILTER_WITH_UNDERSCORE = 'acronym_';
+	const ?string FILTER_WITH_UNDERSCORE = 'acronym_';
 
 	protected $filter = 'acronym';
 	protected $filter_with_underscore = 'acronym_';

--- a/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.1.inc
+++ b/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.1.inc
@@ -6,8 +6,8 @@
 // phpcs:set WordPress.NamingConventions.PrefixAllGlobals prefixes[] wp
 function wp_do_something() {}
 
-// phpcs:set WordPress.NamingConventions.PrefixAllGlobals prefixes[] ^%&
-function ^%&_do_something() {}
+// phpcs:set WordPress.NamingConventions.PrefixAllGlobals prefixes[] ^%&%
+function ^%&%_do_something() {}
 
 // Now let's set the real prefixes we want to test for.
 // phpcs:set WordPress.NamingConventions.PrefixAllGlobals prefixes[] acronym,tgmpa
@@ -511,13 +511,13 @@ function aa_do_something(){}
 
 // The following line mimics an empty prefix value.
 // phpcs:set WordPress.NamingConventions.PrefixAllGlobals prefixes[] ,
-function aaa_do_something(){}
+function aaaa_do_something(){}
 
 // phpcs:set WordPress.NamingConventions.PrefixAllGlobals prefixes[] 😊
 function 😊_do_something(){}
 
-// phpcs:set WordPress.NamingConventions.PrefixAllGlobals prefixes[] 😊😊
-function 😊😊_do_something(){}
+// phpcs:set WordPress.NamingConventions.PrefixAllGlobals prefixes[] 😊😊😊
+function 😊😊😊_do_something(){}
 
 // Reset to the standard test prefixes.
 // phpcs:set WordPress.NamingConventions.PrefixAllGlobals prefixes[] acronym,tgmpa

--- a/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.8.inc
+++ b/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.8.inc
@@ -4,7 +4,7 @@
 
 /*
  * This test safeguards a few edge cases and makes sure the sniff bows out correctly when it finds:
- * - $GLOBALS without a key. Note: overwritting the $GLOBALS variable is no longer allowed since PHP 8.1.
+ * - $GLOBALS without a key. Note: overwriting the $GLOBALS variable is no longer allowed since PHP 8.1.
  * - $GLOBALS without a key due to live coding.
  *
  * This test file should generate no errors or warnings.

--- a/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.9.inc
+++ b/WordPress/Tests/NamingConventions/PrefixAllGlobalsUnitTest.9.inc
@@ -11,7 +11,7 @@
 
 function acronym_unfinished_global_statement($param) {
 	global $var1, $var2 // Deliberately missing semi-colon.
-	
+
 	foreach ($param as $var2) {}
 }
 

--- a/WordPress/Tests/NamingConventions/ValidVariableNameUnitTest.inc
+++ b/WordPress/Tests/NamingConventions/ValidVariableNameUnitTest.inc
@@ -189,7 +189,7 @@ class MultiVarDeclarations {
 
 echo "This is $post_ID with $ThisShouldBeFlagged"; // Bad.
 
-// Safeguard that illegal property declarations are ignored.
+// Properties in interfaces are allowed since PHP 8.4.
 interface PropertiesNotAllowed {
 	public $notAllowed;
 }

--- a/WordPress/Tests/NamingConventions/ValidVariableNameUnitTest.php
+++ b/WordPress/Tests/NamingConventions/ValidVariableNameUnitTest.php
@@ -84,6 +84,7 @@ final class ValidVariableNameUnitTest extends AbstractSniffUnitTest {
 			184 => 1,
 			186 => 1,
 			190 => 1,
+			194 => 1,
 			199 => 1,
 			200 => 1,
 			202 => 1,

--- a/WordPress/Tests/Security/EscapeOutputUnitTest.1.inc
+++ b/WordPress/Tests/Security/EscapeOutputUnitTest.1.inc
@@ -39,7 +39,7 @@ echo 'Some Raw String';  // Good.
 echo '' . $bad; // Bad, should not validate.
 echo "this is $bad"; // Bad.
 echo esc_html( $good . $better ) . $foo; // Bad, should escape all concatenated elements.
-echo esc_html( $food . 'include'  ); // Good, eveything inside the escaping/sanitizing function should pass.
+echo esc_html( $food . 'include'  ); // Good, everything inside the escaping/sanitizing function should pass.
 echo esc_html( strtoupper( $ok ) ) . $foo; // Bad, again.
 echo esc_html( strtoupper( $ok ) ) . ' ' . esc_html( strtolower( $ok ) ); // Ok.
 

--- a/WordPress/Tests/Security/NonceVerificationUnitTest.1.inc
+++ b/WordPress/Tests/Security/NonceVerificationUnitTest.1.inc
@@ -466,7 +466,7 @@ function function_containing_nested_enum_with_nonce_check() {
 			wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['my_nonce'] ) ), 'the_nonce' );
 		}
 	}
-	
+
 	echo $_POST['foo']; // Bad.
 }
 

--- a/WordPress/Tests/Security/NonceVerificationUnitTest.5.inc
+++ b/WordPress/Tests/Security/NonceVerificationUnitTest.5.inc
@@ -5,7 +5,7 @@
  */
 
 if ( isset ( $_POST['prefix_myfield'] ) { // OK.
-	
+
 	do_something();
 	do_something();
 	do_something();

--- a/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.4.inc
+++ b/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.4.inc
@@ -167,7 +167,7 @@ _get_path_to_translation_from_lang_dir();
 _get_path_to_translation();
 
 /*
- * Missing text domain and preceeding args, only throw warning.
+ * Missing text domain and preceding args, only throw warning.
  */
 __();
 _e(   /* comment */  );

--- a/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.4.inc
+++ b/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.4.inc
@@ -246,5 +246,40 @@ esc_html_x(
 	context: $context,
 );
 
+/*
+ * Test that `AbstractFunctionParameterSniff::is_targetted_token()` does not treat first class
+ * callables and function imports as a function call without parameters. This test is added here as
+ * there are no dedicated tests for the WPCS abstract classes. The WPCS abstract classes will be
+ * replaced with PHPCSUtils similar classes in the future, so it is not worth creating dedicated
+ * tests at this point.
+ */
+use function __;
+use function __ as my_function;
+use function
+    __ /* comment */
+    as /* comment */
+    my_function;
+use function
+    _n, // comment
+    _e, /* comment */
+    __ as my_function;
+add_action('my_action', __(...));
+add_action(
+    'my_action',
+    __ /* comment */
+    (
+        /* comment */ ... /* comment */
+    )
+);
+// The tests below ensure that the AbstractFunctionParameterSniff does not incorrectly ignore
+// function calls with variable unpacking. But they are also false positives in the context of the
+// I18nTextDomainFixer sniff and will be addressed in a future update.
+__(...$args);
+__ (
+    ...
+    /* comment */
+    $args
+);
+
 // phpcs:set WordPress.Utils.I18nTextDomainFixer old_text_domain[]
 // phpcs:set WordPress.Utils.I18nTextDomainFixer new_text_domain false

--- a/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.4.inc.fixed
+++ b/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.4.inc.fixed
@@ -171,7 +171,7 @@ _get_path_to_translation_from_lang_dir( 'something-else' );
 _get_path_to_translation( 'something-else' );
 
 /*
- * Missing text domain and preceeding args, only throw warning.
+ * Missing text domain and preceding args, only throw warning.
  */
 __();
 _e(   /* comment */  );

--- a/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.4.inc.fixed
+++ b/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.4.inc.fixed
@@ -251,5 +251,41 @@ esc_html_x(
 	context: $context,
 );
 
+/*
+ * Test that `AbstractFunctionParameterSniff::is_targetted_token()` does not treat first class
+ * callables and function imports as a function call without parameters. This test is added here as
+ * there are no dedicated tests for the WPCS abstract classes. The WPCS abstract classes will be
+ * replaced with PHPCSUtils similar classes in the future, so it is not worth creating dedicated
+ * tests at this point.
+ */
+use function __;
+use function __ as my_function;
+use function
+    __ /* comment */
+    as /* comment */
+    my_function;
+use function
+    _n, // comment
+    _e, /* comment */
+    __ as my_function;
+add_action('my_action', __(...));
+add_action(
+    'my_action',
+    __ /* comment */
+    (
+        /* comment */ ... /* comment */
+    )
+);
+// The tests below ensure that the AbstractFunctionParameterSniff does not incorrectly ignore
+// function calls with variable unpacking. But they are also false positives in the context of the
+// I18nTextDomainFixer sniff and will be addressed in a future update.
+__(...$args, 'something-else');
+__ (
+    ...
+    /* comment */
+    $args,
+    'something-else'
+);
+
 // phpcs:set WordPress.Utils.I18nTextDomainFixer old_text_domain[]
 // phpcs:set WordPress.Utils.I18nTextDomainFixer new_text_domain false

--- a/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.5.inc
+++ b/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.5.inc
@@ -1,7 +1,7 @@
 <?php
 // phpcs:set WordPress.Utils.I18nTextDomainFixer new_text_domain
 
-// Testing behaviour when the `new_text_domain` property is not set.
+// Testing behavior when the `new_text_domain` property is not set.
 
 load_textdomain( 'something-else', '/path/to/file.mo' );
 __( $text, 'something-else' );

--- a/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.6.inc
+++ b/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.6.inc
@@ -2,7 +2,7 @@
 // phpcs:set WordPress.Utils.I18nTextDomainFixer old_text_domain[]
 // phpcs:set WordPress.Utils.I18nTextDomainFixer new_text_domain something-else
 
-// Testing behaviour when the `old_text_domain` property is not set.
+// Testing behavior when the `old_text_domain` property is not set.
 
 load_textdomain( 'old-domain', '/path/to/file.mo' );
 __( $text, 'old-domain' );

--- a/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.7.inc
+++ b/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.7.inc
@@ -1,0 +1,18 @@
+<?php
+// phpcs:set WordPress.Utils.I18nTextDomainFixer old_text_domain[] old-domain
+// phpcs:set WordPress.Utils.I18nTextDomainFixer new_text_domain something-else
+
+/*
+ * Intentional parse error (nothing after opening parenthesis).
+ * This should be the only test in this file.
+ *
+ * Test to document that `AbstractFunctionParameterSniff::is_targetted_token()` ignores unfinished
+ * function calls. This test is added here as there are no dedicated tests for the WPCS abstract
+ * classes. The WPCS abstract classes will be replaced with PHPCSUtils similar classes in the
+ * future, so it is not worth creating dedicated tests at this point.
+ */
+
+__(
+
+// phpcs:set WordPress.Utils.I18nTextDomainFixer old_text_domain[]
+// phpcs:set WordPress.Utils.I18nTextDomainFixer new_text_domain false

--- a/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.php
+++ b/WordPress/Tests/Utils/I18nTextDomainFixerUnitTest.php
@@ -17,6 +17,7 @@ use PHPCSUtils\BackCompat\Helper;
  *
  * @since 1.2.0
  *
+ * @covers \WordPressCS\WordPress\AbstractFunctionParameterSniff::is_targetted_token
  * @covers \WordPressCS\WordPress\Sniffs\Utils\I18nTextDomainFixerSniff
  */
 final class I18nTextDomainFixerUnitTest extends AbstractSniffUnitTest {
@@ -148,6 +149,8 @@ final class I18nTextDomainFixerUnitTest extends AbstractSniffUnitTest {
 					241 => 1,
 					242 => 1,
 					245 => 1,
+					277 => 1,
+					278 => 1,
 				);
 
 			default:

--- a/WordPress/Tests/WP/CapitalPDangitUnitTest.1.inc
+++ b/WordPress/Tests/WP/CapitalPDangitUnitTest.1.inc
@@ -231,3 +231,16 @@ echo Some\Enum\WordPress::ENUM_CONSTANT;
 
 // Safeguard that the sniff doesn't act on anonymous classes.
 $anon = new class() {};
+
+/*
+ * Safeguard that PHP 8.3+ typed class constants are handled correctly (i.e. ignored).
+ */
+class TypeClassConstants {
+    public const string WORDPRESS = 'wordress';
+
+    public const ?string ANOTHER = 'value',
+        WORDPRESS_SOMETHING = 'wordpress';
+
+	// Ensures no false positives on incorrect casing in a class constant type name.
+    public const (\Fully\Qualified\MyClass&wordPRESS)|string ANOTHER_WORDPRESS = 'wordpress';
+}

--- a/WordPress/Tests/WP/CapitalPDangitUnitTest.1.inc
+++ b/WordPress/Tests/WP/CapitalPDangitUnitTest.1.inc
@@ -102,7 +102,7 @@ if ( $counts['wordpress'] ) { // OK.
  *
  * @link OK: http://justintadlock.com/archives/2011/07/01/captions-in-wordpress
  */
- 
+
 if ( file_exists( ABSPATH . 'wp-content/plugins/wordpress-importer/wordpress-importer.php' ) ) { // OK.
 	include_once( ABSPATH . 'wp-admin/includes/plugin.php' );
 
@@ -129,8 +129,8 @@ $default_editor_settings = [
 				'label' 		=> __( 'Arouse Documentation', 'arouse' ),
 				'content' 		=> __( '<a class="button" href="https://themezhut.com/arouse-wordpress-theme-documentation/" target="_blank">Read the documentation.</a>', 'arouse' ), // OK.
 			)
-		) 
-	);	
+		)
+	);
 
 ?>
 

--- a/WordPress/Tests/WP/CapitalPDangitUnitTest.1.inc.fixed
+++ b/WordPress/Tests/WP/CapitalPDangitUnitTest.1.inc.fixed
@@ -231,3 +231,16 @@ echo Some\Enum\WordPress::ENUM_CONSTANT;
 
 // Safeguard that the sniff doesn't act on anonymous classes.
 $anon = new class() {};
+
+/*
+ * Safeguard that PHP 8.3+ typed class constants are handled correctly (i.e. ignored).
+ */
+class TypeClassConstants {
+    public const string WORDPRESS = 'wordress';
+
+    public const ?string ANOTHER = 'value',
+        WORDPRESS_SOMETHING = 'wordpress';
+
+	// Ensures no false positives on incorrect casing in a class constant type name.
+    public const (\Fully\Qualified\MyClass&wordPRESS)|string ANOTHER_WORDPRESS = 'wordpress';
+}

--- a/WordPress/Tests/WP/CapitalPDangitUnitTest.1.inc.fixed
+++ b/WordPress/Tests/WP/CapitalPDangitUnitTest.1.inc.fixed
@@ -102,7 +102,7 @@ if ( $counts['wordpress'] ) { // OK.
  *
  * @link OK: http://justintadlock.com/archives/2011/07/01/captions-in-wordpress
  */
- 
+
 if ( file_exists( ABSPATH . 'wp-content/plugins/wordpress-importer/wordpress-importer.php' ) ) { // OK.
 	include_once( ABSPATH . 'wp-admin/includes/plugin.php' );
 
@@ -129,8 +129,8 @@ $default_editor_settings = [
 				'label' 		=> __( 'Arouse Documentation', 'arouse' ),
 				'content' 		=> __( '<a class="button" href="https://themezhut.com/arouse-wordpress-theme-documentation/" target="_blank">Read the documentation.</a>', 'arouse' ), // OK.
 			)
-		) 
-	);	
+		)
+	);
 
 ?>
 

--- a/WordPress/Tests/WP/DeprecatedClassesUnitTest.inc
+++ b/WordPress/Tests/WP/DeprecatedClassesUnitTest.inc
@@ -23,10 +23,10 @@ $json = new Services_JSON;
 $json = new Services_JSON_Error;
 class Prefix_Menu_section extends WP_Privacy_Data_Export_Requests_Table {}
 WP_Privacy_Data_Removal_Requests_Table::foo();
+/* ============ WP 6.4 ============ */
+WP_Http_Curl::do_something();
+$streams = new WP_Http_Streams();
 
 /*
  * Warning
  */
-/* ============ WP 6.4 ============ */
-WP_Http_Curl::do_something();
-$streams = new WP_Http_Streams();

--- a/WordPress/Tests/WP/DeprecatedClassesUnitTest.php
+++ b/WordPress/Tests/WP/DeprecatedClassesUnitTest.php
@@ -28,11 +28,11 @@ final class DeprecatedClassesUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getErrorList() {
 		$start_line = 9;
-		$end_line   = 25;
+		$end_line   = 28;
 		$errors     = array_fill( $start_line, ( ( $end_line - $start_line ) + 1 ), 1 );
 
 		// Unset the lines related to version comments.
-		unset( $errors[16], $errors[18], $errors[21] );
+		unset( $errors[16], $errors[18], $errors[21], $errors[26] );
 
 		return $errors;
 	}
@@ -43,9 +43,6 @@ final class DeprecatedClassesUnitTest extends AbstractSniffUnitTest {
 	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList() {
-		return array(
-			31 => 1,
-			32 => 1,
-		);
+		return array();
 	}
 }

--- a/WordPress/Tests/WP/DeprecatedFunctionsUnitTest.inc
+++ b/WordPress/Tests/WP/DeprecatedFunctionsUnitTest.inc
@@ -426,3 +426,18 @@ wp_update_https_detection_errors();
 block_core_file_ensure_interactivity_dependency();
 block_core_image_ensure_interactivity_dependency();
 block_core_query_ensure_interactivity_dependency();
+/* ============ WP 6.6 ============ */
+wp_interactivity_process_directives_of_interactive_blocks();
+wp_render_elements_support();
+/* ============ WP 6.7 ============ */
+current_user_can_for_blog();
+wp_create_block_style_variation_instance_name();
+wp_enqueue_global_styles_custom_css();
+wp_get_global_styles_custom_css();
+wp_init_targeted_link_rel_filters();
+wp_remove_targeted_link_rel_filters();
+wp_simplepie_autoload();
+wp_targeted_link_rel();
+wp_targeted_link_rel_callback();
+/* ============ WP 6.8 ============ */
+wp_add_editor_classic_theme_styles();

--- a/WordPress/Tests/WP/DeprecatedFunctionsUnitTest.inc
+++ b/WordPress/Tests/WP/DeprecatedFunctionsUnitTest.inc
@@ -380,10 +380,6 @@ install_global_terms();
 sync_category_tag_slugs();
 wp_get_attachment_thumb_file();
 wp_typography_get_css_variable_inline_style();
-
-/*
- * Warning.
- */
 /* ============ WP 6.2 ============ */
 _resolve_home_block_template();
 get_page_by_title();
@@ -422,6 +418,10 @@ the_block_template_skip_link();
 wp_admin_bar_header();
 wp_img_tag_add_decoding_attr();
 wp_update_https_detection_errors();
+
+/*
+ * Warning.
+ */
 /* ============ WP 6.5 ============ */
 block_core_file_ensure_interactivity_dependency();
 block_core_image_ensure_interactivity_dependency();

--- a/WordPress/Tests/WP/DeprecatedFunctionsUnitTest.php
+++ b/WordPress/Tests/WP/DeprecatedFunctionsUnitTest.php
@@ -90,14 +90,17 @@ final class DeprecatedFunctionsUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getWarningList() {
 		$start_line = 388;
-		$end_line   = 428;
+		$end_line   = 443;
 		$warnings   = array_fill( $start_line, ( ( $end_line - $start_line ) + 1 ), 1 );
 
 		// Unset the lines related to version comments.
 		unset(
 			$warnings[390],
 			$warnings[414],
-			$warnings[425]
+			$warnings[425],
+			$warnings[429],
+			$warnings[432],
+			$warnings[442]
 		);
 
 		return $warnings;

--- a/WordPress/Tests/WP/DeprecatedFunctionsUnitTest.php
+++ b/WordPress/Tests/WP/DeprecatedFunctionsUnitTest.php
@@ -28,7 +28,7 @@ final class DeprecatedFunctionsUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getErrorList() {
 		$start_line = 8;
-		$end_line   = 382;
+		$end_line   = 420;
 		$errors     = array_fill( $start_line, ( ( $end_line - $start_line ) + 1 ), 1 );
 
 		// Unset the lines related to version comments.
@@ -77,7 +77,10 @@ final class DeprecatedFunctionsUnitTest extends AbstractSniffUnitTest {
 			$errors[363],
 			$errors[369],
 			$errors[371],
-			$errors[373]
+			$errors[373],
+			$errors[383],
+			$errors[386],
+			$errors[410]
 		);
 
 		return $errors;
@@ -89,15 +92,12 @@ final class DeprecatedFunctionsUnitTest extends AbstractSniffUnitTest {
 	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList() {
-		$start_line = 388;
+		$start_line = 426;
 		$end_line   = 443;
 		$warnings   = array_fill( $start_line, ( ( $end_line - $start_line ) + 1 ), 1 );
 
 		// Unset the lines related to version comments.
 		unset(
-			$warnings[390],
-			$warnings[414],
-			$warnings[425],
 			$warnings[429],
 			$warnings[432],
 			$warnings[442]

--- a/WordPress/Tests/WP/DeprecatedParameterValuesUnitTest.inc
+++ b/WordPress/Tests/WP/DeprecatedParameterValuesUnitTest.inc
@@ -50,5 +50,10 @@ update_option('blacklist_keys', $value);
 update_option('comment_whitelist', $value);
 update_option(autoload: true, value: $value, option: 'blacklist_keys');
 
+// Passing boolean $settings is deprecated since WP 6.6.0.
+wp_get_typography_font_size_value( $preset, array() ); // OK.
+wp_get_typography_font_size_value( $preset, true ); // Error.
+wp_get_typography_font_size_value( $preset, false ); // Error.
+
 // Live coding/parse error.
 get_bloginfo( show: /*to do*/, );

--- a/WordPress/Tests/WP/DeprecatedParameterValuesUnitTest.php
+++ b/WordPress/Tests/WP/DeprecatedParameterValuesUnitTest.php
@@ -61,6 +61,9 @@ final class DeprecatedParameterValuesUnitTest extends AbstractSniffUnitTest {
 	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList() {
-		return array();
+		return array(
+			55 => 1,
+			56 => 1,
+		);
 	}
 }

--- a/WordPress/Tests/WP/DeprecatedParametersUnitTest.inc
+++ b/WordPress/Tests/WP/DeprecatedParametersUnitTest.inc
@@ -96,4 +96,6 @@ wp_upload_bits( '', 'deprecated' );
 xfn_check( '', '', 'deprecated' );
 global_terms( $foo, 'deprecated' );
 
-// All will give an WARNING as they have been deprecated after WP 5.8.
+// All will give an WARNING as they have been deprecated after WP 6.2.
+inject_ignored_hooked_blocks_metadata_attributes('', 'deprecated');
+wp_render_elements_support_styles('deprecated');

--- a/WordPress/Tests/WP/DeprecatedParametersUnitTest.inc
+++ b/WordPress/Tests/WP/DeprecatedParametersUnitTest.inc
@@ -96,6 +96,6 @@ wp_upload_bits( '', 'deprecated' );
 xfn_check( '', '', 'deprecated' );
 global_terms( $foo, 'deprecated' );
 
-// All will give an WARNING as they have been deprecated after WP 6.2.
+// All will give an WARNING as they have been deprecated after WP 6.5.
 inject_ignored_hooked_blocks_metadata_attributes('', 'deprecated');
 wp_render_elements_support_styles('deprecated');

--- a/WordPress/Tests/WP/DeprecatedParametersUnitTest.php
+++ b/WordPress/Tests/WP/DeprecatedParametersUnitTest.php
@@ -51,6 +51,9 @@ final class DeprecatedParametersUnitTest extends AbstractSniffUnitTest {
 	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
 	public function getWarningList() {
-		return array();
+		return array(
+			100 => 1,
+			101 => 1,
+		);
 	}
 }

--- a/WordPress/Tests/WP/GetMetaSingleUnitTest.inc
+++ b/WordPress/Tests/WP/GetMetaSingleUnitTest.inc
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * Not the sniff target.
+ */
+my\ns\get_post_meta($a, $b);
+$this->get_post_meta($a, $b);
+MyClass::get_post_meta($a, $b);
+echo GET_POST_META;
+add_action('my_action', get_post_meta(...)); // PHP 8.1 first class callable.
+
+/*
+ * These should all be okay.
+ */
+$ok = get_post_meta( $post_id );
+$ok = get_post_meta( $post_id, $meta_key, false );
+$ok = get_post_meta( $post_id, single: true );
+$ok = get_post_meta( $post_id, single: true, key: $meta_key );
+$ok = get_metadata( 'post', $post_id );
+$ok = get_metadata( 'post', $post_id, $meta_key, true );
+$ok = get_metadata( 'post', $post_id, single: true );
+$ok = get_metadata( 'post', $post_id, single: true, meta_key: $meta_key );
+
+// Incorrect function calls, should be ignored by the sniff.
+$incorrect_but_ok = get_post_meta();
+$incorrect_but_ok = get_post_meta( single: true, $post_id );
+$incorrect_but_ok = get_post_meta( single: true );
+$incorrect_but_ok = get_metadata( 'post' );
+
+/*
+ * These should all be flagged with a warning.
+ */
+$warning = \get_post_meta( $post_id, $meta_key );
+implode(', ', get_post_meta( $post_id, $meta_key ));
+if (get_post_meta( $post_id, key: $meta_key )) {}
+$warning = get_post_meta( $post_id, key: $meta_key, sinngle: true ); // Typo in parameter name.
+echo get_comment_meta( $comment_id, $meta_key );
+$warning = get_site_meta( $site_id, $meta_key );
+$warning = get_term_meta( $term_id, $meta_key );
+$warning = get_user_meta( $user_id, $meta_key );
+$warning = GET_METADATA( 'post', $post_id, $meta_key );
+$warning = get_metadata(
+    'post',
+    $post_id,
+    meta_key: $meta_key
+);
+$warning = get_metadata_raw( 'post', $post_id, $meta_key );
+$warning = get_metadata_default( 'post', $post_id, $meta_key );

--- a/WordPress/Tests/WP/GetMetaSingleUnitTest.php
+++ b/WordPress/Tests/WP/GetMetaSingleUnitTest.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Unit test class for WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPressCS\WordPress\Tests\WP;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+/**
+ * Unit test class for the GetMetaSingle sniff.
+ *
+ * @since 3.2.0
+ *
+ * @covers \WordPressCS\WordPress\Sniffs\WP\GetMetaSingleSniff
+ */
+final class GetMetaSingleUnitTest extends AbstractSniffUnitTest {
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * @return array<int, int> Key is the line number, value is the number of expected errors.
+	 */
+	public function getErrorList() {
+		return array();
+	}
+
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
+	 */
+	public function getWarningList() {
+		return array(
+			33 => 1,
+			34 => 1,
+			35 => 1,
+			36 => 1,
+			37 => 1,
+			38 => 1,
+			39 => 1,
+			40 => 1,
+			41 => 1,
+			42 => 1,
+			47 => 1,
+			48 => 1,
+		);
+	}
+}

--- a/WordPress/ruleset.xml
+++ b/WordPress/ruleset.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="WordPress" namespace="WordPressCS\WordPress" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="WordPress" namespace="WordPressCS\WordPress" xsi:noNamespaceSchemaLocation="https://schema.phpcodesniffer.com/phpcs.xsd">
 
 	<description>WordPress Coding Standards</description>
 

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,26 @@
+[files]
+extend-exclude = [
+    "WordPress/Tests/*/*.inc",
+    "WordPress/Tests/*/*.fixed",
+    "WordPress/Tests/*/*.css",
+    "WordPress/Tests/*/*.js",
+]
+ignore-hidden = true
+
+[default]
+locale = "en-us"
+check-filename = true
+extend-ignore-identifiers-re = [
+    # Renaming these (function/array key) names would be a BC-break.
+    'analyse_implode',
+    'analyse_sprintf',
+    'cachable',
+    'is_targetted_token',
+    # These are search targets for sniffs, can't be helped.
+    'avail_post_stati',
+    'url_is_accessable_via_ssl',
+]
+
+[default.extend-words]
+# Don't correct a limited list of specific words.
+Automattic = "Automattic"

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,8 @@
 	"config": {
 		"allow-plugins": {
 			"dealerdirect/phpcodesniffer-composer-installer": true
-		}
+		},
+		"lock": false
 	},
 	"scripts": {
 		"lint": [

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
 		"phpcompatibility/php-compatibility": "^9.0",
 		"phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0",
 		"phpcsstandards/phpcsdevtools": "^1.2.0",
-		"php-parallel-lint/php-parallel-lint": "^1.3.2",
+		"php-parallel-lint/php-parallel-lint": "^1.4.0",
 		"php-parallel-lint/php-console-highlighter": "^1.0.0"
 	},
 	"suggest": {

--- a/composer.json
+++ b/composer.json
@@ -21,9 +21,9 @@
 		"ext-libxml": "*",
 		"ext-tokenizer": "*",
 		"ext-xmlreader": "*",
-		"squizlabs/php_codesniffer": "^3.9.0",
-		"phpcsstandards/phpcsutils": "^1.0.10",
-		"phpcsstandards/phpcsextra": "^1.2.1"
+		"squizlabs/php_codesniffer": "^3.13.0",
+		"phpcsstandards/phpcsutils": "^1.1.0",
+		"phpcsstandards/phpcsextra": "^1.4.0"
 	},
 	"require-dev": {
 		"phpcompatibility/php-compatibility": "^9.0",

--- a/phpcs.xml.dist.sample
+++ b/phpcs.xml.dist.sample
@@ -140,7 +140,7 @@
 	so excluding test files from the `WordPress.Files.Filename` sniff can be a
 	legitimate exclusion.
 
-	For more information on ruleset configuration optiones, check out the PHPCS wiki:
+	For more information on ruleset configuration options, check out the PHPCS wiki:
 	https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Annotated-Ruleset
 	-->
 	<rule ref="WordPress.WP.GlobalVariablesOverride">

--- a/phpcs.xml.dist.sample
+++ b/phpcs.xml.dist.sample
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Example Project" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Example Project" xsi:noNamespaceSchemaLocation="https://schema.phpcodesniffer.com/phpcs.xsd">
 
 	<description>A custom set of rules to check for a WPized WordPress project</description>
 


### PR DESCRIPTION
:warning: **DO NOT MERGE (YET)** :warning:

**Please **do** add approvals if you agree as otherwise we won't be able to release.**

PR for tracking changes for the 3.2.0 release. Target release date: **Thursday July 24, 2025**.

---

## Release checklist

### General

- [x] Verify, and if necessary, update the allowed version ranges for various dependencies in the `composer.json` - PR #2532, #2533
- [ ] PHPCS: check if there have been [releases][phpcs-releases] since the last WordPressCS release and check through the changelog to see if there is anything WordPressCS could take advantage of - PR #2534 + ongoing
- [ ] PHPCSUtils: check if there have been [releases][phpcsutils-releases] since the last WordPressCS release and update WordPressCS code to take advantage of any new utilities - ongoing
- [x] PHPCSExtra: check if there have been [releases][phpcsextra-releases] since the last WordPressCS release and check through the changelog to see if there is anything WordPressCS could take advantage of - verified
- [x] Check if the minimum WP version property needs updating in `MinimumWPVersionTrait::$default_minimum_wp_version` and if so, action it - PR #2553
- [x] Check if any of the list based sniffs need updating and if so, action it.
    :pencil2: Make sure the "last updated" annotation in the docblocks for these lists has also been updated!
    List based sniffs:
    - [x] `WordPress.WP.ClassNameCase` - PR #2537
    - [ ] `WordPress.WP.DeprecatedClasses` - _N/A_
    - [x] `WordPress.WP.DeprecatedFunctions` - PR #2537
    - [x] `WordPress.WP.DeprecatedParameters` - PR #2537
    - [x] `WordPress.WP.DeprecatedParameterValues` - PR #2537
- [ ] Check if any of the other lists containing information about WP Core need updating and if so, action it.
    - [ ] `$allowed_core_constants` in `WordPress.NamingConventions.PrefixAllGlobals` - _N/A_
    - [x] `$pluggable_functions` in `WordPress.NamingConventions.PrefixAllGlobals` - PR #2537
    - [ ] `$pluggable_classes` in `WordPress.NamingConventions.PrefixAllGlobals` - PR _N/A_
    - [ ] `$target_functions` in `WordPress.Security.PluginMenuSlug` - _N/A_
    - [ ] `$reserved_names` in `WordPress.NamingConventions.ValidPostTypeSlug` - _N/A_
    - [ ] `$wp_time_constants` in `WordPress.WP.CronInterval` - _N/A_
    - [ ] `$known_test_classes` in `IsUnitTestTrait` - _N/A_
    - [ ] ...etc...
- [x] Verify there there has been no vandalism on the wiki (and if so, remove/fix it). _Verified & fixed_

### Release prep

- [x] Add changelog for the release - PR #2557
    :pencil2: Remember to add a release link at the bottom!
- [ ] Update `README` (if applicable) - PR #xxx
- [ ] Update wiki (new customizable properties etc.) (if applicable)

### Release

- [ ] Merge this PR.
- [ ] Make sure all CI builds are green.
- [ ] Tag and create a release against `main` (careful, GH defaults to `develop`!) & copy & paste the changelog to it.
    :pencil2: Check if anything from the link collection at the bottom of the changelog needs to be copied in!
    - Remove square brackets from all ticket links or make them proper full links (as GH markdown parser doesn't parse these correctly).
    - Change all contributor links to full inline links (as GH markdown parser on the Releases page doesn't parse these correctly).
- [ ] Make sure all CI builds are green.
- [ ] Close the milestone.
- [ ] Open a new milestone for the next release.
- [ ] If any open PRs/issues which were milestoned for this release did not make it into the release, update their milestone.
- [ ] Fast-forward `develop` to be equal to `main`.

### After release

- [ ] Open a Trac ticket for WordPress Core to update.

### Publicize

- [ ] [Major releases only] Publish post about the release on Make WordPress.
- [ ] Tweet, toot, etc about the release.
- [ ] Post about it in Slack.
- [ ] Submit for ["Month in WordPress"][month-in-wp].
- [ ] Submit for the ["Monthy Dev Roundup"][dev-roundup].

[phpcs-releases]:      https://github.com/PHPCSStandards/PHP_CodeSniffer/releases
[phpcsutils-releases]: https://github.com/PHPCSStandards/PHPCSUtils/releases
[phpcsextra-releases]: https://github.com/PHPCSStandards/PHPCSExtra/releases
[month-in-wp]:         https://make.wordpress.org/community/month-in-wordpress-submissions/
[dev-roundup]:         https://github.com/WordPress/developer-blog-content/issues?q=is%3Aissue+label%3A%22Monthly+Roundup%22