### PR TITLE
Composer: raise the minimum supported PHPCS version to 3.13.6

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -62,9 +62,9 @@ When you introduce new `public` sniff properties, or your sniff extends a class 
 
 ### Pre-requisites
 * WordPress-Coding-Standards
-* PHP_CodeSniffer 3.13.5 or higher
-* PHPCSUtils 1.2.2 or higher
-* PHPCSExtra 1.5.0 or higher
+* PHP_CodeSniffer 3.13.6 or higher
+* PHPCSUtils 1.2.3 or higher
+* PHPCSExtra 1.5.1 or higher
 * PHPUnit 8.x - 9.x
 
 The WordPress Coding Standards use the `PHP_CodeSniffer` native unit test framework for unit testing the sniffs.

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
 		"ext-libxml": "*",
 		"ext-tokenizer": "*",
 		"ext-xmlreader": "*",
-		"squizlabs/php_codesniffer": "^3.13.5",
+		"squizlabs/php_codesniffer": "^3.13.6",
 		"phpcsstandards/phpcsutils": "^1.2.3",
 		"phpcsstandards/phpcsextra": "^1.5.1"
 	},


### PR DESCRIPTION
# Description
PHP_CodeSniffer released security versions last night. Let's update the minimum supported version to encourage WPCS users to update.

Includes follow up to #2770, which forgot to update the `CONTRIBUTING` guide.

Ref: https://github.com/PHPCSStandards/PHP_CodeSniffer/releases#release-3.13.6


## Suggested changelog entry
```
### Changed
- The minimum required `PHP_CodeSniffer` version to 3.13.6 (was 3.13.5).
```
