### PR TITLE
DB/PreparedSQL: fix false positives with case-insensitive function names

### DIFF
--- a/WordPress/Sniffs/DB/PreparedSQLSniff.php
+++ b/WordPress/Sniffs/DB/PreparedSQLSniff.php
@@ -207,10 +207,11 @@ final class PreparedSQLSniff extends Sniff {
 			}
 
 			if ( \T_STRING === $this->tokens[ $this->i ]['code'] ) {
+				$content_lowercase = strtolower( $this->tokens[ $this->i ]['content'] );
 
 				if (
-					isset( $this->SQLEscapingFunctions[ $this->tokens[ $this->i ]['content'] ] )
-					|| isset( $this->SQLAutoEscapedFunctions[ $this->tokens[ $this->i ]['content'] ] )
+					isset( $this->SQLEscapingFunctions[ $content_lowercase ] )
+					|| isset( $this->SQLAutoEscapedFunctions[ $content_lowercase ] )
 				) {
 
 					// Find the opening parenthesis.

--- a/WordPress/Tests/DB/PreparedSQLUnitTest.1.inc
+++ b/WordPress/Tests/DB/PreparedSQLUnitTest.1.inc
@@ -30,7 +30,7 @@ $all_post_meta = $wpdb->get_results( $wpdb->prepare( sprintf(
 ), $post_ids ) );
 
 $wpdb->query( "SELECT * FROM $wpdb->posts WHERE post_title LIKE '" . esc_sql( $foo ) . "';" ); // Ok.
-$wpdb->query( "SELECT * FROM $wpdb->posts WHERE ID = " . absint( $foo ) . ";" ); // Ok.
+$wpdb->query( "SELECT * FROM $wpdb->posts WHERE ID = " . ABSINT( $foo ) . ";" ); // Ok.
 
 // Test multi-line strings.
 $all_post_meta = $wpdb->get_results( $wpdb->prepare( sprintf(
@@ -79,7 +79,7 @@ $all_post_meta = $wpdb->get_results( $wpdb->prepare( sprintf( <<<'ND'
 		AND `post_id` IN (%s)
 ND
 	, $wpdb->postmeta,
-	IMPLODE( ',', array_fill( 0, count( $post_ids ), '%d' ) )
+	IMPLODE( ',', array_fill( 0, COUNT( $post_ids ), '%d' ) )
 ), $post_ids ) ); // OK.
 
 wpdb::prepare( "SELECT * FROM $wpdb?->posts WHERE post_title LIKE '" . foo() . "';" ); // Bad.


### PR DESCRIPTION
The sniff was incorrectly flagging valid SQL escaping functions when they were written with mixed or uppercase letters (e.g., 'Esc_Sql' instead of 'esc_sql'). This occurred because the function name comparison was case-sensitive when checking against the predefined list of safe SQL escaping functions.

This fix ensures that function names are properly normalized to lowercase before comparing them against the allowed escaping functions list, preventing false positives regardless of the function name's capitalization.