### PR TITLE
ContextHelper::is_in_function_call(): add basic tests

### DIFF
--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -45,6 +45,21 @@ if ( false !== $phpcsDir
 ) {
 	require_once $phpcsDir . $ds . 'autoload.php';
 	require_once $phpcsDir . $ds . 'tests' . $ds . 'bootstrap.php'; // PHPUnit 6.x+ support.
+
+	spl_autoload_register(
+		function ( $className ) {
+			// Only try & load our own classes.
+			if ( stripos( $className, 'WordPressCS' ) !== 0 ) {
+				return;
+			}
+
+			$file = realpath( dirname( __DIR__ ) ) . DIRECTORY_SEPARATOR . strtr( str_replace( 'WordPressCS\\', '', $className ), '\\', DIRECTORY_SEPARATOR ) . '.php';
+
+			if ( file_exists( $file ) ) {
+				include_once $file;
+			}
+		}
+	);
 } else {
 	echo 'Uh oh... can\'t find PHPCS.
 

--- a/WordPress/Util/Tests/Helpers/ContextHelper/IsInFunctionCallUnitTest.inc
+++ b/WordPress/Util/Tests/Helpers/ContextHelper/IsInFunctionCallUnitTest.inc
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * Make sure that tokens inside a function call are correctly identified using the default values
+ * for the optional parameters (`$global_function = true` and `$allow_nested = false`).
+ *
+ * The below should *NOT* be recognized as inside a function call to one of the valid functions.
+ */
+
+$a = /* test return false 1 */ 'foo';
+another_function( /* test return false 2 */ $a );
+MyNamespace\my_function( /* test return false 3 */ $a );
+\MyNamespace\my_function( /* test return false 4 */ $a );
+namespace\MyNamespace\my_function( /* test return false 5 */ $a );
+my_function( another_function( /* test return false 6 */ $a ) );
+$anon_func = function() {
+    /* test return false 7 */ $a = 'foo';
+};
+$my_function( /* test return false 8 */ $a );
+
+/*
+ * Make sure that tokens inside a function call are correctly identified using the default values
+ * for the optional parameters (`$global_function = true` and `$allow_nested = false`).
+ *
+ * The below should be recognized as inside a function call to one of the valid functions.
+ */
+
+/* test function call 1 */ my_function( /* test inside function pointer 1 */ $a );
+/* test function call 2 */ MY_FUNCTION( /* test inside function pointer 2 */ $a );
+/* test function call 3 */ \my_function( /* test inside function pointer 3 */ $a );
+
+/*
+ * Make sure that tokens inside a function call are correctly identified when `$global_function` is
+ * set to false.
+ *
+ * The below should be recognized as inside a function call to one of the valid functions.
+ */
+
+/* test function call 4 */ my_function( /* test inside function pointer 4 */ $a );
+/* test function call 5 */ MY_FUNCTION( /* test inside function pointer 5 */ $a );
+/* test function call 6 */ \my_function( /* test inside function pointer 6 */ $a );
+MyNamespace\/* test function call 7 */my_function( /* test inside function pointer 7 */ $a );
+\MyNamespace\/* test function call 8 */my_function( /* test inside function pointer 8 */ $a );
+namespace\MyNamespace\/* test function call 9 */my_function( /* test inside function pointer 9 */ $a );
+MyClass::/* test function call 10 */my_function( /* test inside function pointer 10 */ $a );
+/* test function call 11 */ $obj->my_function( /* test inside function pointer 11 */ $a );
+/* test function call 12 */ $obj?->my_function( /* test inside function pointer 12 */ $a );
+
+/*
+ * Make sure that tokens inside a function call are correctly identified when `$allow_nested` is
+ * set to true.
+ *
+ * The below should be recognized as inside a function call to one of the valid functions.
+ */
+/* test function call 13 */ my_function( another_function( /* test inside function pointer 13 */ $a ) );
+another_function( /* test function call 14 */ my_function( /* test inside function pointer 14 */ $a ) );
+/* test function call 15 */ my_function( middle_function( inner_function( /* test inside function pointer 15 */ $a ) ) );

--- a/WordPress/Util/Tests/Helpers/ContextHelper/IsInFunctionCallUnitTest.php
+++ b/WordPress/Util/Tests/Helpers/ContextHelper/IsInFunctionCallUnitTest.php
@@ -1,0 +1,165 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPressCS\WordPress\Util\Tests\Helpers\ContextHelper;
+
+use PHPCSUtils\Tokens\Collections;
+use WordPressCS\WordPress\Helpers\ContextHelper;
+use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+
+/**
+ * Tests for the `ContextHelper::is_in_function_call()` utility method.
+ *
+ * @since 3.3.0
+ *
+ * @covers \WordPressCS\WordPress\Helpers\ContextHelper::is_in_function_call()
+ */
+final class IsInFunctionCallUnitTest extends UtilityMethodTestCase {
+
+
+	/**
+	 * Test is_in_function_call() returns false if given token is not inside a function call
+	 * or not inside one of the expected function calls.
+	 *
+	 * @dataProvider dataIsInFunctionCallShouldReturnFalse
+	 *
+	 * @param string     $commentString The comment which prefaces the target token in the test file.
+	 * @param int|string $tokenType     The token type to search for.
+	 *
+	 * @return void
+	 */
+	public function testIsInFunctionCallShouldReturnFalse( $commentString, $tokenType ) {
+		$stackPtr = $this->getTargetToken( $commentString, $tokenType );
+		$result   = ContextHelper::is_in_function_call( self::$phpcsFile, $stackPtr, array( 'my_function' => true ) );
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 * @see testIsInFunctionCallShouldReturnFalse()
+	 */
+	public static function dataIsInFunctionCallShouldReturnFalse() {
+		return array(
+			array( '/* test return false 1 */', \T_CONSTANT_ENCAPSED_STRING ),
+			array( '/* test return false 2 */', \T_VARIABLE ),
+			array( '/* test return false 3 */', \T_VARIABLE ),
+			array( '/* test return false 4 */', \T_VARIABLE ),
+			array( '/* test return false 5 */', \T_VARIABLE ),
+			array( '/* test return false 6 */', \T_VARIABLE ),
+			array( '/* test return false 7 */', \T_VARIABLE ),
+			array( '/* test return false 8 */', \T_VARIABLE ),
+		);
+	}
+
+	/**
+	 * Test is_in_function_call() returns pointer to function name if given token is inside a function call.
+	 *
+	 * @dataProvider dataIsInFunctionCallShouldReturnFunctionPointer
+	 *
+	 * @param string     $insideFunctionCommentString The comment which prefaces the target token inside a function in the test file.
+	 * @param int|string $insideFunctionTokenType     The token type to search for.
+	 * @param string     $functionCallCommentString   The comment which prefaces the function call token in the test file.
+	 *
+	 * @return void
+	 */
+	public function testIsInFunctionCallShouldReturnFunctionPointer( $insideFunctionCommentString, $insideFunctionTokenType, $functionCallCommentString ) {
+		$insideFunctionPtr = $this->getTargetToken( $insideFunctionCommentString, $insideFunctionTokenType );
+		$functionNamePtr   = $this->getTargetToken( $functionCallCommentString, Collections::nameTokens() );
+		$result            = ContextHelper::is_in_function_call( self::$phpcsFile, $insideFunctionPtr, array( 'my_function' => true ) );
+		$this->assertSame( $result, $functionNamePtr );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 * @see testIsInFunctionCallShouldReturnFunctionPointer()
+	 */
+	public static function dataIsInFunctionCallShouldReturnFunctionPointer() {
+		return array(
+			array( '/* test inside function pointer 1 */', \T_VARIABLE, '/* test function call 1 */' ),
+			array( '/* test inside function pointer 2 */', \T_VARIABLE, '/* test function call 2 */' ),
+			array( '/* test inside function pointer 3 */', \T_VARIABLE, '/* test function call 3 */' ),
+		);
+	}
+
+	/**
+	 * Test is_in_function_call() returns pointer to function name if given token is inside a
+	 * function call when `$global_functions` is set to false.
+	 *
+	 * @dataProvider dataIsInFunctionCallShouldReturnFunctionPointerWhenGlobalIsFalse
+	 *
+	 * @param string     $insideFunctionCommentString The comment which prefaces the target token inside a function in the test file.
+	 * @param int|string $insideFunctionTokenType     The token type to search for.
+	 * @param string     $functionCallCommentString   The comment which prefaces the function call token in the test file.
+	 *
+	 * @return void
+	 */
+	public function testIsInFunctionCallShouldReturnFunctionPointerWhenGlobalIsFalse( $insideFunctionCommentString, $insideFunctionTokenType, $functionCallCommentString ) {
+		$insideFunctionPtr = $this->getTargetToken( $insideFunctionCommentString, $insideFunctionTokenType );
+		$functionNamePtr   = $this->getTargetToken( $functionCallCommentString, Collections::nameTokens() );
+		$result            = ContextHelper::is_in_function_call( self::$phpcsFile, $insideFunctionPtr, array( 'my_function' => true ), false );
+		$this->assertSame( $result, $functionNamePtr );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 * @see testIsInFunctionCallShouldReturnFunctionPointerWhenGlobalIsFalse()
+	 */
+	public static function dataIsInFunctionCallShouldReturnFunctionPointerWhenGlobalIsFalse() {
+		return array(
+			array( '/* test inside function pointer 4 */', \T_VARIABLE, '/* test function call 4 */' ),
+			array( '/* test inside function pointer 5 */', \T_VARIABLE, '/* test function call 5 */' ),
+			array( '/* test inside function pointer 6 */', \T_VARIABLE, '/* test function call 6 */' ),
+			array( '/* test inside function pointer 7 */', \T_VARIABLE, '/* test function call 7 */' ),
+			array( '/* test inside function pointer 8 */', \T_VARIABLE, '/* test function call 8 */' ),
+			array( '/* test inside function pointer 9 */', \T_VARIABLE, '/* test function call 9 */' ),
+			array( '/* test inside function pointer 10 */', \T_VARIABLE, '/* test function call 10 */' ),
+			array( '/* test inside function pointer 11 */', \T_VARIABLE, '/* test function call 11 */' ),
+			array( '/* test inside function pointer 12 */', \T_VARIABLE, '/* test function call 12 */' ),
+		);
+	}
+
+	/**
+	 * Test is_in_function_call() returns pointer to function name if given token is inside a
+	 * function call when `$allow_nested` is set to true.
+	 *
+	 * @dataProvider dataIsInFunctionCallShouldReturnFunctionPointerWhenAllowNestedIsTrue
+	 *
+	 * @param string     $insideFunctionCommentString The comment which prefaces the target token inside a function in the test file.
+	 * @param int|string $insideFunctionTokenType     The token type to search for.
+	 * @param string     $functionCallCommentString   The comment which prefaces the function call token in the test file.
+	 *
+	 * @return void
+	 */
+	public function testIsInFunctionCallShouldReturnFunctionPointerWhenAllowNestedIsTrue( $insideFunctionCommentString, $insideFunctionTokenType, $functionCallCommentString ) {
+		$insideFunctionPtr = $this->getTargetToken( $insideFunctionCommentString, $insideFunctionTokenType );
+		$functionNamePtr   = $this->getTargetToken( $functionCallCommentString, Collections::nameTokens() );
+		$result            = ContextHelper::is_in_function_call( self::$phpcsFile, $insideFunctionPtr, array( 'my_function' => true ), true, true );
+		$this->assertSame( $result, $functionNamePtr );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 * @see testIsInFunctionCallShouldReturnFunctionPointerWhenAllowNestedIsTrue()
+	 */
+	public static function dataIsInFunctionCallShouldReturnFunctionPointerWhenAllowNestedIsTrue() {
+		return array(
+			array( '/* test inside function pointer 13 */', \T_VARIABLE, '/* test function call 13 */' ),
+			array( '/* test inside function pointer 14 */', \T_VARIABLE, '/* test function call 14 */' ),
+			array( '/* test inside function pointer 15 */', \T_VARIABLE, '/* test function call 15 */' ),
+		);
+	}
+}

--- a/composer.json
+++ b/composer.json
@@ -53,10 +53,12 @@
 			"@php ./vendor/squizlabs/php_codesniffer/bin/phpcbf"
 		],
 		"run-tests": [
-			"@php ./vendor/phpunit/phpunit/phpunit --filter WordPress ./vendor/squizlabs/php_codesniffer/tests/AllTests.php --no-coverage"
+			"@php ./vendor/phpunit/phpunit/phpunit --filter WordPress ./vendor/squizlabs/php_codesniffer/tests/AllTests.php --no-coverage",
+            "@php ./vendor/phpunit/phpunit/phpunit WordPress/Util/Tests/ --no-coverage"
 		],
 		"coverage": [
-			"@php ./vendor/phpunit/phpunit/phpunit --filter WordPress ./vendor/squizlabs/php_codesniffer/tests/AllTests.php"
+			"@php ./vendor/phpunit/phpunit/phpunit --filter WordPress ./vendor/squizlabs/php_codesniffer/tests/AllTests.php",
+            "@php ./vendor/phpunit/phpunit/phpunit WordPress/Util/Tests/"
 		],
 		"check-complete": [
 			"@php ./vendor/phpcsstandards/phpcsdevtools/bin/phpcs-check-feature-completeness -q ./WordPress"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -13,7 +13,10 @@
 	forceCoversAnnotation="true">
 
 	<testsuites>
-		<testsuite name="WordPress">
+        <testsuite name="WordPress Utilities Tests">
+            <directory suffix="UnitTest.php">./WordPress/Util/Tests/</directory>
+        </testsuite>
+		<testsuite name="WordPress Sniffs Tests">
 			<directory suffix="UnitTest.php">./WordPress/Tests/</directory>
 		</testsuite>
 	</testsuites>


### PR DESCRIPTION
# Description

As part of the work to prepare WPCS for PHPCS 4.0, this PR adds basic tests for `ContextHelper::is_in_function_call()`. Those tests should help safeguard this method against regressions when updating it to be compatible with PHPCS 4.0.

Since there were no previous tests for utility methods, it was also necessary to modify the test structure to enable running utility tests. They are different from the sniff tests as they extend `UtilityMethodTestCase` and don't need to run via `./vendor/squizlabs/php_codesniffer/tests/AllTests.php`.

After this one is approved, I plan to open another PR, adding tests for more utility methods. I opted to open this one first with tests for a single method to get feedback on the way that I organized the tests.
