### PR TITLE
DB/PreparedSQLPlaceholders: fix false negative when checking quotes in dynamic generated placeholders

### DIFF
--- a/WordPress/Sniffs/DB/PreparedSQLPlaceholdersSniff.php
+++ b/WordPress/Sniffs/DB/PreparedSQLPlaceholdersSniff.php
@@ -266,8 +266,13 @@ final class PreparedSQLPlaceholdersSniff extends Sniff {
 						unset( $sprintf_parameters, $valid_sprintf, $last_param );
 
 					} elseif ( 'implode' === strtolower( $this->tokens[ $i ]['content'] ) ) {
+						$ignore_tokens = Tokens::$emptyTokens + array(
+							\T_STRING_CONCAT => \T_STRING_CONCAT,
+							\T_NS_SEPARATOR  => \T_NS_SEPARATOR,
+						);
+
 						$prev = $this->phpcsFile->findPrevious(
-							Tokens::$emptyTokens + array( \T_STRING_CONCAT => \T_STRING_CONCAT ),
+							$ignore_tokens,
 							( $i - 1 ),
 							$query['start'],
 							true

--- a/WordPress/Tests/DB/PreparedSQLPlaceholdersUnitTest.inc
+++ b/WordPress/Tests/DB/PreparedSQLPlaceholdersUnitTest.inc
@@ -148,7 +148,7 @@ $where = $wpdb->prepare(
 	"{$wpdb->posts}.post_type IN (\""
 		. implode( ',', array_fill( 0, count($post_types), '%s' ) )
 		. "\") AND {$wpdb->posts}.post_status IN ('"
-		. implode( ',', array_fill( 0, count($post_statusses), '%s' ) )
+		. \implode( ',', array_fill( 0, count($post_statusses), '%s' ) )
 		. '\')',
 	array_merge( $post_types, $post_statusses )
 ); // Bad x 2 - quotes between the () for the IN.


### PR DESCRIPTION
While working on preparing WPCS for the changes in PHPCS 4.0, more specifically the changes around namespace tokenization, I noticed that the `WordPress.DB.PreparedSQLPlaceholders` sniff was not accounting for fully qualified calls to `implode()` in the code that checks for quotes in dynamically generated placeholders. This PR fixes that. See the modified test for an example of a code that would cause a false negative.