### PR TITLE
PHP 8.5 | WP/EnqueuedResourceParameters: prevent deprecation notice for non-standard casts

### DIFF
--- a/WordPress/Sniffs/WP/EnqueuedResourceParametersSniff.php
+++ b/WordPress/Sniffs/WP/EnqueuedResourceParametersSniff.php
@@ -227,6 +227,30 @@ final class EnqueuedResourceParametersSniff extends AbstractFunctionParameterSni
 				continue;
 			}
 
+			// Make sure that when deprecated casts are used in the code under scan and the sniff is run on PHP 8.5,
+			// the eval() won't cause a deprecation notice, borking the scan of the file.
+			if ( \PHP_VERSION_ID >= 80500 ) {
+				if ( \T_INT_CAST === $this->tokens[ $i ]['code'] ) {
+					$code_string .= '(int)';
+					continue;
+				}
+
+				if ( \T_DOUBLE_CAST === $this->tokens[ $i ]['code'] ) {
+					$code_string .= '(float)';
+					continue;
+				}
+
+				if ( \T_BOOL_CAST === $this->tokens[ $i ]['code'] ) {
+					$code_string .= '(bool)';
+					continue;
+				}
+
+				if ( \T_BINARY_CAST === $this->tokens[ $i ]['code'] ) {
+					$code_string .= '(string)';
+					continue;
+				}
+			}
+
 			$code_string .= $this->tokens[ $i ]['content'];
 		}
 

--- a/WordPress/Tests/WP/EnqueuedResourceParametersUnitTest.1.inc
+++ b/WordPress/Tests/WP/EnqueuedResourceParametersUnitTest.1.inc
@@ -83,3 +83,15 @@ wp_register_script( 'someScript-js', $url, [], 0_0.0_0, true ); // Error - 0, fa
 
 // Safeguard handling of PHP 8.1 explicit octals.
 wp_register_script( 'someScript-js', $url, [], 0o0, true ); // Error - 0, false or NULL are not allowed.
+
+// Safeguard against PHP 8.5 deprecation of non-standard cast names.
+wp_register_script( 'someScript-js', 'https://example.com/someScript.js' , array( 'jquery' ), (boolean) 1, true ); // OK.
+wp_register_script( 'someScript-js', 'https://example.com/someScript.js' , array( 'jquery' ), (boolean) 0, true ); // Error - 0, false or NULL are not allowed.
+
+wp_register_script( 'someScript-js', 'https://example.com/someScript.js' , array( 'jquery' ), (integer) 1, true ); // OK.
+wp_register_script( 'someScript-js', 'https://example.com/someScript.js' , array( 'jquery' ), (integer) 0, true ); // Error - 0, false or NULL are not allowed.
+
+wp_register_script( 'someScript-js', 'https://example.com/someScript.js' , array( 'jquery' ), (double) 1, true ); // OK.
+wp_register_script( 'someScript-js', 'https://example.com/someScript.js' , array( 'jquery' ), (double) 0, true ); // Error - 0, false or NULL are not allowed.
+
+wp_register_script( 'someScript-js', 'https://example.com/someScript.js' , array( 'jquery' ), (binary) 0, true ); // Error - 0, false or NULL are not allowed.

--- a/WordPress/Tests/WP/EnqueuedResourceParametersUnitTest.1.inc
+++ b/WordPress/Tests/WP/EnqueuedResourceParametersUnitTest.1.inc
@@ -83,6 +83,3 @@ wp_register_script( 'someScript-js', $url, [], 0_0.0_0, true ); // Error - 0, fa
 
 // Safeguard handling of PHP 8.1 explicit octals.
 wp_register_script( 'someScript-js', $url, [], 0o0, true ); // Error - 0, false or NULL are not allowed.
-
-// Live coding/parse error.
-wp_register_style( src: 'https://example.com/someScript.js', ver: /*to do*/, handle: 'someScript-js', );

