### PR TITLE
WP/GlobalVariablesOverride: more tests covering unresolvable `$GLOBALS` keys

### DIFF
--- a/WordPress/Tests/WP/GlobalVariablesOverrideUnitTest.1.inc
+++ b/WordPress/Tests/WP/GlobalVariablesOverrideUnitTest.1.inc
@@ -320,3 +320,15 @@ class AsymmetricVisibilityProperties {
 
     public function __construct(public protected(set) int $page = 0) {} // Ok.
 }
+
+/*
+ * $GLOBALS with non-string key, unable to determine if it is a global variable override or not.
+ */
+$GLOBALS[ "some{$name}" ] = 'test'; // Ok.
+$GLOBALS[ $obj->global_name ] = 'test'; // Ok.
+$GLOBALS[ MyClass::GLOBAL_NAME ] = 'test'; // Ok.
+$GLOBALS[ GLOBAL_NAME_CONSTANT ] = 'test'; // Ok.
+$GLOBALS[ get_my_global_name() ] = 'test'; // Ok.
+$GLOBALS[ MyNamespace\get_my_global_name() ] = 'test'; // Ok.
+$GLOBALS[ \MyNamespace\get_my_global_name() ] = 'test'; // Ok.
+$GLOBALS[ namespace\get_my_global_name() ] = 'test'; // Ok.

--- a/WordPress/Tests/WP/GlobalVariablesOverrideUnitTest.1.inc
+++ b/WordPress/Tests/WP/GlobalVariablesOverrideUnitTest.1.inc
@@ -322,13 +322,15 @@ class AsymmetricVisibilityProperties {
 }
 
 /*
- * $GLOBALS with non-string key, unable to determine if it is a global variable override or not.
+ * $GLOBALS with non-string key, unable to determine which variable is being overridden.
  */
-$GLOBALS[ "some{$name}" ] = 'test'; // Ok.
-$GLOBALS[ $obj->global_name ] = 'test'; // Ok.
-$GLOBALS[ MyClass::GLOBAL_NAME ] = 'test'; // Ok.
-$GLOBALS[ GLOBAL_NAME_CONSTANT ] = 'test'; // Ok.
-$GLOBALS[ get_my_global_name() ] = 'test'; // Ok.
-$GLOBALS[ MyNamespace\get_my_global_name() ] = 'test'; // Ok.
-$GLOBALS[ \MyNamespace\get_my_global_name() ] = 'test'; // Ok.
-$GLOBALS[ namespace\get_my_global_name() ] = 'test'; // Ok.
+function globals_with_non_string_key() {
+	$GLOBALS[ "some{$name}" ] = 'test'; // Ok.
+	$GLOBALS[ $obj->global_name ] = 'test'; // Ok.
+	$GLOBALS[ MyClass::GLOBAL_NAME ] = 'test'; // Ok.
+	$GLOBALS[ GLOBAL_NAME_CONSTANT ] = 'test'; // Ok.
+	$GLOBALS[ get_my_global_name() ] = 'test'; // Ok.
+	$GLOBALS[ MyNamespace\get_my_global_name() ] = 'test'; // Ok.
+	$GLOBALS[ \MyNamespace\get_my_global_name() ] = 'test'; // Ok.
+	$GLOBALS[ namespace\get_my_global_name() ] = 'test'; // Ok.
+}


### PR DESCRIPTION
This PR adds tests for cases where the  `WordPress.WP.GlobalsVariableOverride` sniff is not able to resolve the value of `$GLOBALS` keys.