### PR TITLE
Release checklist: add new bullet about checking all PRs are milestoned

### DIFF
--- a/.github/release-checklist.md
+++ b/.github/release-checklist.md
@@ -36,6 +36,7 @@ PR for tracking changes for the x.x.x release. Target release date: **DOW MONTH 
 
 ### Release prep
 
+- [ ] Double-check that all PRs which were merged since the last release have a milestone attached to it.
 - [ ] Add changelog for the release - PR #xxx
     :pencil2: Remember to add a release link at the bottom!
 - [ ] Update `README` (if applicable) - PR #xxx


### PR DESCRIPTION
Rodrigo and me just noticed that a few PRs which were merged into the `3.2.0` release did not have a milestone attached. We've fixed those now and will fix the changelog too (only one needed a mention, the others were maintenance PRs).

This commit just adds a new reminder bullet to verify that all PRs are milestoned before creating the changelog to (hopefully) prevent this from happening again.

_Side-note: in other repos I actually have it required check for the milestone being set (can't merge without it), but that would require permission from the WordPress organisation to allow the [app which handles that](https://github.com/scholzj/milestone-check) and that might get complicated..._