### PR TITLE
EscapingFunctionsTrait: remove `wp_kses_allowed_html()` from escaping functions

### DIFF
--- a/WordPress/Helpers/EscapingFunctionsTrait.php
+++ b/WordPress/Helpers/EscapingFunctionsTrait.php
@@ -90,7 +90,6 @@ trait EscapingFunctionsTrait {
 		'urlencode_deep'             => true,
 		'urlencode'                  => true,
 		'wp_json_encode'             => true,
-		'wp_kses_allowed_html'       => true,
 		'wp_kses_data'               => true,
 		'wp_kses_one_attr'           => true,
 		'wp_kses_post'               => true,


### PR DESCRIPTION

The `wp_kses_allowed_html()` function is not an escaping function, but retrieves an array of allowed HTML tags and attributes for a given context.

Ref: https://developer.wordpress.org/reference/functions/wp_kses_allowed_html/