### PR TITLE
Use PHPCSUtils 1.1.0 features

### DIFF
--- a/WordPress/Helpers/ListHelper.php
+++ b/WordPress/Helpers/ListHelper.php
@@ -9,8 +9,8 @@
 
 namespace WordPressCS\WordPress\Helpers;
 
-use PHP_CodeSniffer\Exceptions\RuntimeException;
 use PHP_CodeSniffer\Files\File;
+use PHPCSUtils\Exceptions\UnexpectedTokenType;
 use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\Lists;
 
@@ -67,7 +67,7 @@ final class ListHelper {
 
 		try {
 			$assignments = Lists::getAssignments( $phpcsFile, $stackPtr );
-		} catch ( RuntimeException $e ) {
+		} catch ( UnexpectedTokenType $e ) {
 			// Parse error/live coding.
 			return array();
 		}

--- a/WordPress/Sniffs/Files/FileNameSniff.php
+++ b/WordPress/Sniffs/Files/FileNameSniff.php
@@ -10,8 +10,8 @@
 namespace WordPressCS\WordPress\Sniffs\Files;
 
 use PHPCSUtils\Tokens\Collections;
+use PHPCSUtils\Utils\FilePath;
 use PHPCSUtils\Utils\ObjectDeclarations;
-use PHPCSUtils\Utils\TextStrings;
 use WordPressCS\WordPress\Helpers\IsUnitTestTrait;
 use WordPressCS\WordPress\Sniff;
 
@@ -151,8 +151,7 @@ final class FileNameSniff extends Sniff {
 	 *                  normal file processing.
 	 */
 	public function process_token( $stackPtr ) {
-		// Usage of `stripQuotes` is to ensure `stdin_path` passed by IDEs does not include quotes.
-		$file = TextStrings::stripQuotes( $this->phpcsFile->getFileName() );
+		$file = FilePath::getName( $this->phpcsFile );
 		if ( 'STDIN' === $file ) {
 			return $this->phpcsFile->numTokens;
 		}
@@ -197,7 +196,7 @@ final class FileNameSniff extends Sniff {
 			$this->check_filename_has_class_prefix( $class_ptr, $file_name );
 		}
 
-		if ( false !== strpos( $file, \DIRECTORY_SEPARATOR . 'wp-includes' . \DIRECTORY_SEPARATOR )
+		if ( false !== strpos( $file, '/wp-includes/' )
 			&& false === $class_ptr
 		) {
 			$this->check_filename_for_template_suffix( $stackPtr, $file_name );

--- a/WordPress/Sniffs/PHP/YodaConditionsSniff.php
+++ b/WordPress/Sniffs/PHP/YodaConditionsSniff.php
@@ -43,10 +43,9 @@ final class YodaConditionsSniff extends Sniff {
 
 		$starters                        = Tokens::$booleanOperators;
 		$starters                       += Tokens::$assignmentTokens;
+		$starters                       += Collections::ternaryOperators();
 		$starters[ \T_CASE ]             = \T_CASE;
 		$starters[ \T_RETURN ]           = \T_RETURN;
-		$starters[ \T_INLINE_THEN ]      = \T_INLINE_THEN;
-		$starters[ \T_INLINE_ELSE ]      = \T_INLINE_ELSE;
 		$starters[ \T_SEMICOLON ]        = \T_SEMICOLON;
 		$starters[ \T_OPEN_PARENTHESIS ] = \T_OPEN_PARENTHESIS;
 

--- a/WordPress/Sniffs/Utils/I18nTextDomainFixerSniff.php
+++ b/WordPress/Sniffs/Utils/I18nTextDomainFixerSniff.php
@@ -11,6 +11,7 @@ namespace WordPressCS\WordPress\Sniffs\Utils;
 
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\BackCompat\Helper;
+use PHPCSUtils\Utils\FilePath;
 use PHPCSUtils\Utils\GetTokensAsString;
 use PHPCSUtils\Utils\PassedParameters;
 use PHPCSUtils\Utils\TextStrings;
@@ -675,7 +676,7 @@ final class I18nTextDomainFixerSniff extends AbstractFunctionParameterSniff {
 		$headers = $this->plugin_headers;
 		$type    = 'plugin';
 
-		$file = TextStrings::stripQuotes( $this->phpcsFile->getFileName() );
+		$file = FilePath::getName( $this->phpcsFile );
 		if ( 'STDIN' === $file ) {
 			return;
 		}

--- a/WordPress/Sniffs/WP/EnqueuedResourcesSniff.php
+++ b/WordPress/Sniffs/WP/EnqueuedResourcesSniff.php
@@ -9,8 +9,8 @@
 
 namespace WordPressCS\WordPress\Sniffs\WP;
 
-use PHP_CodeSniffer\Exceptions\RuntimeException;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Exceptions\ValueError;
 use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\TextStrings;
 use WordPressCS\WordPress\Sniff;
@@ -54,7 +54,7 @@ final class EnqueuedResourcesSniff extends Sniff {
 			try {
 				$end_ptr = TextStrings::getEndOfCompleteTextString( $this->phpcsFile, $stackPtr );
 				$content = TextStrings::getCompleteTextString( $this->phpcsFile, $stackPtr );
-			} catch ( RuntimeException $e ) {
+			} catch ( ValueError $e ) {
 				// Parse error/live coding.
 				return;
 			}

--- a/WordPress/Tests/Security/EscapeOutputUnitTest.1.inc
+++ b/WordPress/Tests/Security/EscapeOutputUnitTest.1.inc
@@ -655,3 +655,10 @@ echo '<input type="search" value="' . get_search_query( false ) . '">'; // Bad.
 echo '<input type="search" value="' . get_search_query( 0 ) . '">'; // Bad.
 echo '<input type="search" value="' . get_search_query( escape: false ) . '">'; // OK, well not really, typo in param name, but that's not our concern.
 echo '<input type="search" value="' . get_search_query( escaped: false ) . '">'; // Bad.
+
+// PHP 8.4: exit/die using named parameters.
+exit( status: esc_html( $foo ) ); // Ok.
+die( status: esc_html( $foo ) ); // Ok.
+
+exit( status: $foo ); // Bad.
+die( status: $foo ); // Bad.

--- a/WordPress/Tests/Security/EscapeOutputUnitTest.php
+++ b/WordPress/Tests/Security/EscapeOutputUnitTest.php
@@ -159,6 +159,8 @@ final class EscapeOutputUnitTest extends AbstractSniffUnitTest {
 					654 => 1,
 					655 => 1,
 					657 => 1,
+					663 => 1,
+					664 => 1,
 				);
 
 			case 'EscapeOutputUnitTest.6.inc':


### PR DESCRIPTION
Just a collection of some small commits to take advantage of things which PHPCSUtils 1.1.0 brings.

---

### PHP/YodaConditions: use new Collections::ternaryOperators() token array

### Files/FileName: start using the PHPCSUtils FilePath utility 

The `FilePath::getName()` method will strip quotes from the file name, as well as normalize the slashes to forward (*nix) slashes.

This allows for a minor simplication in the code and improves code readability.

### Utils/I18nTextDomainFixer: start using the PHPCSUtils FilePath utility 

The `FilePath::getName()` method will strip quotes from the file name, as well as normalize the slashes to forward (*nix) slashes.

This allows for a minor simplication in the code and improves code readability.

### PHP 8.4 | Security/EscapeOutput: handle exit/die using named parameters 

As of PHP 8.4, the internal of `T_EXIT` are changing in PHP itself and `exit`/`die` will internally be treated as a function call.

The net effect of this is that named parameters can now be used with `exit()`/`die()`.

For the `WordPress.Security.EscapeOutput` sniff this would lead to false positives as the parameter name would be seen as "not escaped".

As of PHPCSUtils 1.1.0, the methods within the `PassedParameters` class will allow for passing a `T_EXIT` token. This, in turn, allows for handling `exit`/`die` with named parameters correctly in the context of the `EscapeOutput` sniff.

This commit implements using the `PassedParameters` class for parsing calls to `exit`/`die`, which fixes the issue.

Includes tests.

Ref: https://wiki.php.net/rfc/exit-as-function

### PHPCSUtils 1.1.0: only catch what should be caught 

PHPCSUtils 1.1.0 introduces much more modular exceptions for a variety of errors the utility methods can throw.

This commit changes the exceptions being caught in various `catch` statements to more specific ones.

This means that exceptions which shouldn't be able to occur are no longer caught (passing incorrect data type and such) and only the potentially expected (and acceptable) exceptions will now be caught.