### PR TITLE
Security/ValidatedSanitizedInput: fix link in docblock

### DIFF
--- a/WordPress/Sniffs/Security/ValidatedSanitizedInputSniff.php
+++ b/WordPress/Sniffs/Security/ValidatedSanitizedInputSniff.php
@@ -23,7 +23,7 @@ use WordPressCS\WordPress\Sniff;
 /**
  * Flag any non-validated/sanitized input ( _GET / _POST / etc. ).
  *
- * @link https://github.com/WordPress/WordPress-Coding-Standards/issues/69
+ * @link https://github.com/WordPress/WordPress-Coding-Standards/issues/72
  *
  * @since 0.3.0
  * @since 0.4.0  This class now extends the WordPressCS native `Sniff` class.


### PR DESCRIPTION
While reviewing another PR related to this sniff, I noticed an incorrect link in the class docblock. The link was pointing to an unrelated GitHub issue instead of pointing to the GitHub issue that discussed the introduction of this sniff. This is now fixed in this commit, and the correct link is used. I believe this was caused by a copy and paste error in the PR that introduced the sniff (https://github.com/WordPress/WordPress-Coding-Standards/pull/101).