### PR TITLE
Security/EscapeOutput: fix false negatives when handling anonymous classes

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -68,6 +68,7 @@
 		<exclude name="PHPCompatibility.Constants.NewConstants.t_coalesceFound"/>
 		<exclude name="PHPCompatibility.Constants.NewConstants.t_coalesce_equalFound"/>
 		<exclude name="PHPCompatibility.Constants.NewConstants.t_yield_fromFound"/>
+		<exclude name="PHPCompatibility.Constants.NewConstants.t_readonlyFound"/>
 	</rule>
 
 	<!-- Enforce PSR1 compatible namespaces. -->

--- a/WordPress/Sniffs/Security/EscapeOutputSniff.php
+++ b/WordPress/Sniffs/Security/EscapeOutputSniff.php
@@ -235,7 +235,7 @@ class EscapeOutputSniff extends AbstractFunctionRestrictionsSniff {
 				}
 
 				// Skip over attribute declarations when searching for the open parenthesis.
-				if ( \T_ATTRIBUTE === $this->tokens[ $next_relevant ]['code'] ) {
+				while ( \T_ATTRIBUTE === $this->tokens[ $next_relevant ]['code'] ) {
 					if ( isset( $this->tokens[ $next_relevant ]['attribute_closer'] ) === false ) {
 						return;
 					}

--- a/WordPress/Tests/Security/EscapeOutputUnitTest.1.inc
+++ b/WordPress/Tests/Security/EscapeOutputUnitTest.1.inc
@@ -671,4 +671,8 @@ die( status: $foo ); // Bad.
 throw new #[MyAttribute] readonly class( esc_html( $message ) ) extends Exception {}; // Good.
 throw new readonly class( $unescaped ) {}; // Bad.
 throw new #[MyAttribute] class( $unescaped ) extends Exception {}; // Bad.
-throw new #[MyAttribute] readonly class( $unescaped ) extends Exception {}; // Bad.
+throw new
+#[Attribute1]
+/* some comment */
+#[Attribute2('text', 10)]
+readonly class( $unescaped ) {}; // Bad.

--- a/WordPress/Tests/Security/EscapeOutputUnitTest.1.inc
+++ b/WordPress/Tests/Security/EscapeOutputUnitTest.1.inc
@@ -662,3 +662,13 @@ die( status: esc_html( $foo ) ); // Ok.
 
 exit( status: $foo ); // Bad.
 die( status: $foo ); // Bad.
+
+/*
+ * Issue https://github.com/WordPress/WordPress-Coding-Standards/issues/2552
+ * Ensure that readonly anonymous classes and anonymous classes with attributes are handled
+ * correctly when part of a throw statement.
+ */
+throw new #[MyAttribute] readonly class( esc_html( $message ) ) extends Exception {}; // Good.
+throw new readonly class( $unescaped ) {}; // Bad.
+throw new #[MyAttribute] class( $unescaped ) extends Exception {}; // Bad.
+throw new #[MyAttribute] readonly class( $unescaped ) extends Exception {}; // Bad.

--- a/WordPress/Tests/Security/EscapeOutputUnitTest.21.inc
+++ b/WordPress/Tests/Security/EscapeOutputUnitTest.21.inc
@@ -1,0 +1,8 @@
+<?php
+
+/*
+ * Intentional parse error (nothing after T_ATTRIBUTE).
+ * This should be the only test in this file.
+ */
+
+throw new #[

--- a/WordPress/Tests/Security/EscapeOutputUnitTest.22.inc
+++ b/WordPress/Tests/Security/EscapeOutputUnitTest.22.inc
@@ -1,0 +1,8 @@
+<?php
+
+/*
+ * Intentional parse error (nothing after T_ATTRIBUTE_END).
+ * This should be the only test in this file.
+ */
+
+throw new #[MyAttribute]

--- a/WordPress/Tests/Security/EscapeOutputUnitTest.22.inc
+++ b/WordPress/Tests/Security/EscapeOutputUnitTest.22.inc
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * Intentional parse error (nothing after T_ATTRIBUTE_END).
+ * Intentional parse error (only whitespaces after T_ATTRIBUTE_END).
  * This should be the only test in this file.
  */
 

--- a/WordPress/Tests/Security/EscapeOutputUnitTest.23.inc
+++ b/WordPress/Tests/Security/EscapeOutputUnitTest.23.inc
@@ -1,0 +1,9 @@
+<?php
+
+/*
+ * Intentional parse error (nothing after T_ATTRIBUTE_END).
+ * There should be no whitespaces at the end of this file.
+ * This should be the only test in this file.
+ */
+
+throw new #[MyAttribute]

--- a/WordPress/Tests/Security/EscapeOutputUnitTest.php
+++ b/WordPress/Tests/Security/EscapeOutputUnitTest.php
@@ -161,6 +161,9 @@ final class EscapeOutputUnitTest extends AbstractSniffUnitTest {
 					657 => 1,
 					663 => 1,
 					664 => 1,
+					672 => 1,
+					673 => 1,
+					674 => 1,
 				);
 
 			case 'EscapeOutputUnitTest.6.inc':

--- a/WordPress/Tests/Security/EscapeOutputUnitTest.php
+++ b/WordPress/Tests/Security/EscapeOutputUnitTest.php
@@ -163,7 +163,7 @@ final class EscapeOutputUnitTest extends AbstractSniffUnitTest {
 					664 => 1,
 					672 => 1,
 					673 => 1,
-					674 => 1,
+					678 => 1,
 				);
 
 			case 'EscapeOutputUnitTest.6.inc':


### PR DESCRIPTION
This PR fixes false negatives when the sniff `WordPress.Security.EscapeOutput` handles readonly anonymous classes and anonymous classes with attributes that are part of a throw statement.

When stepping over tokens after `T_THROW` to find the `T_OPEN_PARENTHESIS` of the exception creation function call/class instantiation, the sniff was not considering that it might need to step over `T_READONLY` tokens or attribute declarations when dealing with anonymous classes.

Fixes #2552