### PR TITLE
WP/AlternativeFunctions: fix typo in code comment

### DIFF
--- a/WordPress/Sniffs/WP/AlternativeFunctionsSniff.php
+++ b/WordPress/Sniffs/WP/AlternativeFunctionsSniff.php
@@ -259,7 +259,7 @@ final class AlternativeFunctionsSniff extends AbstractFunctionRestrictionsSniff 
 			case 'file_get_contents':
 				/*
 				 * Using `wp_remote_get()` will only work for remote URLs.
-				 * See if we can determine is this function call is for a local file and if so, bow out.
+				 * See if we can determine if this function call is for a local file and if so, bow out.
 				 */
 				$params = PassedParameters::getParameters( $this->phpcsFile, $stackPtr );
 


### PR DESCRIPTION
# Description

Fixes a typo found while investigating https://github.com/WordPress/WordPress-Coding-Standards/issues/2602 and https://github.com/WordPress/WordPress-Coding-Standards/issues/2603.

## Suggested changelog entry
_N/A_