--- a/WordPress/Tests/WP/EnqueuedResourceParametersUnitTest.2.inc
+++ b/WordPress/Tests/WP/EnqueuedResourceParametersUnitTest.2.inc
@@ -1,0 +1,5 @@
+<?php
+
+// Live coding/parse error.
+// This should be the only test in the file.
+wp_register_style( src: 'https://example.com/someScript.js', ver: /*to do*/, handle: 'someScript-js', );

--- a/WordPress/Tests/WP/EnqueuedResourceParametersUnitTest.php
+++ b/WordPress/Tests/WP/EnqueuedResourceParametersUnitTest.php
@@ -23,41 +23,61 @@ final class EnqueuedResourceParametersUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Returns the lines where errors should occur.
 	 *
+	 * @param string $testFile The name of the file being tested.
+	 *
 	 * @return array<int, int> Key is the line number, value is the number of expected errors.
 	 */
-	public function getErrorList() {
-		return array(
-			6  => 1,
-			9  => 1,
-			10 => 1,
-			12 => 1,
-			13 => 1,
-			14 => 1,
-			22 => 1,
-			54 => 1,
-			57 => 1,
-			61 => 1,
-			82 => 1,
-			85 => 1,
-			88 => 1,
-		);
+	public function getErrorList( $testFile = '' ) {
+		switch ( $testFile ) {
+			case 'EnqueuedResourceParametersUnitTest.1.inc':
+				return array(
+					6  => 1,
+					9  => 1,
+					10 => 1,
+					12 => 1,
+					13 => 1,
+					14 => 1,
+					22 => 1,
+					54 => 1,
+					57 => 1,
+					61 => 1,
+					82 => 1,
+					85 => 1,
+				);
+
+			case 'EnqueuedResourceParametersUnitTest.2.inc':
+				return array(
+					5 => 1,
+				);
+
+			default:
+				return array();
+		}
 	}
 
 	/**
 	 * Returns the lines where warnings should occur.
 	 *
+	 * @param string $testFile The name of the file being tested.
+	 *
 	 * @return array<int, int> Key is the line number, value is the number of expected warnings.
 	 */
-	public function getWarningList() {
-		return array(
-			3  => 2,
-			11 => 1,
-			32 => 1,
-			39 => 2,
-			42 => 1,
-			45 => 1,
-			66 => 2,
-			77 => 1,
-		);
+	public function getWarningList( $testFile = '' ) {
+		switch ( $testFile ) {
+			case 'EnqueuedResourceParametersUnitTest.1.inc':
+				return array(
+					3  => 2,
+					11 => 1,
+					32 => 1,
+					39 => 2,
+					42 => 1,
+					45 => 1,
+					66 => 2,
+					77 => 1,
+				);
+
+			default:
+				return array();
+		}
 	}
 }

--- a/WordPress/Tests/WP/EnqueuedResourceParametersUnitTest.php
+++ b/WordPress/Tests/WP/EnqueuedResourceParametersUnitTest.php
@@ -43,6 +43,10 @@ final class EnqueuedResourceParametersUnitTest extends AbstractSniffUnitTest {
 					61 => 1,
 					82 => 1,
 					85 => 1,
+					89 => 1,
+					92 => 1,
+					95 => 1,
+					97 => 1,
 				);
 
 			case 'EnqueuedResourceParametersUnitTest.2.inc':


### PR DESCRIPTION
### WP/EnqueuedResourceParameters: move parse error test to its own file

### PHP 8.5 | WP/EnqueuedResourceParameters: prevent deprecation notice for non-standard casts

Four non-standard type casts are going to be deprecated in PHP 8.5.

When any of these type casts would be used in the parameter this sniff examines in the "code under scan" and the sniff would be run on PHP 8.5, the non-standard type cast would be executed via the `eval()`, leading to a deprecation notice, which would stop the scan of the file.

This commit works around this by always using the "standard" type cast syntax in the code which would be passed to `eval()`.

Includes tests.