### PR TITLE
Changelog: add WPCS maintainers to the list of GitHub profile links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1705,11 +1705,14 @@ Initial tagged release.
 [@davidperezgar]:   https://github.com/davidperezgar
 [@dawidurbanski]:   https://github.com/dawidurbanski
 [@desrosj]:         https://github.com/desrosj
+[@dingo-d]:         https://github.com/dingo-d
 [@fredden]:         https://github.com/fredden
+[@GaryJones]:       https://github.com/GaryJones
 [@grappler]:        https://github.com/grappler
 [@Ipstenu]:         https://github.com/Ipstenu
 [@jaymcp]:          https://github.com/jaymcp
 [@JDGrimes]:        https://github.com/JDGrimes
+[@jrfnl]:           https://github.com/jrfnl
 [@khacoder]:        https://github.com/khacoder
 [@Luc45]:           https://github.com/Luc45
 [@marconmartins]:   https://github.com/marconmartins


### PR DESCRIPTION
@jrfnl is mentioned in the changelog, but there was no link for their GitHub profile page at the bottom, so the link was broken. This commits adds the link to fix this problem.

Per Juliette's suggestion, I'm adding links to the other maintainers as well to prevent this problem from happen to them in the future.