### PR TITLE
NamingConventions/ValidPostTypeSlug: check token via code, not type

### DIFF
--- a/WordPress/Sniffs/NamingConventions/ValidPostTypeSlugSniff.php
+++ b/WordPress/Sniffs/NamingConventions/ValidPostTypeSlugSniff.php
@@ -172,8 +172,8 @@ final class ValidPostTypeSlugSniff extends AbstractFunctionParameterSniff {
 		);
 
 		// Warn for dynamic parts in the slug parameter.
-		if ( 'T_DOUBLE_QUOTED_STRING' === $this->tokens[ $string_pos ]['type']
-			|| ( 'T_HEREDOC' === $this->tokens[ $string_pos ]['type']
+		if ( \T_DOUBLE_QUOTED_STRING === $this->tokens[ $string_pos ]['code']
+			|| ( \T_HEREDOC === $this->tokens[ $string_pos ]['code']
 			&& strpos( $this->tokens[ $string_pos ]['content'], '$' ) !== false )
 		) {
 			$this->phpcsFile->addWarning(


### PR DESCRIPTION
The `'type'` index in the token array should generally only be used for PHPCS cross-version compatibility, where the token constant we are looking for may not be defined in all supported PHPCS versions.

That's not the case for these.