### PR TITLE
DB/RestrictedClasses: remove redundant call to `parent::setUpPrerequisites()`

### DIFF
--- a/WordPress/Tests/DB/RestrictedClassesUnitTest.php
+++ b/WordPress/Tests/DB/RestrictedClassesUnitTest.php
@@ -37,8 +37,6 @@ final class RestrictedClassesUnitTest extends AbstractSniffUnitTest {
 	 * @return void
 	 */
 	protected function enhanceGroups() {
-		parent::setUpPrerequisites();
-
 		AbstractFunctionRestrictionsSniff::$unittest_groups = array(
 			'test' => array(
 				'type'    => 'error',


### PR DESCRIPTION
Calling `AbstractSniffUnitTest::setUpPrerequisites()` manually inside `RestrictedClassesUnitTest::enhanceGroups()` is not necessary, as this method already executes via its `@before` tag and results in the method running twice.

Originally, `RestrictedClassesUnitTest::enhanceGroups()` was named `RestrictedClassesUnitTest::setUp()` and called `parent::setUp()` ([WordPress/Tests/DB/RestrictedClassesUnitTest.php#L34-L35](https://github.com/WordPress/WordPress-Coding-Standards/blob/3b9ae92607295548df357e108fd27090cf89d1d7/WordPress/Tests/DB/RestrictedClassesUnitTest.php#L34-L35)). But later it was renamed, and then it probably didn't make sense to continue calling `parent::setUp()` (which was later renamed to `setUpPrerequisites()`): https://github.com/WordPress/WordPress-Coding-Standards/commit/00b895c92f41a49923c37df58b370b801080a204.

I found this in the context of the work to prepare this codebase for PHPCS 4.0 as `AbstractSniffUnitTest::setUpPrerequisites()` was renamed in 4.0 (https://github.com/PHPCSStandards/PHP_CodeSniffer/commit/92cf10f65c2ff1486e28eb1e359680eea5c54224#diff-91ba2a2a923bbfdaa61dcd31051d783bd0e7ff99f979f6e1a2917cae7dde3eb2L58).