### PR TITLE
DB/DirectDatabaseQuery: fix false negatives when cache function names are not a function call

### DIFF
--- a/WordPress/Sniffs/DB/DirectDatabaseQuerySniff.php
+++ b/WordPress/Sniffs/DB/DirectDatabaseQuerySniff.php
@@ -229,6 +229,12 @@ final class DirectDatabaseQuerySniff extends Sniff {
 
 			for ( $i = ( $scopeStart + 1 ); $i < $scopeEnd; $i++ ) {
 				if ( \T_STRING === $this->tokens[ $i ]['code'] ) {
+					$nextNonEmpty = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $i + 1 ), null, true );
+
+					if ( \T_OPEN_PARENTHESIS !== $this->tokens[ $nextNonEmpty ]['code'] ) {
+						continue;
+					}
+
 					$content = strtolower( $this->tokens[ $i ]['content'] );
 
 					if ( isset( $this->cacheDeleteFunctions[ $content ] ) ) {

--- a/WordPress/Tests/DB/DirectDatabaseQueryUnitTest.1.inc
+++ b/WordPress/Tests/DB/DirectDatabaseQueryUnitTest.1.inc
@@ -354,3 +354,28 @@ function cache_custom_mixed_case_B() {
 // phpcs:set WordPress.DB.DirectDatabaseQuery customCacheGetFunctions[]
 // phpcs:set WordPress.DB.DirectDatabaseQuery customCacheSetFunctions[]
 // phpcs:set WordPress.DB.DirectDatabaseQuery customCacheDeleteFunctions[]
+
+// Protect against false negatives where the cache function names are used as the content
+// of a T_STRING token that is not a function call.
+function notCacheFunctionCalls() {
+    global $wpdb;
+
+    $bar->wp_cache_get = 'something';
+    $listofthings = $wpdb->get_col( 'SELECT something FROM somewhere WHERE someotherthing = 1' ); // Warning x 2.
+    $foo = wp_cache_set;
+
+    return $listofthings;
+}
+
+// The sniff deliberately does not distinguish between calls to cache functions and calls to methods with the same name as the functions,
+// as those method calls are likely custom cache functions.
+function methodNamesSameAsCacheFunctions() {
+	global $wpdb, $bar;
+
+	if ( ! ( $listofthings = $bar->wp_cache_get( 'foo' ) ) ) {
+		$listofthings = $wpdb->get_col( 'SELECT something FROM somewhere WHERE someotherthing = 1' ); // Warning direct DB call.
+		$bar->wp_cache_set( 'foo', $listofthings );
+	}
+
+	return $listofthings;
+}

--- a/WordPress/Tests/DB/DirectDatabaseQueryUnitTest.php
+++ b/WordPress/Tests/DB/DirectDatabaseQueryUnitTest.php
@@ -97,6 +97,8 @@ final class DirectDatabaseQueryUnitTest extends AbstractSniffUnitTest {
 					333 => 2,
 					343 => 1,
 					350 => 1,
+					364 => 2,
+					376 => 1,
 				);
 			default:
 				return array();


### PR DESCRIPTION
# Description

Before, the sniff was checking if the content of a `T_STRING` token matched one of the names of the expected cache functions without checking if it was actually a function call. This could lead to some false negatives that are addressed in this commit.

As suggested by Juliette, I'm including a test to document that method names that match the cache function names are deliberately not flagged by this sniff, as they will be most likely valid custom cache functions.

## Suggested changelog entry

Fixed: WordPress.DB.DirectDatabaseQuery: prevents false negatives when cache function names are not a function call.