### PR TITLE
Update CONTRIBUTING.md with tips for successful PRs

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,6 +1,8 @@
+# Contributing to the WordPress Coding Standards
+
 Hi, thank you for your interest in contributing to the WordPress Coding Standards! We look forward to working with you.
 
-# Reporting Bugs
+## Reporting Bugs
 
 Please search the repo to see if your issue has been reported already and if so, comment in that issue instead of opening a new one.
 
@@ -9,7 +11,7 @@ Running `phpcs` with the `-s` flag will show the name of the sniff with each err
 
 Bug reports containing a minimal code sample which can be used to reproduce the issue are highly appreciated as those are most easily actionable.
 
-## Upstream Issues
+### Upstream Issues
 
 Since WordPressCS employs many sniffs that are part of PHP_CodeSniffer itself or PHPCSExtra, sometimes an issue will be caused by a bug in PHPCS or PHPCSExtra and not in WordPressCS itself.
 If the error message in question doesn't come from a sniff whose name starts with `WordPress`, the issue is probably a bug in PHPCS or PHPCSExtra.
@@ -17,27 +19,27 @@ If the error message in question doesn't come from a sniff whose name starts wit
 * Bugs for sniffs starting with `Generic`, `PEAR`, `PSR1`, `PSR2`, `PSR12`, `Squiz` or `Zend` should be [reported to PHPCS](https://github.com/PHPCSStandards/PHP_CodeSniffer/issues).
 * Bugs for sniffs starting with `Modernize`, `NormalizedArrays` or `Universal` should be [reported to PHPCSExtra](https://github.com/PHPCSStandards/PHPCSExtra/issues).
 
-# Contributing patches and new features
+## Contributing patches and new features
 
-## Branches
+### Branches
 
 Ongoing development will be done in the `develop` branch with merges to `main` once considered stable.
 
 To contribute an improvement to this project, fork the repo, run `composer install`, make your changes to the code, run the unit tests and code style checks by running `composer check-all`, and if all is good, open a pull request to the `develop` branch.
 Alternatively, if you have push access to this repo, create a feature branch prefixed by `feature/` and then open an intra-repo PR from that branch to `develop`.
 
-# Considerations when writing sniffs
+## Considerations when writing sniffs
 
-## Public properties
+### Public properties
 
 When writing sniffs, always remember that any `public` sniff property can be overruled via a custom ruleset by the end-user.
 Only make a property `public` if that is the intended behavior.
 
 When you introduce new `public` sniff properties, or your sniff extends a class from which you inherit a `public` property, please don't forget to update the [public properties wiki page](https://github.com/WordPress/WordPress-Coding-Standards/wiki/Customizable-sniff-properties) with the relevant details once your PR has been merged into the `develop` branch.
 
-# Unit Testing
+## Unit Testing
 
-## Pre-requisites
+### Pre-requisites
 * WordPress-Coding-Standards
 * PHP_CodeSniffer 3.13.0 or higher
 * PHPCSUtils 1.1.0 or higher
@@ -46,11 +48,11 @@ When you introduce new `public` sniff properties, or your sniff extends a class 
 
 The WordPress Coding Standards use the `PHP_CodeSniffer` native unit test framework for unit testing the sniffs.
 
-## Getting ready to test
+### Getting ready to test
 
 Presuming you have cloned WordPressCS for development, to run the unit tests you need to make sure you have run `composer install` from the root directory of your WordPressCS git clone.
 
-## Custom develop setups
+### Custom develop setups
 
 If you are developing with a stand-alone PHP_CodeSniffer (git clone) installation and want to use that git clone to test WordPressCS, there are three extra things you need to do:
 1. Install [PHPCSUtils](https://github.com/PHPCSStandards/PHPCSUtils).
@@ -73,7 +75,7 @@ If you are developing with a stand-alone PHP_CodeSniffer (git clone) installatio
         </php>
     ```
 
-## Running the unit tests
+### Running the unit tests
 
 From the root of your WordPressCS install, run the unit tests like so:
 ```bash
@@ -99,7 +101,7 @@ Time: 10.19 seconds, Memory: 40.00 MB
 OK (57 tests, 0 assertions)
 ```
 
-## Unit Testing conventions
+### Unit Testing conventions
 
 If you look inside the `WordPress/Tests` subdirectory, you'll see the structure mimics the `WordPress/Sniffs` subdirectory structure. For example, the `WordPress/Sniffs/PHP/POSIXFunctionsSniff.php` sniff has its unit test class defined in `WordPress/Tests/PHP/POSIXFunctionsUnitTest.php` which checks the `WordPress/Tests/PHP/POSIXFunctionsUnitTest.inc` test case file. See the file naming convention?
 
@@ -171,6 +173,6 @@ You'll see the line number and number of ERRORs we need to return in the `getErr
 
 The `--sniffs=...` directive limits the output to the sniff you are testing.
 
-## Code Standards for this project
+### Code Standards for this project
 
 The sniffs and test files - not test _case_ files! - for WordPressCS should be written such that they pass the `WordPress-Extra` and the `WordPress-Docs` code standards using the custom ruleset as found in `/.phpcs.xml.dist`.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -21,6 +21,27 @@ If the error message in question doesn't come from a sniff whose name starts wit
 
 ## Contributing patches and new features
 
+### Tips for Successful PRs
+
+We welcome contributions from everyone, and want your PR to have the best chance of being reviewed and merged. To help with this, please keep the following in mind:
+
+* **Respect copyright and licensing.**
+  Only submit code that you have written yourself or that comes from sources where the license clearly allows inclusion. Submitting code that infringes on copyright or licensing terms puts both you and the project at legal risk, and such contributions cannot be accepted.
+
+* **Do not submit AI-generated code.**
+  Pull requests containing AI-generated code are not acceptable. Beyond copyright and licensing uncertainties, AI-generated contributions consistently require disproportionate amounts of maintainer time to review, correct, or rewrite. This wastes limited project resources and slows progress for everyone. Submitting AI-generated code may be treated as a violation of our [Code of Conduct](../CODE_OF_CONDUCT.md).
+
+* **Focus on quality and clarity.**
+  Take time to explain *why* the change is needed, and include tests or examples where appropriate. Clear, self-written explanations make it more straightforward for reviewers to understand what you are trying to achieve.
+
+* **Think about long-term maintainability.**
+  Code should align with WordPress coding standards and be written in a way that others can readily read, understand, and maintain.
+
+* **Be collaborative.**
+  If you’re unsure about an approach, open an issue or draft PR first to start a conversation.
+
+By following these tips, you’ll save time for both yourself and the maintainers — and increase the likelihood that your contribution can be merged smoothly.
+
 ### Branches
 
 Ongoing development will be done in the `develop` branch with merges to `main` once considered stable.


### PR DESCRIPTION
See https://github.com/WordPress/WordPress-Coding-Standards/pull/2594.

We want contributors to be successful with their PRs, but we need to balance that with the limited time that maintainers have. This PR updates the `CONTRIBUTING.md` file to guide new users, and provides a place to direct authors of PRs who have missed the memo.

- Emphasise not to submit AI-generated PRs. They tend to be low quality as the nuances of the PHP possible syntax, and the tests that are required to test that nuance, are not handled well by AI.
- Watch out for copyright and license infringements. Code licensing is important, and we often can't use code that has been copied from elsewhere.
- As per any PR, explaining the _why_ is necessary to establish if the change is warranted. Without that, maintainers will just move on. They aren't mind-readers!

----

The first commit here fixes up the heading levels, as there were multiple level 1's, which translate as multiple `h1` elements, which is bad for accessibility.

The second commit is the additional text.
